### PR TITLE
Add JWT_ADMIN_EMAIL config value to comply with new UserModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `app.rabbitmq.retry_interval`        | Number of seconds to wait between RabbitMQ retries on startup | 10                                         |
 | `app.replicas`                       | Number of App pods to start. Experimental!       | 1                                                       |
 | `app.auth`                           | Enable JWT Auth or allow unfettered access (Python boolean string) | `false`                             |
-| `app.adminUser`                      | Username for auto created admin user to manage new user workflow   | admin                                 |
+| `app.adminEmail`                     | Email for auto created admin user to manage new user workflow   | admin@example.com                        |
 | `app.adminPassword`                  | Password for auto created admin user to manage new user workflow   | changeme                                 |
 | `app.authTimeout`                    | How many seconds should the generated JWTs be valid for? | 21600 (six hours)                               |
 | `app.ingress.enabled`                | Enable install of ingres                         | false                                                   |

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -19,8 +19,7 @@ data:
     ENABLE_AUTH={{- ternary "True" "False" .Values.app.auth }}
 
     # Create an initial admin user to manage new user workflow
-    JWT_ADMIN_EMAIL = '{{ .Values.app.adminEmail }}'
-    JWT_ADMIN = '{{ .Values.app.adminUser }}'
+    JWT_ADMIN = '{{ .Values.app.adminEmail }}'
     JWT_PASS = '{{ .Values.app.adminPassword }}'
 
     # Number of seconds the JWT is valid for

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -19,6 +19,7 @@ data:
     ENABLE_AUTH={{- ternary "True" "False" .Values.app.auth }}
 
     # Create an initial admin user to manage new user workflow
+    JWT_ADMIN_EMAIL = '{{ .Values.app.adminEmail }}'
     JWT_ADMIN = '{{ .Values.app.adminUser }}'
     JWT_PASS = '{{ .Values.app.adminPassword }}'
 

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -26,6 +26,7 @@ app:
   auth: false
 
   # Create an initial admin user to manage new user workflow
+  adminEmail: admin@example.com
   adminUser: admin
   adminPassword: changeme
 

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -27,7 +27,6 @@ app:
 
   # Create an initial admin user to manage new user workflow
   adminEmail: admin@example.com
-  adminUser: admin
   adminPassword: changeme
 
   # JWT remains valid for 6 hours


### PR DESCRIPTION
This PR enables the automatically-created admin user to be saved to POSTGRES under the new UserModel described in ssl-hep/ServiceX_App#37. Related: #160.