### PR TITLE
Add Slack webhook URL for new signups to app configmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `app.ingress.enabled`                | Enable install of ingres                         | false                                                   |
 | `app.ingress.host`                   | Hostname to associate ingress with               | uc.ssl-hep.org                                          |
 | `app.ingress.defaultBackend`         | Name of a service to send requests to internal endpoints to | default-http-backend                         |
-| `app.resources`                      | Pass in Kubernetes pod resource spec to deployment to change CPU and memory | { }                          |
-| `app.secret`                         | Name of a Kubernetes Secret which is used to populate environment variables |                              |               
+| `app.resources`                      | Pass in Kubernetes pod resource spec to deployment to change CPU and memory | { }                          |    
+| `app.newSignupWebhook`               | Slack webhook URL for new signups                | - 
 | `didFinder.image`                    | DID Finder image name                            | `sslhep/servicex-did-finder`                            |
 | `didFinder.tag`                      | DID Finder image tag                             | `latest`                                                |
 | `didFinder.pullPolicy`               | DID Finder image pull policy                     | `IfNotPresent`                                          |

--- a/README.md
+++ b/README.md
@@ -241,7 +241,11 @@ To set this up, complete the following steps before deploying ServiceX:
 - Scroll down to the App Credentials section and find your Signing Secret. Copy this value and place it in your `values.yaml` file as `app.slackSigningSecret`.
 - Scroll up to the feature list, click on Incoming Webhooks, and click the switch to turn them on.
 - Click the Add New Webhook to Workspace button at the bottom, choose your signups channel, and click the Allow button.
