### PR TITLE
Add public URL to app config

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,12 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `gridAccount`                        | CERN User account name to access Rucio           | - 
 | `rabbitmq.password`                  | Override the generated RabbitMQ password         | leftfoot1 |
 | `objectstore.enabled`                | Deploy a minio object store with Servicex?       | true      |
+| `objectstore.publicURL`              | What URL should the client use to download files? If set, this is given whether ingress is enabled or not  | nil |      |
 | `postgres.enabled`                   | Deploy a postgres database into cluster? If not, we use a sqllite db | false  |
 | `minio.accessKey`                    | Access key to log into minio                     | miniouser |
 | `minio.accessKey`                    | Secret key to log into minio                     | leftfoot1 |
+| `minio.ingress.enabled`              | Should minio chart deploy an ingress to the service? | false |
+| `minio.ingress.hosts`                | List of hosts to associate with ingress controller | nil |
 | `transformer.pullPolicy`             | Pull policy for transformer pods (Image name specified in REST Request) | IfNotPresent |
 | `transformer.autoscalerEnabled`      | Set to True to enable the pod horizontal autoscaler for transformers |  False          |
 | `elasticsearchLogging.enabled`       | Set to True to enable writing of reports to an external ElasticSearch system | False |

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -67,6 +67,11 @@ data:
     MINIO_URL_TRANSFORMER = '{{ .Release.Name }}-minio:9000'
     MINIO_ACCESS_KEY = '{{ .Values.minio.accessKey }}'
     MINIO_SECRET_KEY = '{{ .Values.minio.secretKey }}'
+    {{ if .Values.minio.ingress.enabled }}
+    MINIO_PUBLIC_URL = '{{index .Values.minio.ingress.hosts 0 }}'
+    {{ else }}
+    MINIO_PUBLIC_URL = '{{ .Release.Name }}-minio:9000'
+    {{ end }}
     {{ else }}
     OBJECT_STORE_ENABLED = False
     {{ end }}

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -63,15 +63,19 @@ data:
 
     {{ if .Values.objectStore.enabled }}
     OBJECT_STORE_ENABLED = True
-    MINIO_URL = '{{ .Release.Name }}-minio:9000'
-    MINIO_URL_TRANSFORMER = '{{ .Release.Name }}-minio:9000'
+    MINIO_URL = '{{ .Release.Name }}-minio:{{ .Values.minio.service.port }}'
+    MINIO_URL_TRANSFORMER = '{{ .Release.Name }}-minio:{{ .Values.minio.service.port }}'
     MINIO_ACCESS_KEY = '{{ .Values.minio.accessKey }}'
     MINIO_SECRET_KEY = '{{ .Values.minio.secretKey }}'
+
     {{ if .Values.minio.ingress.enabled }}
-    MINIO_PUBLIC_URL = '{{index .Values.minio.ingress.hosts 0 }}'
+    {{- $minio_ingress := index .Values.minio.ingress.hosts 0 -}}
+    MINIO_PUBLIC_URL = '{{ .Values.objectStore.publicURL | default $minio_ingress }}'
     {{ else }}
-    MINIO_PUBLIC_URL = '{{ .Release.Name }}-minio:9000'
+    {{- $internal_minio := printf "%s--minio:%v" .Release.Name .Values.minio.service.port -}}
+    MINIO_PUBLIC_URL = '{{- .Values.objectStore.publicURL | default $internal_minio }}'
     {{ end }}
+
     {{ else }}
     OBJECT_STORE_ENABLED = False
     {{ end }}

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -8,6 +8,7 @@
 # want to have the option of delivering results as parquet files
 objectStore:
     enabled: true
+    publicURL:
 
 # Enable deployment of a full postgres sql database. This is advisable for
 # bigger clusters where there will be several workers hitting the database


### PR DESCRIPTION
# Problem
A client of serviceX needs to know the URL, username, and password of the Minio instance where results are stored.

Partial solution to ServiceX issue #146

# Approach
Add `MINIO_PUBLIC_URL` to the flask app ConfigMap. If no ingress is requested, then provide the internal service name so it works in Jupyter.