### PR TITLE
Add instructions and resources for deploying a Kafka cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ ConfigMap for the PEM files and a Secret for the passcode.
 This works reliably, but may not be best practice for securing sensitive 
 information. Suggestions are welcome.
 
+## Optional Kafka Installation
+ServiceX can deliver transformed datasets to an object store service (Minio) 
+that is optionally installed with this helm chart. An alternative delivery
+mechanism is streamed arrow tables using Kafka. Full instructions and sample
+config files are in the [kafka](kafka) directory.
+
 ## Configuration
 The following table lists the configurable parameters of the ServiceX chart and 
 their default values. Note that you may wish to change some of the default 

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -1,0 +1,84 @@
+# Deploying Kafka For ServiceX
+This directory contains instructions and resources for deploying a kafka
+cluster to support ServiceX.
+
+This helm deployment is described 
+[here.](https://github.com/helm/charts/tree/master/incubator/kafka). 
+
+By following this recipe you can deploy a kafka cluster inside Kubernetes. 
+
+We will assume that you have [Helm3](https://helm.sh) installed.
+   
+## Deployment  
+
+Add helm repository:
+
+    helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+
+Optionally, create a namespace for the cluster:
+    
+    kubectl create ns kafka-inc
+
+Install kafka:
+
+    helm install kafka-inc incubator/kafka -n kafka-inc -f servicex-values.yaml
+
+
+## Uninstall
+    
+Delete deployment:
+
+    helm delete kafka-inc
+
+Delete persistent volume claims:
+
+    kubectl delete pvc datadir-kafka-inc-0,1,2...
+
+
+## Accessing kafka
+
+Here a list of services that are accessible from any namespace in the cluster
+
+    export ZOO=kafka-inc-zookeeper.kafka-inc.svc.cluster.local:2181
+    export KBOOTSTR=kafka-inc-headless.kafka-inc.svc.cluster.local:9092
+    export KBROKERS=kafka-inc.kafka-inc.svc.cluster.local:9092
+
+## Install An In-Cluster CLI
+You can use the popular [kafkacat](https://github.com/edenhill/kafkacat) inside
+the cluster. 
+
+    kubectl create -f kafkacat.yaml
+    
+After the pod is running
+
+    kubectl exec -it kafkacat bash
+    kafkacat -L -b $KBROKERS
+    
+You can list the partitions of a topic and monitor thier offsets with:
+    
+    kafkacat -t <<topic>> -b $KBROKERS -f 'Partition %p, offset: %o, Size: %S\n'
+    
+
+## Install Web-Based GUI
+There is an excellent web client called [CMAK](https://github.com/yahoo/CMAK).
+You can install it into your cluster using the helm chart from Google Stable
+repo:
+
+    helm repo add stable https://kubernetes-charts.storage.googleapis.com
+    
+You will need to edit the zookeeper settings in the `kafka-manager-values.yaml`
+file found in this directory. It will need to match the name of the kafka 
+deployment. Once you've updated this file you can install the manager:
+
+    helm install kafkaman stable/kafka-manager
+    
+You can use port forwarding to access this dashboard
+
+    kubectl port-forward <kafka-manager pod> 9000:9000
+
+And log in with username: admin, password: leftfoot1
+
+
+    
+    
+ 

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -5,7 +5,11 @@ cluster to support ServiceX.
 This helm deployment is described 
 [here.](https://github.com/helm/charts/tree/master/incubator/kafka). 
 
-By following this recipe you can deploy a kafka cluster inside Kubernetes. 
+By following this recipe you can deploy a kafka cluster inside Kubernetes. These
+instructions do not include making Kafka accessable outside of the cluster since
+this brings in a number of authentication issues. See 
+[ServiceX Issue 72](https://github.com/ssl-hep/ServiceX/issues/72) for full 
+details and updates on this.
 
 We will assume that you have [Helm3](https://helm.sh) installed.
    
@@ -36,6 +40,12 @@ Delete persistent volume claims:
 
 
 ## Accessing kafka
+
+The Kafka brokers and Zookeeper can be referenced inside the cluster using 
+their service name. If you wish to access them from a pod in a different 
+namespace you can use a fully qualified cluster DNS name such as 
+`kafka-inc.kafka-inc.svc.cluster.local:9092`
+
 
 Here a list of services that are accessible from any namespace in the cluster
 

--- a/kafka/kafka-manager-values.yaml
+++ b/kafka/kafka-manager-values.yaml
@@ -1,0 +1,28 @@
+# Values to configure deployment of Kafka manager
+zkHosts: "benkafka-zookeeper:2181"
+
+## Basic Auth configuration
+##
+basicAuth:
+  enabled: true
+  username: "admin"
+  password: "leftfoot1"
+
+service:
+  type: LoadBalancer
+  port: 9000
+  annotations: {}
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - kafka-manager.mydomain.net
+  tls: []
+    # - secretName: kafka-manager-tls
+    #   hosts:
+    #     - kafka-manager.local
+

--- a/kafka/kafkacat.yaml
+++ b/kafka/kafkacat.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kafkacat
+spec:
+  containers:
+  - name: kafka
+    image: solsson/kafkacat
+    command:
+      - sh
+      - -c
+      - "exec tail -f /dev/null"

--- a/kafka/servicex-values.yaml
+++ b/kafka/servicex-values.yaml
@@ -1,0 +1,28 @@
+## The size of the PersistentVolume to allocate to each Kafka Pod in the StatefulSet. For
+## production servers this number should likely be much larger.
+##
+size: "100Gi"
+
+## Kafka data Persistent Volume Storage Class
+## If defined, storageClassName: <storageClass>
+## If set to "-", storageClassName: "", which disables dynamic provisioning
+## If undefined (the default) or set to null, no storageClassName spec is
+##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+##   GKE, AWS & OpenStack)
+##
+storageClass: "nfs-provisioner"
+
+## Prometheus Exporters / Metrics
+##
+prometheus:
+  ## Prometheus JMX Exporter: exposes the majority of Kafkas metrics
+  jmx:
+    enabled: true
+  ## Prometheus Kafka Exporter: exposes complimentary metrics to JMX Exporter
+  kafka:
+    enabled: true
+
+zookeeper:
+  ## Configure Zookeeper resource requests and limits
+  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  resources: {}


### PR DESCRIPTION
# Problem
Deploying Kafka is a dark art, outside of the usual ServiceX deployment instructions.
Issue #42 

# Approach
Based on the excellent work of @ivukotic, this is just a collection of documentation and resource files stored in a the `Kafka` directory of the ServiceX repo.

These instructions show:
1. How to configure, deploy,  and connect to a Kafka cluster inside the River cluster
2. How to deploy a kafkacat cli inside the cluster
3. How to deploy a web based dashboard for Kafka
