### PR TITLE
Make autoscaler CPU limit configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `transformer.pullPolicy`             | Pull policy for transformer pods (Image name specified in REST Request) | IfNotPresent |
 | `transformer.autoscalerEnabled`      | Set to True to enable the pod horizontal autoscaler for transformers |  False          |
 | `transformer.cpuLimit`               | Set CPU resource limit for pod in number of cores | 1 |
-| `transformer.cpuScaleThreshold`      | Set CPU percentage threshold for pod scaling | 1 |
+| `transformer.cpuScaleThreshold`      | Set CPU percentage threshold for pod scaling | 70 |
 | `elasticsearchLogging.enabled`       | Set to True to enable writing of reports to an external ElasticSearch system | False |
 | `elasticsearchLogging.host`          | Hostname for external ElasticSearch server | |
 | `elasticsearchLogging.port`          | Port for external ElasticSearch Server           | 9200 |

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `minio.ingress.hosts`                | List of hosts to associate with ingress controller | nil |
 | `transformer.pullPolicy`             | Pull policy for transformer pods (Image name specified in REST Request) | IfNotPresent |
 | `transformer.autoscalerEnabled`      | Set to True to enable the pod horizontal autoscaler for transformers |  False          |
+| `transformer.cpuLimit`               | Set CPU percentage threshold for pod scaling | 1 |
 | `elasticsearchLogging.enabled`       | Set to True to enable writing of reports to an external ElasticSearch system | False |
 | `elasticsearchLogging.host`          | Hostname for external ElasticSearch server | |
 | `elasticsearchLogging.port`          | Port for external ElasticSearch Server           | 9200 |

--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `minio.ingress.hosts`                | List of hosts to associate with ingress controller | nil |
 | `transformer.pullPolicy`             | Pull policy for transformer pods (Image name specified in REST Request) | IfNotPresent |
 | `transformer.autoscalerEnabled`      | Set to True to enable the pod horizontal autoscaler for transformers |  False          |
-| `transformer.cpuLimit`               | Set CPU percentage threshold for pod scaling | 1 |
+| `transformer.cpuLimit`               | Set CPU resource limit for pod in number of cores | 1 |
+| `transformer.cpuScaleThreshold`      | Set CPU percentage threshold for pod scaling | 1 |
 | `elasticsearchLogging.enabled`       | Set to True to enable writing of reports to an external ElasticSearch system | False |
 | `elasticsearchLogging.host`          | Hostname for external ElasticSearch server | |
 | `elasticsearchLogging.port`          | Port for external ElasticSearch Server           | 9200 |

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -63,6 +63,7 @@ data:
     TRANSFORMER_MANAGER_ENABLED = True
 
     TRANSFORMER_AUTOSCALE_ENABLED = {{- ternary "True" "False" .Values.transformer.autoscalerEnabled }}
+    TRANSFORMER_CPU_LIMIT = {{ .Values.transformer.cpuLimit }}
     TRANSFORMER_MANAGER_MODE = 'internal-kubernetes'
     TRANSFORMER_X509_SECRET="{{ .Release.Name }}-x509-proxy"
 

--- a/servicex/templates/flask_app-configmap.yaml
+++ b/servicex/templates/flask_app-configmap.yaml
@@ -64,6 +64,7 @@ data:
 
     TRANSFORMER_AUTOSCALE_ENABLED = {{- ternary "True" "False" .Values.transformer.autoscalerEnabled }}
     TRANSFORMER_CPU_LIMIT = {{ .Values.transformer.cpuLimit }}
+    TRANSFORMER_CPU_SCALE_THRESHOLD = {{ .Values.transformer.cpuScaleThreshold }}
     TRANSFORMER_MANAGER_MODE = 'internal-kubernetes'
     TRANSFORMER_X509_SECRET="{{ .Release.Name }}-x509-proxy"
 

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -79,7 +79,7 @@ transformer:
   pullPolicy: IfNotPresent
   autoscalerEnabled: false
   cpuLimit: 1
-  cpuScaleThreshold: 1
+  cpuScaleThreshold: 70
 
 
 x509Secrets:

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -79,6 +79,7 @@ transformer:
   pullPolicy: IfNotPresent
   autoscalerEnabled: false
   cpuLimit: 1
+  cpuScaleThreshold: 1
 
 
 x509Secrets:

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -78,6 +78,7 @@ codeGen:
 transformer:
   pullPolicy: IfNotPresent
   autoscalerEnabled: false
+  cpuLimit: 1
 
 
 x509Secrets:


### PR DESCRIPTION
Updates README, Flask configmap, and values.yaml to accommodate new CPU threshold configuration for autoscaling.