### PR TITLE
Update values.yaml to reflect auth values for bitnami

### DIFF
--- a/servicex/templates/NOTES.txt
+++ b/servicex/templates/NOTES.txt
@@ -15,8 +15,8 @@ Optionally, you can use a port forward to access the RabbitMQ Dashboard:
   kubectl port-forward --namespace {{ .Release.Namespace }} {{ .Release.Name }}-rabbitmq-0 15672:15672
 and then visit http://localhost:15672
 Log in with
-    username: {{ .Values.rabbitmq.rabbitmq.username }}
-    password: {{ .Values.rabbitmq.rabbitmq.password }}
+    username: {{ .Values.rabbitmq.auth.username }}
+    password: {{ .Values.rabbitmq.auth.password }}
 
 {{ if .Values.postgres.enabled }}
 You can also connect to the deployed postgres server with your favorite SQL client

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -54,8 +54,8 @@ data:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SECRET_KEY = 'some-secret-string'
     JWT_SECRET_KEY = 'jwt-secret-string'
-    RABBIT_MQ_URL= 'amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F'
-    TRANSFORMER_RABBIT_MQ_URL= 'amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F?heartbeat=9000'
+    RABBIT_MQ_URL= 'amqp://user:{{ .Values.rabbitmq.auth.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F'
+    TRANSFORMER_RABBIT_MQ_URL= 'amqp://user:{{ .Values.rabbitmq.auth.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F?heartbeat=9000'
 
     # Keep retrying to connect to Rabbit if its not yet up
     RABBIT_RETRIES = {{ .Values.app.rabbitmq.retries }}

--- a/servicex/templates/did-finder/deployment.yaml
+++ b/servicex/templates/did-finder/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       - name: {{ .Release.Name }}-did-finder
         image: {{ .Values.didFinder.image }}:{{ .Values.didFinder.tag }}
         command: ["bash","-c"]
-        args: ["/usr/src/app/proxy-exporter.sh & sleep 5 && env PYTHONPATH=./src python scripts/did_finder.py --rabbit-uri amqp://user:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F {{ if .Values.didFinder.site }} --site {{ .Values.didFinder.site }} {{ end }} --threads {{ .Values.didFinder.threads }}"]
+        args: ["/usr/src/app/proxy-exporter.sh & sleep 5 && env PYTHONPATH=./src python scripts/did_finder.py --rabbit-uri amqp://user:{{ .Values.rabbitmq.auth.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F {{ if .Values.didFinder.site }} --site {{ .Values.didFinder.site }} {{ end }} --threads {{ .Values.didFinder.threads }}"]
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.didFinder.pullPolicy }}

--- a/servicex/templates/preflight/deployment.yaml
+++ b/servicex/templates/preflight/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         env:
           - name: "BASH_ENV"
             value: "/servicex/.bashrc"
-        args: ["/servicex/proxy-exporter.sh & sleep 5 && python /servicex/validate_requests.py --rabbit-uri amqp://user:{{.Values.rabbitmq.rabbitmq.password}}@{{ .Release.Name }}-rabbitmq:5672/%2F"]
+        args: ["/servicex/proxy-exporter.sh & sleep 5 && python /servicex/validate_requests.py --rabbit-uri amqp://user:{{.Values.rabbitmq.auth.password}}@{{ .Release.Name }}-rabbitmq:5672/%2F"]
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.preflight.pullPolicy }}

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -114,7 +114,7 @@ rabbitmq:
   # For easy testing we don't require PVs for rabbit
   persistence:
     enabled: false
-  rabbitmq:
+  auth:
     password: leftfoot1
   # This is needed for Windows users
   volumePermissions:


### PR DESCRIPTION
The stable rabbitMQ chart has been deprecated in favor of the Bitnami chart. The new chart moves the username and password from the `rabbitmq` collection in `values.yaml` to the more meaningful `auth` collection.

This PR updates the templates to use that