### PR TITLE
Request Rucio Replicas in Batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,13 +182,15 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `app.pullPolicy`                     | ServiceX image pull policy                       | `IfNotPresent`                                          |
 | `app.rabbitmq.retries`               | Number of times to retry connecting to RabbitMQ on startup | 12                                            |
 | `app.rabbitmq.retry_interval`        | Number of seconds to wait between RabbitMQ retries on startup | 10                                         |
+| `app.replicas`                       | Number of App pods to start. Experimental!       | 1                                                       |
+| `app.resources`                      | Pass in Kubernetes pod resource spec to deployment to change CPU and memory | { } |               
 | `didFinder.image`                    | DID Finder image name                            | `sslhep/servicex-did-finder`                            |
 | `didFinder.tag`                      | DID Finder image tag                             | `latest`                                                |
 | `didFinder.pullPolicy`               | DID Finder image pull policy                     | `IfNotPresent`                                          |
-| `didFinder.staticFile`               | For debugging, DID Finder will always return this file for any DID. | _Set to an open xAOD File_           |
 | `didFinder.site`                     | Tier 2 site to pass on to Rucio as client location |                                                       |
 | `didFinder.rucio_host`               | URL for Rucio service to use                     | `https://voatlasrucio-server-prod.cern.ch:443`          |
-| `didFinder.auth _host`               | URL to obtain rucio authentication               | `https://voatlasrucio-auth-prod.cern.ch:443`          |
+| `didFinder.auth _host`               | URL to obtain rucio authentication               | `https://voatlasrucio-auth-prod.cern.ch:443`            |
+| `didFinder.threads`                  | Number of threads for pull replicas out of Rucio | 5
 | `preflight.image`                    | Preflight image name                             | `sslhep/servicex-transformer`                           |
 | `preflight.tag`                      | Preflight image tag                              | `latest`                                                |
 | `preflight.pullPolicy`               | Preflight image pull policy                      | `IfNotPresent`                                          |
@@ -233,6 +235,20 @@ Once you have exposed port 5000 of the REST app, you can use the included
 transformation request, and check on the status of a running job. You can 
 import the collection from the [ServiceX REST App](https://raw.githubusercontent.com/ssl-hep/ServiceX_App/develop/ServiceXTest.postman_collection.json) repo
 
+
+### Production Deployment
+We are still experimenting with various configurations for deploying a scaled-up
+ServiceX. 
+
+It's certainly helpful to beef up the RabbitMQ deployment:
+```yaml
+rabbitmq:
+  resources:
+     requests:
+       memory: 256Mi
+       cpu: 100m
+  replicas: 3
+```
 
 > **Tip**: List all releases using `helm list`
 

--- a/servicex/templates/app_deployment.yaml
+++ b/servicex/templates/app_deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-servicex-app
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: {{ .Release.Name }}-servicex-app
@@ -23,6 +23,11 @@ spec:
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.app.pullPolicy }}
+        {{- if .Values.app.resources }}
+        resources:
+{{ toYaml .Values.app.resources | indent 10 }}
+        {{- end }}
+
         volumeMounts:
           - name: app-cfg
             mountPath: /opt/servicex

--- a/servicex/templates/app_deployment.yaml
+++ b/servicex/templates/app_deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-servicex-app
 spec:
-  replicas: 3
+  replicas: {{ .Values.app.replicas }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}-servicex-app

--- a/servicex/templates/did-finder-deployment.yaml
+++ b/servicex/templates/did-finder-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       - name: {{ .Release.Name }}-did-finder
         image: {{ .Values.didFinder.image }}:{{ .Values.didFinder.tag }}
         command: ["bash","-c"]
-        args: ["/usr/src/app/proxy-exporter.sh & sleep 5 && env PYTHONPATH=./did_finder python scripts/did_finder.py --rabbit-uri amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F {{ if .Values.didFinder.site }} --site {{ .Values.didFinder.site }} {{ end }} {{ if .Values.didFinder.staticFile }} --staticfile {{ .Values.didFinder.staticFile }} {{ end }}"]
+        args: ["/usr/src/app/proxy-exporter.sh & sleep 5 && env PYTHONPATH=./src python scripts/did_finder.py --rabbit-uri amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F {{ if .Values.didFinder.site }} --site {{ .Values.didFinder.site }} {{ end }} {{ if .Values.didFinder.staticFile }} --staticfile {{ .Values.didFinder.staticFile }} {{ end }}"]
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.didFinder.pullPolicy }}

--- a/servicex/templates/did-finder-deployment.yaml
+++ b/servicex/templates/did-finder-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       - name: {{ .Release.Name }}-did-finder
         image: {{ .Values.didFinder.image }}:{{ .Values.didFinder.tag }}
         command: ["bash","-c"]
-        args: ["/usr/src/app/proxy-exporter.sh & sleep 5 && env PYTHONPATH=./src python scripts/did_finder.py --rabbit-uri amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F {{ if .Values.didFinder.site }} --site {{ .Values.didFinder.site }} {{ end }} {{ if .Values.didFinder.staticFile }} --staticfile {{ .Values.didFinder.staticFile }} {{ end }}"]
+        args: ["/usr/src/app/proxy-exporter.sh & sleep 5 && env PYTHONPATH=./src python scripts/did_finder.py --rabbit-uri amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F {{ if .Values.didFinder.site }} --site {{ .Values.didFinder.site }} {{ end }} --threads {{ .Values.didFinder.threads }}"]
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.didFinder.pullPolicy }}

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -21,6 +21,7 @@ app:
   image: sslhep/servicex_app
   tag: v0.3
   pullPolicy: IfNotPresent
+  replicas: 1
 
   # RabbitMQ can take up to one minute to start up. Simplify app startup by waiting for it
   rabbitmq:
@@ -34,6 +35,7 @@ didFinder:
   pullPolicy: IfNotPresent
   rucio_host: https://voatlasrucio-server-prod.cern.ch:443
   auth_host: https://voatlasrucio-auth-prod.cern.ch:443
+  threads: 5
 
   site:
 


### PR DESCRIPTION
# Problem 
Improving the DID finder to request replicas in batches required refactoring of the code in that service as well as removing some unused functionality. It also sped up the delivery of file add messages to the REST server!

# Approach
1. Change the invocation of DID finder service in deployment to use `./src` in the PYTHONPATH
2. Remove static file capability from chart
3. Add threads property to DID finder launch and in values.yaml
4. Add ability to specify pod resources for App