### PR TITLE
Add default transformer image and code-gen image to app configmap

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -210,6 +210,7 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `transformer.autoscalerEnabled`      | Set to True to enable the pod horizontal autoscaler for transformers |  False          |
 | `transformer.cpuLimit`               | Set CPU resource limit for pod in number of cores | 1 |
 | `transformer.cpuScaleThreshold`      | Set CPU percentage threshold for pod scaling | 70 |
+| 'transformer.defaultTransformerImage` | Default image for the transformers - must match the codeGen | 'sslhep/servicex_func_adl_xaod_transformer:1.0.0-RC.3' | 
 | `elasticsearchLogging.enabled`       | Set to True to enable writing of reports to an external ElasticSearch system | False |
 | `elasticsearchLogging.host`          | Hostname for external ElasticSearch server | |
 | `elasticsearchLogging.port`          | Port for external ElasticSearch Server           | 9200 |

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -78,6 +78,8 @@ data:
     TRANSFORMER_VALIDATE_DOCKER_IMAGE = {{- ternary "True" "False" .Values.app.validateTransformerImage }}
 
     TRANSFORMER_MESSAGING = 'none'
+    TRANSFORMER_DEFAULT_IMAGE = "{{ .Values.transformer.defaultTransformerImage }}"
+
 
     {{ if .Values.objectStore.enabled }}
     OBJECT_STORE_ENABLED = True
@@ -110,4 +112,5 @@ data:
 
     {{ if .Values.codeGen.enabled }}
     CODE_GEN_SERVICE_URL = 'http://{{ .Release.Name }}-code-gen:8000'
+    CODE_GEN_IMAGE = '{{ .Values.codeGen.image }}:{{ .Values.codeGen.tag }}'
     {{ end }}

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -90,7 +90,9 @@ transformer:
   autoscalerEnabled: false
   cpuLimit: 1
   cpuScaleThreshold: 70
-
+  defaultTransformerImage: sslhep/servicex_func_adl_xaod_transformer:1.0.0-RC.3
+  # For uproot deployment
+  #  defaultTransformerImage: sslhep/servicex_func_adl_uproot_transformer:1.0.0-RC.3
 
 x509Secrets:
   image: sslhep/x509-secrets


### PR DESCRIPTION
# Problem 
The user of serviceX needs to know the transformer image name that matches the deployment. Some users may have strong opinions about this, but most users want the system to know which transformer works best.

Partial solution of [ServiceX Issue 149](https://github.com/ssl-hep/ServiceX/issues/149)

# Approach
1. Add new value for default transformer image
2. Put this value, along with the code-gen image name and tag into the application ConfigMap

