### PR TITLE
Add placeholders for slack secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ venv.bak/
 node_modules
 
 .idea/
+deployed-values/

--- a/river-uproot-values.yaml
+++ b/river-uproot-values.yaml
@@ -1,6 +1,8 @@
 app:
   adminPassword: changeme
   auth: true
+  slackSigningSecret: See README for instructions
+  newSignupWebhook: See README for instructions
   ingress:
     enabled: true
 codeGen:

--- a/river-xaod-values.yaml
+++ b/river-xaod-values.yaml
@@ -1,6 +1,8 @@
 app:
   adminPassword: changeme
   auth: true
+  slackSigningSecret: See README for instructions
+  newSignupWebhook: See README for instructions
   ingress:
     enabled: true
 codeGen:
@@ -12,7 +14,7 @@ minio:
   ingress:
     enabled: true
     hosts:
-    - "rc2-xaod-minio.uc.ssl-hep.org"
+    - "xaod-minio.uc.ssl-hep.org"
   mode: distributed
 postgres:
   enabled: true


### PR DESCRIPTION
Add placeholders for secrets. To make it easier to maintain deployments I'm storing values files with secrets and passwords in a directory called `deployed-values/` - I added this to .gitignore