### PR TITLE
RC2 Bug Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ venv.bak/
 node_modules
 
 .idea/
+deployed-values/

--- a/river-uproot-values.yaml
+++ b/river-uproot-values.yaml
@@ -1,6 +1,8 @@
 app:
   adminPassword: changeme
   auth: true
+  slackSigningSecret: See README for instructions
+  newSignupWebhook: See README for instructions
   ingress:
     enabled: true
 codeGen:

--- a/river-xaod-values.yaml
+++ b/river-xaod-values.yaml
@@ -1,6 +1,8 @@
 app:
   adminPassword: changeme
   auth: true
+  slackSigningSecret: See README for instructions
+  newSignupWebhook: See README for instructions
   ingress:
     enabled: true
 codeGen:
@@ -12,7 +14,7 @@ minio:
   ingress:
     enabled: true
     hosts:
-    - "rc2-xaod-minio.uc.ssl-hep.org"
+    - "xaod-minio.uc.ssl-hep.org"
   mode: distributed
 postgres:
   enabled: true

--- a/servicex/templates/preflight-check-deployment.yaml
+++ b/servicex/templates/preflight-check-deployment.yaml
@@ -19,8 +19,8 @@ spec:
         command: ["bash","-c"]
         env:
           - name: "BASH_ENV"
-            value: "/home/atlas/.bashrc"
-        args: ["/home/atlas/proxy-exporter.sh & sleep 5 && python validate_requests.py --rabbit-uri amqp://user:{{.Values.rabbitmq.rabbitmq.password}}@{{ .Release.Name }}-rabbitmq:5672/%2F"]
+            value: "/servicex/.bashrc"
+        args: ["/servicex/proxy-exporter.sh & sleep 5 && python /servicex/validate_requests.py --rabbit-uri amqp://user:{{.Values.rabbitmq.rabbitmq.password}}@{{ .Release.Name }}-rabbitmq:5672/%2F"]
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.preflight.pullPolicy }}


### PR DESCRIPTION
There were still `/home/atlas` references in the preflight module. Fixed these
Deployment with slack secrets is easier with placeholders in the river template values.yaml
I started maintaining deployed versions of the river templates with secrets and passwords. These are in a subdirectory called `deployed-values`. Added this to .gitignore to avoid costly mistakes