### PR TITLE
Fix Kubernetes 1.16 breaking changes

### DIFF
--- a/servicex/requirements.lock
+++ b/servicex/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.1.6
+  version: 6.17.2
 - name: minio
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.5.16
+  version: 5.0.6
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.3.0
-digest: sha256:7ad624b5f30b1c036aee0bd044be04be95948422bf760847cc70b841ee3eb08c
-generated: "2019-10-15T15:34:24.423305-05:00"
+  version: 8.3.3
+digest: sha256:c585c1bd722d105a53d059a2104841a1ee4e21ceb97b342fbc56671c3757b74b
+generated: "2020-02-13T14:50:08.862796-06:00"

--- a/servicex/requirements.yaml
+++ b/servicex/requirements.yaml
@@ -1,13 +1,13 @@
 dependencies:
   - name: rabbitmq
-    version: 6.1.*
+    version: 6.17.*
     repository: https://kubernetes-charts.storage.googleapis.com/
   - name: minio
-    version: 2.5.*
+    version: 5.0.*
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: objectStore.enabled
   - name: postgresql
-    version: 6.3
+    version: 8.3.*
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: postgres.enabled
 

--- a/servicex/templates/app_deployment.yaml
+++ b/servicex/templates/app_deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-servicex-app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-servicex-app
   template:
     metadata:
       labels:

--- a/servicex/templates/code_gen_deployment.yaml
+++ b/servicex/templates/code_gen_deployment.yaml
@@ -1,10 +1,13 @@
 {{- if .Values.codeGen.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-code-gen
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-code-gen
   template:
     metadata:
       labels:

--- a/servicex/templates/did-finder-deployment.yaml
+++ b/servicex/templates/did-finder-deployment.yaml
@@ -1,10 +1,13 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-did-finder
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-did-finder
   template:
     metadata:
       labels:

--- a/servicex/templates/preflight-check-deployment.yaml
+++ b/servicex/templates/preflight-check-deployment.yaml
@@ -1,10 +1,13 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-preflight
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-preflight
   template:
     metadata:
       labels:

--- a/servicex/templates/x509-secrets-deployment.yaml
+++ b/servicex/templates/x509-secrets-deployment.yaml
@@ -1,10 +1,13 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-x509-secrets
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-x509-secrets
   template:
     metadata:
       labels:


### PR DESCRIPTION
# Problem
Kubernetes 1.16 introduced breaking changes to `Deployment` and `StatefulSet`. They moved from beta to app interfaces.

# Approach
- Updated the dependent helm charts to pick up their fixes
- Changed the interface for the serviceX deployments