### PR TITLE
Autoscale Transformer Pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `minio.accessKey`                    | Access key to log into minio                     | miniouser |
 | `minio.accessKey`                    | Secret key to log into minio                     | leftfoot1 |
 | `transformer.pullPolicy`             | Pull policy for transformer pods (Image name specified in REST Request) | IfNotPresent |
+| `transformer.autoscalerEnabled`      | Set to True to enable the pod horizontal autoscaler for transformers |  False          |
 | `elasticsearchLogging.enabled`       | Set to True to enable writing of reports to an external ElasticSearch system | False |
 | `elasticsearchLogging.host`          | Hostname for external ElasticSearch server | |
 | `elasticsearchLogging.port`          | Port for external ElasticSearch Server           | 9200 |

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -49,6 +49,8 @@ data:
     TRANSFORMER_PULL_POLICY = '{{ .Values.transformer.pullPolicy }}'
 
     TRANSFORMER_MANAGER_ENABLED = True
+
+    TRANSFORMER_AUTOSCALE_ENABLED = {{- ternary "True" "False" .Values.transformer.autoscalerEnabled }}
     TRANSFORMER_MANAGER_MODE = 'internal-kubernetes'
     TRANSFORMER_X509_SECRET="{{ .Release.Name }}-x509-proxy"
 

--- a/servicex/templates/role.yaml
+++ b/servicex/templates/role.yaml
@@ -9,9 +9,13 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:
-- apiGroups: ["batch"]
-  resources: ["jobs"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["autoscaling"]
+  resources: ["horizontalpodautoscalers"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
 
 ---
 

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -72,6 +72,8 @@ codeGen:
 # part of the transform request
 transformer:
   pullPolicy: IfNotPresent
+  autoscalerEnabled: false
+
 
 x509Secrets:
   image: sslhep/x509-secrets


### PR DESCRIPTION
# Problem
Slow dataset lookups, poorly specified transform requests, and I/O bottlenecks can create conditions where transformers are sitting idle and wasting compute resources.

This is partial solution to [ServiceX Issue 53](https://github.com/ssl-hep/ServiceX/issues/53)

# Approach
Support changes to the App's TransformerManager. 

1. Add helm value `transformer.autoscalerEnabled`
2. Update the flask app.config to turn autoscaling on or off as per user specification
3. Update the created service role to add permissions for managing deployments and horizontal pod autoscaler. Remove job permissions

# How to Test
1. Create a helm installation with:
 -  `transformer.autoscalerEnabled` set to _true_
 - App image tag set to `53_autoscale`
2. Submit a transform request with 17 workers
3. Verify that app creates a `deployment` with one pod
4. Use `kubectl get horizontalpodautoscaler` to verify that the autoscaler was created
5. Once the single transformer pod is created and gets going. Check to see that the number of pods is autoscaled to 17
6. You can watch ongoing status with  `kubectl get horizontalpodautoscaler`

You can also verify that the helm value is respected
1. Create a helm installation with:
 -  `transformer.autoscalerEnabled` set to _false_
 - App image tag set to `53_autoscale`
2. Submit a transform request with 17 workers
3. Verify that app creates a `deployment` with 17 pod
4. Use `kubectl get horizontalpodautoscaler` to verify that the autoscaler was not created


