### PR TITLE
Add elasticsearch and postgres to improve logging and monitoring

### DIFF
--- a/servicex/requirements.lock
+++ b/servicex/requirements.lock
@@ -4,6 +4,9 @@ dependencies:
   version: 6.1.6
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.5.15
-digest: sha256:423dd26c98cce1de2fb430ed93edf17fb2ef9d48ab90187e6514c169dc6cf71a
-generated: "2019-09-25T10:45:20.628323-05:00"
+  version: 2.5.16
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 6.3.0
+digest: sha256:7ad624b5f30b1c036aee0bd044be04be95948422bf760847cc70b841ee3eb08c
+generated: "2019-10-15T15:34:24.423305-05:00"

--- a/servicex/requirements.yaml
+++ b/servicex/requirements.yaml
@@ -6,3 +6,8 @@ dependencies:
     version: 2.5.*
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: objectStore.enabled
+  - name: postgresql
+    version: 6.3
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: postgres.enabled
+

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -15,8 +15,12 @@ data:
     # details are beyond the scope of this example
     SECRET_KEY = 'abc123!'
 
-    # Based on https://codeburst.io/jwt-authorization-in-flask-c63c1acf4eeb
+    {{ if .Values.postgres.enabled }}
+    SQLALCHEMY_DATABASE_URI = 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
+    {{ else }}
     SQLALCHEMY_DATABASE_URI = 'sqlite:////sqlite/app.db'
+    {{ end }}
+
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SECRET_KEY = 'some-secret-string'
     JWT_SECRET_KEY = 'jwt-secret-string'
@@ -46,4 +50,14 @@ data:
     MINIO_SECRET_KEY = '{{ .Values.minio.secretKey }}'
     {{ else }}
     OBJECT_STORE_ENABLED = False
+    {{ end }}
+
+    {{ if .Values.elasticsearchLogging.enabled }}
+    ELASTIC_SEARCH_LOGGING_ENABLED = True
+    ES_HOST = '{{ .Values.elasticsearchLogging.host }}'
+    ES_PORT = '{{ .Values.elasticsearchLogging.port }}'
+    ES_USER = '{{ .Values.elasticsearchLogging.user }}'
+    ES_PASS = '{{ .Values.elasticsearchLogging.password }}'
+    {{ else }}
+    ELASTIC_SEARCH_LOGGING_ENABLED = False
     {{ end }}

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -12,13 +12,22 @@ rabbitmq:
 objectStore:
     enabled: true
 
+postgres:
+    enabled: false
+
+
+postgresql:
+  postgresqlDatabase: servicex
+  postgresqlPassword: leftfoot1
+  persistence:
+    enabled: false
 minio:
   accessKey: miniouser
   secretKey: leftfoot1
 
 app:
   image: sslhep/servicex_app
-  tag: 0.1
+  tag: elasticsearch-logging
   pullPolicy: IfNotPresent
 
 didFinder:
@@ -34,6 +43,14 @@ preflight:
 
 transformer:
   pullPolicy: IfNotPresent
+
+elasticsearchLogging:
+  enabled: False
+  host: 'host'
+  port: 9200
+  user: 'user account'
+  password: 'password'
+
 
 rbacEnabled: True
 


### PR DESCRIPTION
# Problem 
Need to send logging messages to elastic search

This is partial fulfillment of #37 

# Approach
Added config to enable logging to  elastic search as well as connection information.

The additional status reporting highlighted some deficiencies in sqllight for heavy transaction volumes. Added an option of deploying Postgres 