### PR TITLE
remove hard-coded RabbitMQ password

### DIFF
--- a/servicex/templates/did-finder-deployment.yaml
+++ b/servicex/templates/did-finder-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       - name: {{ .Release.Name }}-did-finder
         image: {{ .Values.didFinder.image }}:{{ .Values.didFinder.tag }}
         command: ["bash","-c"]
-        args: ["/usr/src/app/run_x509_updater.sh & sleep 10 && env PYTHONPATH=./did_finder python scripts/did_finder.py --rabbit-uri amqp://user:leftfoot1@{{ .Release.Name }}-rabbitmq:5672/%2F {{ if .Values.didFinder.staticFile }} --staticfile {{ .Values.didFinder.staticFile }} {{ end }}"]
+        args: ["/usr/src/app/run_x509_updater.sh & sleep 10 && env PYTHONPATH=./did_finder python scripts/did_finder.py --rabbit-uri amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F {{ if .Values.didFinder.staticFile }} --staticfile {{ .Values.didFinder.staticFile }} {{ end }}"]
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.didFinder.pullPolicy }}

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -24,8 +24,8 @@ data:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SECRET_KEY = 'some-secret-string'
     JWT_SECRET_KEY = 'jwt-secret-string'
-    RABBIT_MQ_URL= 'amqp://user:leftfoot1@{{ .Release.Name }}-rabbitmq:5672/%2F'
-    TRANSFORMER_RABBIT_MQ_URL= 'amqp://user:leftfoot1@{{ .Release.Name }}-rabbitmq:5672/%2F?heartbeat=9000'
+    RABBIT_MQ_URL= 'amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F'
+    TRANSFORMER_RABBIT_MQ_URL= 'amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F?heartbeat=9000'
     ADVERTISED_HOSTNAME= '{{ .Release.Name }}-servicex-app:8000'
 
     {{ if .Values.hostMount }}

--- a/servicex/templates/preflight-check-deployment.yaml
+++ b/servicex/templates/preflight-check-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         env:
           - name: "BASH_ENV"
             value: "/home/atlas/.bashrc"
-        args: ["python validate_requests.py --rabbit-uri amqp://user:leftfoot1@{{ .Release.Name }}-rabbitmq:5672/%2F"]
+        args: ["python validate_requests.py --rabbit-uri amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F"]
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.preflight.pullPolicy }}


### PR DESCRIPTION
I've replaced the hard-coded `leftfoot1` value with the one specified in the Values file for RabbitMQ.