### PR TITLE
Add ingress template

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `app.rabbitmq.retries`               | Number of times to retry connecting to RabbitMQ on startup | 12                                            |
 | `app.rabbitmq.retry_interval`        | Number of seconds to wait between RabbitMQ retries on startup | 10                                         |
 | `app.replicas`                       | Number of App pods to start. Experimental!       | 1                                                       |
+| `app.auth`                           | Enable JWT Auth or allow unfettered access (Python boolean string) | `"False"`                             |
+| `app.authTimeout`                    | How many seconds should the generated JWTs be valid for? | 21600 (six hours)                               |
+| `app.ingress.enabled`                | Enable install of ingres                         | false                                                   |
+| `app.ingress.host`                   | Hostname to associate ingress with               | uc.ssl-hep.org                                          |
+| `app.ingress.defaultBackend`         | Name of a service to send requests to internal endpoints to | default-http-backend                         |
 | `app.resources`                      | Pass in Kubernetes pod resource spec to deployment to change CPU and memory | { } |               
 | `didFinder.image`                    | DID Finder image name                            | `sslhep/servicex-did-finder`                            |
 | `didFinder.tag`                      | DID Finder image tag                             | `latest`                                                |

--- a/servicex/templates/NOTES.txt
+++ b/servicex/templates/NOTES.txt
@@ -38,3 +38,8 @@ Log in with
     Access Key: {{ .Values.minio.accessKey }}
     Secret Key: {{ .Values.minio.secretKey }}
 {{ end }}
+
+{{ if .Values.app.ingress.enabled }}
+Congratulations! You deployed an ingress for this service. You can access the
+REST service at http://{{ .Release.Name }}-servicex.{{ .Values.app.ingress.host }}
+{{ end }}

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -15,6 +15,12 @@ data:
     # details are beyond the scope of this example
     SECRET_KEY = 'abc123!'
 
+    # Enable JWT auth on public endpoints
+    ENABLE_AUTH={{ .Values.app.auth }}
+
+    # Number of seconds the JWT is valid for
+    JWT_ACCESS_TOKEN_EXPIRES={{ .Values.app.authTimeout }}
+
     {{ if .Values.postgres.enabled }}
     SQLALCHEMY_DATABASE_URI = 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
     {{ else }}

--- a/servicex/templates/ingress.yaml
+++ b/servicex/templates/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.app.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  labels:
+    app: {{ .Release.Name }}-servicex
+  name: {{ .Release.Name }}-servicex-ingress
+spec:
+  rules:
+  - host: {{ .Release.Name }}-servicex.{{ .Values.app.ingress.host }}
+    http:
+      paths:
+      {{- if .Values.objectStore.enabled }}
+      - path: /minio
+        backend:
+          serviceName: {{ .Release.Name }}-minio
+          servicePort: 9000
+      {{- end }}
+      - path: /servicex/internal
+        backend:
+          serviceName: {{ .Values.app.ingress.defaultBackend }}
+          servicePort: 80
+      - path: /
+        backend:
+          serviceName: {{ .Release.Name }}-servicex-app
+          servicePort: 8000
+{{- end }}

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -22,6 +22,15 @@ app:
   tag: v0.4
   pullPolicy: IfNotPresent
   replicas: 1
+  auth: "True"
+
+  # JWT remains valid for 6 hours
+  authTimeout: 21600
+
+  ingress:
+    enabled: false
+    host: uc.ssl-hep.org
+    defaultBackend: default-http-backend
 
   # RabbitMQ can take up to one minute to start up. Simplify app startup by waiting for it
   rabbitmq:


### PR DESCRIPTION
Partial solution to #61 

# Problem 
Users can only access ServiceX and Minio through Kubernetes Port Forwards

# Approach
Add an ingress to the template that allows access to the App service, while blocking access to the `/servicex/internal` endpoints.

Add an ingress rule to allow access to Minio

Add values to enable or disable JWT auth in the App. 
