### PR TITLE
Disable persistence by default for Rabbit and Minio

### DIFF
--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -62,6 +62,9 @@ elasticsearchLogging:
 
 # Values for the RabbitMQ Chart
 rabbitmq:
+  # For easy testing we don't require PVs for rabbit
+  persistence:
+    enabled: false
   rabbitmq:
     password: leftfoot1
   # This is needed for Windows users
@@ -79,6 +82,9 @@ postgresql:
 
 # Values for Minio Chart
 minio:
+  # For easy testing we don't require PVs for minio
+  persistence:
+    enabled: false
   accessKey: miniouser
   secretKey: leftfoot1
 


### PR DESCRIPTION
# Problem
The default values for persistence.enabled is True for both Minio and RabbitMQ. This is great for a production deployment but makes development deployment to a local kubernetes cluster more difficult. If these values are set to False then the dependent helm charts will use `emptyDir` volumes.

Fixes #78 

# Approach
Added correct default settings to values.yaml
