### PR TITLE
Configure Ingress to use TLS cert and HTTPS

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -168,8 +168,9 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `app.tokenExpires`                   | Seconds until the ServiceX API tokens (JWT refresh tokens) expire | False (never)                          |
 | `app.authExpires`                    | Seconds until the JWT access tokens expire       | 21600 (six hours)                                       |
 | `app.ingress.enabled`                | Enable install of ingress                        | false                                                   |
-| `app.ingress.host`                   | Hostname to associate ingress with               | uc.ssl-hep.org                                          |
+| `app.ingress.host`                   | Hostname to associate ingress with               | servicex.ssl-hep.org                                    |
 | `app.ingress.defaultBackend`         | Name of a service to send requests to internal endpoints to | default-http-backend                         |
+| `app.ingress.clusterIssuer`          | Name of the ClusterIssuer to use which will be used to obtain a TLS certificate | letsencrypt-staging      |
 | `app.resources`                      | Pass in Kubernetes pod resource spec to deployment to change CPU and memory | { }                          |    
 | `app.slackSigningSecret`             | Signing secret for Slack application             | -
 | `app.newSignupWebhook`               | Slack webhook URL for new signups                | -
@@ -229,7 +230,7 @@ To set this up, complete the following steps before deploying ServiceX:
 - Copy the Webhook URL and store it in `values.yaml` under `app.newSignupWebhook`.
 - After completing the rest of the configuration, deploy ServiceX.
 - Go back to the [Slack App dashboard](https://api.slack.com/apps) and choose the app you created earlier. In the sidebar, click on Interactivity & Shortcuts under Features.
-- Click the switch to turn Interactivity on. In the Request URL field, enter the base URL for the ServiceX API, followed by `/slack`, e.g. `http://rc1-xaod-servicex.uc.ssl-hep.org/slack`. Save your changes.
+- Click the switch to turn Interactivity on. In the Request URL field, enter the base URL for the ServiceX API, followed by `/slack`, e.g. `https://xaod.servicex.ssl-hep.org/slack`. Save your changes.
 - You're all set! ServiceX will now send interactive Slack notifications to your signups channel whenever a new user registers.
 
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -206,9 +206,9 @@ The App name can be whatever you like.
 
 The scopes should include:
 ```
-email,
-urn:globus:auth:scope:auth.globus.org:view_identity_set
-```
+openid
+email
+profile```
 
 Note the Client ID and paste this into your `values.yaml` as
 ```yaml
@@ -217,7 +217,7 @@ app:
 ```
 
 Generate a client secret and paste this value into:
- ```yaml
+```yaml
 app:
   globusClientSecret: << client secret here>> 
 ```
@@ -226,7 +226,9 @@ The redirect URL will be your host followed by `/auth-callback`.
 In the earlier example, the redirect would be
 `https://xaod.servicex.ssl-hep.org/auth-callback`.
 If you want to use port-forwarding, also include
-`http://localhost:5000/auth-callback`. Save the record.
+`http://localhost:5000/auth-callback`. 
+
+Save the record.
 
 ### Set the Minio Ingress
 Resulting files are stored in a minio object store which is deployed as a 

--- a/docs/development.md
+++ b/docs/development.md
@@ -65,7 +65,7 @@ file. For example, to run on SSL-RIVER,
           ingress:
             enabled: true
             hosts:
-            - "servicex-minio.uc.ssl-hep.org"
+            - "xaod-minio.servicex.ssl-hep.org"
         gridAccount: bgalewsk
         EOF
 

--- a/river-uproot-values.yaml
+++ b/river-uproot-values.yaml
@@ -5,6 +5,7 @@ app:
   newSignupWebhook: See README for instructions
   ingress:
     enabled: true
+    clusterIssuer: letsencrypt-prod
 codeGen:
   image: sslhep/servicex_code_gen_func_adl_uproot
 didFinder:
@@ -14,7 +15,7 @@ minio:
   ingress:
     enabled: true
     hosts:
-    - "rc2-uproot-minio.uc.ssl-hep.org"
+    - "uproot-minio.servicex.ssl-hep.org"
   mode: distributed
 postgres:
   enabled: true

--- a/river-xaod-values.yaml
+++ b/river-xaod-values.yaml
@@ -5,6 +5,7 @@ app:
   newSignupWebhook: See README for instructions
   ingress:
     enabled: true
+    clusterIssuer: letsencrypt-prod
 codeGen:
   image: sslhep/servicex_code_gen_func_adl_xaod
 didFinder:
@@ -14,7 +15,7 @@ minio:
   ingress:
     enabled: true
     hosts:
-    - "xaod-minio.uc.ssl-hep.org"
+    - "xaod-minio.servicex.ssl-hep.org"
   mode: distributed
 postgres:
   enabled: true

--- a/servicex/templates/NOTES.txt
+++ b/servicex/templates/NOTES.txt
@@ -41,5 +41,5 @@ Log in with
 
 {{ if .Values.app.ingress.enabled }}
 Congratulations! You deployed an ingress for this service. You can access the
-REST service at http://{{ .Release.Name }}-servicex.{{ .Values.app.ingress.host }}
+REST service at http://{{ .Release.Name }}.{{ .Values.app.ingress.host }}
 {{ end }}

--- a/servicex/templates/app/ingress.yaml
+++ b/servicex/templates/app/ingress.yaml
@@ -4,12 +4,22 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if .Values.app.ingress.clusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.app.ingress.clusterIssuer }}
+    acme.cert-manager.io/http01-edit-in-place: "true"
+    {{- end }}
   labels:
     app: {{ .Release.Name }}-servicex
