### PR TITLE
Check that docker image exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `app.ingress.defaultBackend`         | Name of a service to send requests to internal endpoints to | default-http-backend                         |
 | `app.resources`                      | Pass in Kubernetes pod resource spec to deployment to change CPU and memory | { }                          |    
 | `app.slackSigningSecret`             | Signing secret for Slack application             | -
-| `app.newSignupWebhook`               | Slack webhook URL for new signups                | - 
+| `app.newSignupWebhook`               | Slack webhook URL for new signups                | -
+| `app.validateTransformerImage`       | Should docker image name be validated at DockerHub? | `true`                                               | 
 | `didFinder.image`                    | DID Finder image name                            | `sslhep/servicex-did-finder`                            |
 | `didFinder.tag`                      | DID Finder image tag                             | `latest`                                                |
 | `didFinder.pullPolicy`               | DID Finder image pull policy                     | `IfNotPresent`                                          |

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -65,7 +65,7 @@ data:
     TRANSFORMER_AUTOSCALE_ENABLED = {{- ternary "True" "False" .Values.transformer.autoscalerEnabled }}
     TRANSFORMER_MANAGER_MODE = 'internal-kubernetes'
     TRANSFORMER_X509_SECRET="{{ .Release.Name }}-x509-proxy"
-
+    TRANSFORMER_VALIDATE_DOCKER_IMAGE = {{- ternary "True" "False" .Values.app.validateTransformerImage }}
 
     TRANSFORMER_MESSAGING = 'none'
 

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -24,6 +24,7 @@ app:
   pullPolicy: IfNotPresent
   replicas: 1
   auth: false
+  validateTransformerImage: true
 
   # Create an initial admin user to manage new user workflow
   adminEmail: admin@example.com


### PR DESCRIPTION
Companion to [ServiceX_App PR 46](https://github.com/ssl-hep/ServiceX_App/pull/46) and partial solution to Issue #154 

# Problem
When deploying a serviceX instance, a user may wish for the app to ignore the check for docker image on Docker Hub. For example when debugging a new transformer that may not exist in the repository.

# Approach
Add a new setting in `values.yaml` to allow user to turn off this check.
