### PR TITLE
Update all images to v0.2

### DIFF
--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -33,7 +33,7 @@ didFinder:
 # the transformer
 preflight:
   image: sslhep/servicex_xaod_cpp_transformer
-  tag: develop
+  tag: v0.2
   pullPolicy: IfNotPresent
 
 #
@@ -41,7 +41,7 @@ preflight:
 codeGen:
   enabled: true
   image: sslhep/servicex_code_gen_funcadl_xaod
-  tag: master
+  tag: v0.2
   pullPolicy: IfNotPresent
 
 
@@ -52,7 +52,7 @@ transformer:
 
 x509Secrets:
   image: sslhep/x509-secrets
-  tag: latest
+  tag: v0.2
   pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
Now that we have a v0.2 release and all images have this tag, we need to make the chart pull consistently from this tag