### PR TITLE
Add config for RabbitMQ retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- App retries connection to RabbitMQ on startup instead of just falling into Crash Loop
 
+### Changed
+- Max size of select statement increased to postgres varchar max
 
 ## [0.3] - 2020-02-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `app.image`                          | ServiceX_App image name                          | `sslhep/servicex_app`                                   |
 | `app.tag`                            | ServiceX image tag                               | `latest`                                                |
 | `app.pullPolicy`                     | ServiceX image pull policy                       | `IfNotPresent`                                          |
+| `app.rabbitmq.retries`               | Number of times to retry connecting to RabbitMQ on startup | 12                                            |
+| `app.rabbitmq.retry_interval`        | Number of seconds to wait between RabbitMQ retries on startup | 10                                         |
 | `didFinder.image`                    | DID Finder image name                            | `sslhep/servicex-did-finder`                            |
 | `didFinder.tag`                      | DID Finder image tag                             | `latest`                                                |
 | `didFinder.pullPolicy`               | DID Finder image pull policy                     | `IfNotPresent`                                          |

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -26,6 +26,11 @@ data:
     JWT_SECRET_KEY = 'jwt-secret-string'
     RABBIT_MQ_URL= 'amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F'
     TRANSFORMER_RABBIT_MQ_URL= 'amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F?heartbeat=9000'
+
+    # Keep retrying to connect to Rabbit if its not yet up
+    RABBIT_RETRIES = {{ .Values.app.rabbitmq.retries }}
+    RABBIT_RETRY_INTERVAL = {{ .Values.app.rabbitmq.retry_interval }}
+
     ADVERTISED_HOSTNAME= '{{ .Release.Name }}-servicex-app:8000'
 
     {{ if .Values.hostMount }}

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -22,6 +22,11 @@ app:
   tag: v0.3
   pullPolicy: IfNotPresent
 
+  # RabbitMQ can take up to one minute to start up. Simplify app startup by waiting for it
+  rabbitmq:
+    retries: 12
+    retry_interval: 10 # seconds
+
 # Settings for the DID Finder
 didFinder:
   image: sslhep/servicex-did-finder


### PR DESCRIPTION
# Problem
The App has been updated to expect configuration settings for connecting to RabbitMQ Server.

# Approach
- Added these settings to the app.conf template
- Added new values to the chart. Defaults to two minutes of retries
- Updated README