### PR TITLE
Add x509 Proxy Secret Service

### DIFF
--- a/servicex/templates/did-finder-deployment.yaml
+++ b/servicex/templates/did-finder-deployment.yaml
@@ -10,21 +10,11 @@ spec:
       labels:
         app: {{ .Release.Name }}-did-finder
     spec:
-      initContainers:
-        - name: take-data-dir-ownership
-          image: alpine:3.6
-          command: ["/bin/sh","-c"]
-          args: ["base64 -d /etc/grid-certs-ro/usercert.pem.b64 > /etc/grid-certs/usercert.pem; chmod 600 /etc/grid-certs/usercert.pem; base64 -d /etc/grid-certs-ro/userkey.pem.b64 > /etc/grid-certs/userkey.pem; chmod 400 /etc/grid-certs/userkey.pem"]
-          volumeMounts:
-          - name: grid-certs-rw-copy
-            mountPath: /etc/grid-certs/
-          - name: grid-certs-cfg
-            mountPath: /etc/grid-certs-ro/
       containers:
       - name: {{ .Release.Name }}-did-finder
         image: {{ .Values.didFinder.image }}:{{ .Values.didFinder.tag }}
         command: ["bash","-c"]
-        args: ["/usr/src/app/run_x509_updater.sh & sleep 10 && env PYTHONPATH=./did_finder python scripts/did_finder.py --rabbit-uri amqp://user:leftfoot1@{{ .Release.Name }}-rabbitmq:5672/%2F {{ if .Values.didFinder.staticFile }} --staticfile {{ .Values.didFinder.staticFile }} {{ end }}"]
+        args: ["/usr/src/app/proxy-exporter.sh & sleep 5 && env PYTHONPATH=./did_finder python scripts/did_finder.py --rabbit-uri amqp://user:leftfoot1@{{ .Release.Name }}-rabbitmq:5672/%2F {{ if .Values.didFinder.staticFile }} --staticfile {{ .Values.didFinder.staticFile }} {{ end }}"]
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.didFinder.pullPolicy }}
@@ -33,12 +23,9 @@ spec:
             mountPath: /opt/rucio/etc/
           - name: did-finder-cfg
             mountPath: /usr/src/app/config/
-          - name: grid-certs-rw-copy
-            mountPath: /etc/grid-certs/
-          - name: grid-secret
-            mountPath: /servicex/
-          - name: grid-certs-cfg
-            mountPath: /etc/grid-certs-ro/
+          - name: x509-secret
+            mountPath: /etc/grid-security-ro
+            readOnly: true
 
       volumes:
         - name: rucio-cfg
@@ -47,12 +34,7 @@ spec:
         - name: did-finder-cfg
           configMap:
             name: {{ .Release.Name }}-did-finder-config
-        - name: grid-certs-cfg
-          configMap:
-            name: {{ .Release.Name }}-grid-certs-config
-            defaultMode: 400
-        - name: grid-certs-rw-copy
-          emptyDir: {}
-        - name: grid-secret
+        - name: x509-secret
           secret:
-            secretName: {{ .Release.Name }}-grid-secrets
+            defaultMode: 292
+            secretName: {{ .Release.Name }}-x509-proxy

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -39,6 +39,8 @@ data:
 
     TRANSFORMER_MANAGER_ENABLED = True
     TRANSFORMER_MANAGER_MODE = 'internal-kubernetes'
+    TRANSFORMER_X509_SECRET="{{ .Release.Name }}-x509-proxy"
+
 
     TRANSFORMER_MESSAGING = 'none'
 

--- a/servicex/templates/preflight-check-deployment.yaml
+++ b/servicex/templates/preflight-check-deployment.yaml
@@ -17,17 +17,25 @@ spec:
         env:
           - name: "BASH_ENV"
             value: "/home/atlas/.bashrc"
-        args: ["python validate_requests.py --rabbit-uri amqp://user:leftfoot1@{{ .Release.Name }}-rabbitmq:5672/%2F"]
+        args: ["/home/atlas/proxy-exporter.sh & sleep 5 && python validate_requests.py --rabbit-uri amqp://user:leftfoot1@{{ .Release.Name }}-rabbitmq:5672/%2F"]
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.preflight.pullPolicy }}
-        {{ if .Values.hostMount }}
         volumeMounts:
+          - name: x509-secret
+            mountPath: /etc/grid-security-ro
+            readOnly: true
+
+          {{ if .Values.hostMount }}
           - name: rootfiles
             mountPath: /data
-        {{ end }}
-      {{ if .Values.hostMount }}
+          {{ end }}
       volumes:
