### PR TITLE
Add MINIO_SECURED to app ConfigMap

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -244,6 +244,24 @@ minio:
     - "xaod-minio.servicex.ssl-hep.org"
 ```
 
+TLS can also be enabled for Minio. To do so using cert-manager and the 
+Let's Encrypt ClusterIssuer, use the following configuration:
+```yaml
+minio:
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      acme.cert-manager.io/http01-edit-in-place: "true"
+    hosts:
+    - xaod-minio.servicex.ssl-hep.org
+    tls:
+    - hosts:
+      - xaod-minio.servicex.ssl-hep.org
+      secretName: xaod-minio-tls
+```
+
 ### Sneak a Peek
 If you wish, you could deploy these values and have a ServiceX instance that
 is not secured but is reachable via the public URL.

--- a/river-uproot-values.yaml
+++ b/river-uproot-values.yaml
@@ -14,8 +14,16 @@ gridAccount: bgalewsk
 minio:
   ingress:
     enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      acme.cert-manager.io/http01-edit-in-place: "true"
     hosts:
-    - "uproot-minio.servicex.ssl-hep.org"
+    - uproot-minio.servicex.ssl-hep.org
+    tls:
+    - hosts:
+      - uproot-minio.servicex.ssl-hep.org
+      secretName: uproot-minio-tls
   mode: distributed
 postgres:
   enabled: true

--- a/river-xaod-values.yaml
+++ b/river-xaod-values.yaml
@@ -14,8 +14,16 @@ gridAccount: bgalewsk
 minio:
   ingress:
     enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      acme.cert-manager.io/http01-edit-in-place: "true"
     hosts:
-    - "xaod-minio.servicex.ssl-hep.org"
+    - xaod-minio.servicex.ssl-hep.org
+    tls:
+    - hosts:
+      - xaod-minio.servicex.ssl-hep.org
+      secretName: xaod-minio-tls
   mode: distributed
 postgres:
   enabled: true

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -89,6 +89,7 @@ data:
     {{ if .Values.minio.ingress.enabled }}
     {{- $minio_ingress := index .Values.minio.ingress.hosts 0 -}}
     MINIO_PUBLIC_URL = '{{ .Values.objectStore.publicURL | default $minio_ingress }}'
+    MINIO_SECURED = {{ ternary "True" "False" (not (empty .Values.minio.ingress.tls)) }}
     {{ else }}
     {{- $internal_minio := printf "%s--minio:%v" .Release.Name .Values.minio.service.port -}}
     MINIO_PUBLIC_URL = '{{- .Values.objectStore.publicURL | default $internal_minio }}'


### PR DESCRIPTION
`MINIO_SECURED` is True if the Minio Ingress is enabled and its tls property is nonempty, and False otherwise.

Linked to ssl-hep/ServiceX_App#66.