-  name: {{ .Release.Name }}-servicex-ingress
+  name: {{ .Release.Name }}-servicex
 spec:
+  {{- if .Values.app.ingress.clusterIssuer }}
+  tls:
+  - hosts:
+    - {{ .Release.Name }}.{{ .Values.app.ingress.host }}
+    secretName: {{ .Release.Name }}-tls
+  {{- end }}
   rules:
-  - host: {{ .Release.Name }}-servicex.{{ .Values.app.ingress.host }}
+  - host: {{ .Release.Name }}.{{ .Values.app.ingress.host }}
     http:
       paths:
       {{- if .Values.objectStore.enabled }}

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -43,8 +43,9 @@ app:
 
   ingress:
     enabled: false
-    host: uc.ssl-hep.org
+    host: servicex.ssl-hep.org
     defaultBackend: default-http-backend
+    clusterIssuer: letsencrypt-staging
 
   # RabbitMQ can take up to one minute to start up. Simplify app startup by waiting for it
   rabbitmq:


### PR DESCRIPTION
Our new auth system cannot be used externally without a TLS certificate, as the redirect URLs must be served over HTTPS.
While it's possible to get around this by port-forwarding, we need to resolve this before RC3.

#### Assumptions
- Cluster has [cert-manager](https://cert-manager.io/) installed.
- A ClusterIssuer is deployed for at least one widely-accepted certificate authority, preferably Let's Encrypt.
The proposed changes to the chart don't currently support regular Issuers, which are scoped to a single namespace, but are otherwise identical to ClusterIssuers.
- `letsencrypt-staging` is the default, since `letsencrypt-prod` is [limited](https://letsencrypt.org/docs/rate-limits/) to 50 certificates **per week per domain**.  The staging CA is not accepted by major browsers, and gives warnings in Chrome, Firefox, and Edge.

#### Scope
- Configure the Ingress to use TLS whenever a ClusterIssuer is provided in `values.yaml`
- Update the deployment guide
- Change all occurrences of `*.uc.ssl-hep.org` to `*.servicex.ssl-hep.org` (Lincoln has configured this subdomain for our use on River). Remove the `-servicex` suffix after the release name since it is now redundant.

The River values files are given a ClusterIssuer of `letsencrypt-prod`, but we can change it to staging if development team members are making deployments frequently enough to hit the rate limit. We can also figure out how to allow Issuers as well as ClusterIssuers if it's important.

An unusual, but possible scenario is to make an externally accessible deployment with an Ingress and TLS, but authentication disabled. We could mention this in the "Sneak a Peek" section of the deployment docs if it's not clear.

