### PR TITLE
Make ingress class annotation value configurable

### DIFF
--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -7,7 +7,8 @@ For a guide to making a simple deployment of ServiceX with no extra features,
 check out our [basic deployment guide](basic.md).
 
 ## Prerequisites
-- A Kubernetes cluster running K8s version 1.16 or later. 
+- A Kubernetes cluster running K8s version 1.16 or later 
+with an ingress controller such as NGINX.
 - [Helm 3](https://helm.sh/docs/intro/install/) installed.
 - You've used the ServiceX CLI to install your grid certificates on 
 your cluster (if not, see the basic guide).
@@ -27,6 +28,7 @@ following section to your values file:
 app:
     ingress:
         enabled: true
+        class: <ingress class>
         host: <domain name for your deployment>
 ```
 
@@ -52,6 +54,10 @@ then the instance's URL would be `my-release.servicex.ssl-hep.org`.
 You should also make sure the host has a DNS A record pointing this 
 subdomain at the external IP address of your ingress controller.
 
+The `app.ingress.class` value is used to set the `kubernetes.io/ingress.class` 
+annotation on the Ingress resource. It defaults to `nginx`, but you can set a 
+different value, such as `traefik`.
+
 ### Adding an Ingress to Minio
 ServiceX stores files in a Minio object store which is deployed as a 
 subchart. The Helm chart for Minio has it's own support for an Ingress,
@@ -61,6 +67,8 @@ which we can activate like so:
 minio:
   ingress:
     enabled: true
+    annotations:
+      kubernetes.io/ingress.class: <ingress class>
     hosts:
     - my-release-minio.servicex.ssl-hep.org
 ```
@@ -154,7 +162,7 @@ minio:
   ingress:
     enabled: true
     annotations:
-      kubernetes.io/ingress.class: nginx
+      kubernetes.io/ingress.class: <ingress class>
     hosts:
     - my-release-minio.servicex.ssl-hep.org
     tls:
@@ -195,7 +203,7 @@ minio:
   ingress:
     enabled: true
     annotations:
-      kubernetes.io/ingress.class: nginx
+      kubernetes.io/ingress.class: <ingress class>
       cert-manager.io/cluster-issuer: letsencrypt-prod
       acme.cert-manager.io/http01-edit-in-place: "true"
     hosts:
@@ -316,6 +324,7 @@ rabbitmq:
        cpu: 100m
   replicas: 3
 ```
+<<<<<<< HEAD
 
 ## Autoscaling
 ServiceX should automatically scale up/down number of transformers. For this to work it uses Horizontal Pod Autoscaler (HPA). For the HPA to work, k8s cluster needs to be able to measure CPU utilization of the pods. This is easiest enabled by installing [metric-server](https://github.com/kubernetes-sigs/metrics-server). The latest one is easily installed and supports up to 100 nodes by default:
@@ -331,3 +340,5 @@ servicex-did-finder-56dfdbb85-pfrn7      1m           28Mi
 ```
 
 
+=======
+>>>>>>> Make ingress class annotation value configurable

--- a/docs/deployment/reference.md
+++ b/docs/deployment/reference.md
@@ -19,6 +19,7 @@ parameters for the [rabbitMQ](https://github.com/bitnami/charts/tree/master/bitn
 | `app.tokenExpires`                   | Seconds until the ServiceX API tokens (JWT refresh tokens) expire | False (never)                          |
 | `app.authExpires`                    | Seconds until the JWT access tokens expire       | 21600 (six hours)                                       |
 | `app.ingress.enabled`                | Enable install of ingress                        | false                                                   |
+| `app.ingress.class`                  | Class to be set in `kubernetes.io/ingress.class` annotation | nginx                                        |
 | `app.ingress.host`                   | Hostname to associate ingress with               | servicex.ssl-hep.org                                    |
 | `app.ingress.defaultBackend`         | Name of a service to send requests to internal endpoints to | default-http-backend                         |
 | `app.ingress.tls.enabled`            | Enable TLS for ServiceX API Ingress resource     | false                                                   |

--- a/servicex/Chart.yaml
+++ b/servicex/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Install ServiceX deployment - HEP Columnar Data Delivery Service
 name: servicex
-version: 1.0.2
+version: 1.0.3
 appVersion: develop

--- a/servicex/templates/app/ingress.yaml
+++ b/servicex/templates/app/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: {{ .Values.app.ingress.class }}
     {{- if .Values.app.ingress.tls.clusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.app.ingress.tls.clusterIssuer }}
     acme.cert-manager.io/http01-edit-in-place: "true"

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -43,6 +43,7 @@ app:
 
   ingress:
     enabled: false
+    class: nginx
     host: servicex.ssl-hep.org
     defaultBackend: default-http-backend
     tls:


### PR DESCRIPTION
Closes #232.

Note: this change still uses the [deprecated annotation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) to set the ingress class. The new `ingressClassName` field is not used at all. I was going to set both; however, it appears that this will [throw an error](https://github.com/kubernetes/kubernetes/blob/ededd08ba131b727e60f663bd7217fffaaccd448/pkg/apis/networking/validation/validation.go#L226). Kubernetes will not allow you to create a Ingress resource which specifies both the `kubernetes.io/ingress.class` annotation and `ingressClassName` field, so we will stick with the old way of doing things until something breaks.