+        - name: x509-secret
+          secret:
+            defaultMode: 292
+            secretName: {{ .Release.Name }}-x509-proxy
+        {{ if .Values.hostMount }}
         - name: rootfiles
           hostPath:
             path: {{ .Values.hostMount }}

--- a/servicex/templates/role.yaml
+++ b/servicex/templates/role.yaml
@@ -12,4 +12,20 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "servicex.fullname" . }}-x509-secret-manager
+  labels:
+    app: {{ template "servicex.name" . }}
+    chart: {{ template "servicex.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {{- end }}

--- a/servicex/templates/rolebinding.yaml
+++ b/servicex/templates/rolebinding.yaml
@@ -15,4 +15,23 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ template "servicex.fullname" . }}-job-manager
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "servicex.fullname" . }}-x509-secret-manager
+  labels:
+    app: {{ template "servicex.name" . }}
+    chart: {{ template "servicex.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+- kind: ServiceAccount
+  name: {{ template "servicex.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "servicex.fullname" . }}-x509-secret-manager
 {{- end }}

--- a/servicex/templates/x509-secrets-deployment.yaml
+++ b/servicex/templates/x509-secrets-deployment.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-x509-secrets
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-x509-secrets
+    spec:
+      serviceAccountName: {{ template "servicex.fullname" . }}
+      initContainers:
+        - name: take-data-dir-ownership
+          image: alpine:3.6
+          command: ["/bin/sh","-c"]
+          args: ["base64 -d /etc/grid-certs-ro/usercert.pem.b64 > /etc/grid-certs/usercert.pem; chmod 600 /etc/grid-certs/usercert.pem; base64 -d /etc/grid-certs-ro/userkey.pem.b64 > /etc/grid-certs/userkey.pem; chmod 400 /etc/grid-certs/userkey.pem"]
+          volumeMounts:
+          - name: grid-certs-rw-copy
+            mountPath: /etc/grid-certs/
+          - name: grid-certs-cfg
+            mountPath: /etc/grid-certs-ro/
+      containers:
+      - name: {{ .Release.Name }}-x509-secrets
+        image: {{ .Values.x509Secrets.image }}:{{ .Values.x509Secrets.tag }}
+        command: ["bash","-c"]
+        args: ["python x509_updater.py {{ .Release.Name }}-x509-proxy"]
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        tty: true
+        stdin: true
+        imagePullPolicy: {{ .Values.x509Secrets.pullPolicy }}
+        volumeMounts:
+          - name: rucio-cfg
+            mountPath: /opt/rucio/etc/
+          - name: did-finder-cfg
+            mountPath: /usr/src/app/config/
+          - name: grid-certs-rw-copy
+            mountPath: /etc/grid-certs/
+          - name: grid-secret
+            mountPath: /servicex/
+          - name: grid-certs-cfg
+            mountPath: /etc/grid-certs-ro/
+
+      volumes:
+        - name: rucio-cfg
+          configMap:
+            name: {{ .Release.Name }}-rucio-config
+        - name: did-finder-cfg
+          configMap:
+            name: {{ .Release.Name }}-did-finder-config
+        - name: grid-certs-cfg
+          configMap:
+            name: {{ .Release.Name }}-grid-certs-config
+            defaultMode: 400
+        - name: grid-certs-rw-copy
+          emptyDir: {}
+        - name: grid-secret
+          secret:
+            secretName: {{ .Release.Name }}-grid-secrets

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -46,6 +46,11 @@ preflight:
 transformer:
   pullPolicy: IfNotPresent
 
+x509Secrets:
+  image: sslhep/x509-secrets
+  tag: latest
+  pullPolicy: IfNotPresent
+
 
 # Settings for sending logging messages to an elasticsearch service
 elasticsearchLogging:


### PR DESCRIPTION
# Problem
The current mechanism for generating X509 proxy certs is to mount users key and cert, along with the user's secret in the DID finder. This works, but is awkward to scale up to transformers.

Solves #57 

# Approach
Create a new service that has the key and certs mounted. This service obtains x509 proxy cert and publishes it as a secret. It renews the cert and updates the secret as needed. 
The DID Finder, Preflight Check, and transformer then mount this secret. Unfortunately, it doesn't seem possible to mount this secret with the correct ownership and permissions for XRootD to accept them. We get around this by mounting the secret to a `/etc/grid-security-ro` and have a little process that copies data from there to `/etc/grid-security`, updates ownership and permissions. This process refreshes the file every few hours.

# How to test
Create a values.yaml that contains the x509-proxy tags for all of the components:
```
app:
  tag: x509-secrets
preflight:
  tag: x509-secrets
didFinder:
  tag: x509-secrets
```

and deploy the helm chart.