-- Copy the Webhook URL and store it in `values.yaml` under `app.newSignupWebhook`. Your next ServiceX deployment is ready to send Slack notifications!
+- Copy the Webhook URL and store it in `values.yaml` under `app.newSignupWebhook`.
+- After completing the rest of the configuration, deploy ServiceX.
+- Go back to the [Slack App dashboard](https://api.slack.com/apps) and choose the app you created earlier. In the sidebar, click on Interactivity & Shortcuts under Features.
+- Click the switch to turn Interactivity on. In the Request URL field, enter the base URL for the ServiceX API, followed by `/slack`, e.g. `http://rc1-xaod-servicex.uc.ssl-hep.org/slack`. Save your changes.
+- You're all set! ServiceX will now send interactive Slack notifications to your signups channel whenever a new user registers.
 
 
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ training wheels off and run ServiceX against a real dataset.
 
 ### Grid Certification
 The DID Finder will need to talk to CERN's Rucio service which requires grid
-certificates and a passcode to unlock them. If you are a member of the ATLAS
+certificates and a passcode to unlock them. If you are a mkember of the ATLAS
 experiment, you can follow these 
 [helpful instructions](https://hep.pa.msu.edu/wiki/bin/view/ATLAS_Tier3/GridCert) 
 on obtaining proper grid certificates.
@@ -191,6 +191,7 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `app.ingress.host`                   | Hostname to associate ingress with               | uc.ssl-hep.org                                          |
 | `app.ingress.defaultBackend`         | Name of a service to send requests to internal endpoints to | default-http-backend                         |
 | `app.resources`                      | Pass in Kubernetes pod resource spec to deployment to change CPU and memory | { }                          |    
+| `app.slackSigningSecret`             | Signing secret for Slack application             | -
 | `app.newSignupWebhook`               | Slack webhook URL for new signups                | - 
 | `didFinder.image`                    | DID Finder image name                            | `sslhep/servicex-did-finder`                            |
 | `didFinder.tag`                      | DID Finder image tag                             | `latest`                                                |
@@ -230,6 +231,20 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `elasticsearchLogging.password`      | Password to connect to external ElasticSearch Server | |
 
 
+### Slack Integration
+
+ServiceX can send notifications of new user registrations to the Slack channel of your choice and allow administrators to approve pending users directly from Slack. 
+To set this up, complete the following steps before deploying ServiceX:
+
+- Create a secure Slack channel in your workspace (suggested name: `#servicex-signups`), accessible only to developers or administrators of ServiceX. 
+- Go to https://api.slack.com/apps and click "Create New App". Fill in ServiceX as the name and choose your workspace.
+- Scroll down to the App Credentials section and find your Signing Secret. Copy this value and place it in your `values.yaml` file as `app.slackSigningSecret`.
+- Scroll up to the feature list, click on Incoming Webhooks, and click the switch to turn them on.
+- Click the Add New Webhook to Workspace button at the bottom, choose your signups channel, and click the Allow button.
+- Copy the Webhook URL and store it in `values.yaml` under `app.newSignupWebhook`. Your next ServiceX deployment is ready to send Slack notifications!
+
+
+
 ### Using The Service
 You can access the REST service on your desktop with 
 ```bash
@@ -263,6 +278,7 @@ rabbitmq:
 ```
 
 > **Tip**: List all releases using `helm list`
+
 
 ### Uninstalling the Chart
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ public xAOD file without any grid credentials.
 There is also an included Jupyter notebook for driving the system and getting
 some simple plots back.
 
-### Step 0 - Preperation
+### Step 0 - Preparation
 ServiceX requires an installation of Kubernetes. If you have access to a 
 cluster you can use that. Otherwise, you can enable a
 single node kubernetes cluster on your desktop 
@@ -146,7 +146,7 @@ training wheels off and run ServiceX against a real dataset.
 
 ### Grid Certification
 The DID Finder will need to talk to CERN's Rucio service which requires grid
-certificates and a passcode to unlock them. If you are a mkember of the ATLAS
+certificates and a passcode to unlock them. If you are a member of the ATLAS
 experiment, you can follow these 
 [helpful instructions](https://hep.pa.msu.edu/wiki/bin/view/ATLAS_Tier3/GridCert) 
 on obtaining proper grid certificates.
@@ -278,7 +278,6 @@ rabbitmq:
 ```
 
 > **Tip**: List all releases using `helm list`
-
 
 ### Uninstalling the Chart
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `app.ingress.enabled`                | Enable install of ingres                         | false                                                   |
 | `app.ingress.host`                   | Hostname to associate ingress with               | uc.ssl-hep.org                                          |
 | `app.ingress.defaultBackend`         | Name of a service to send requests to internal endpoints to | default-http-backend                         |
-| `app.resources`                      | Pass in Kubernetes pod resource spec to deployment to change CPU and memory | { } |               
+| `app.resources`                      | Pass in Kubernetes pod resource spec to deployment to change CPU and memory | { }                          |
+| `app.secret`                         | Name of a Kubernetes Secret which is used to populate environment variables |                              |               
 | `didFinder.image`                    | DID Finder image name                            | `sslhep/servicex-did-finder`                            |
 | `didFinder.tag`                      | DID Finder image tag                             | `latest`                                                |
 | `didFinder.pullPolicy`               | DID Finder image pull policy                     | `IfNotPresent`                                          |

--- a/servicex/templates/app_deployment.yaml
+++ b/servicex/templates/app_deployment.yaml
@@ -19,7 +19,13 @@ spec:
         env:
         - name: APP_CONFIG_FILE
           value: "/opt/servicex/app.conf"
-
+        {{- if .Values.app.secret }}
+        - name: SLACK_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.app.secret }}
+              key: SLACK_WEBHOOK_URL
+        {{- end }}
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.app.pullPolicy }}

--- a/servicex/templates/app_deployment.yaml
+++ b/servicex/templates/app_deployment.yaml
@@ -19,13 +19,6 @@ spec:
         env:
         - name: APP_CONFIG_FILE
           value: "/opt/servicex/app.conf"
-        {{- if .Values.app.secret }}
-        - name: SLACK_WEBHOOK_URL
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.app.secret }}
-              key: SLACK_WEBHOOK_URL
-        {{- end }}
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.app.pullPolicy }}

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -25,6 +25,11 @@ data:
     # Number of seconds the JWT is valid for
     JWT_ACCESS_TOKEN_EXPIRES={{ .Values.app.authTimeout }}
 
+    # Slack webhooks
+    {{ if .Values.app.newSignupWebhook }}
+    SIGNUP_WEBHOOK_URL = '{{ .Values.app.newSignupWebhook }}'
+    {{ end }}
+
     {{ if .Values.postgres.enabled }}
     SQLALCHEMY_DATABASE_URI = 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
     {{ else }}
@@ -93,4 +98,5 @@ data:
     {{ if .Values.codeGen.enabled }}
     CODE_GEN_SERVICE_URL = 'http://{{ .Release.Name }}-code-gen:8000'
     {{ end }}
+
 

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -26,6 +26,9 @@ data:
     JWT_ACCESS_TOKEN_EXPIRES={{ .Values.app.authTimeout }}
 
     # Slack webhooks
+    {{ if .Values.app.slackSigningSecret }}
+    SLACK_SIGNING_SECRET = '{{ .Values.app.slackSigningSecret }}'
+    {{ end }}
     {{ if .Values.app.newSignupWebhook }}
     SIGNUP_WEBHOOK_URL = '{{ .Values.app.newSignupWebhook }}'
     {{ end }}

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -25,9 +25,6 @@ app:
   replicas: 1
   auth: false
 
-  # Name of secret used to populate environment variables
-  secret:
-
   # Create an initial admin user to manage new user workflow
   adminUser: admin
   adminPassword: changeme

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -25,6 +25,9 @@ app:
   replicas: 1
   auth: false
 
+  # Name of secret used to populate environment variables
+  secret:
+
   # Create an initial admin user to manage new user workflow
   adminUser: admin
   adminPassword: changeme


### PR DESCRIPTION
This adds an optional secret to the Flask app, which is then used to populate environment variables (namely `SLACK_WEBHOOK_URL`). The name of the secret can be specified in `values.yaml` (default null so that the app can be deployed without one).

Related to ssl-hep/ServiceX_App#35, which partially resolves #152.