### PR TITLE
Remove unused servicex ingress to minio

### DIFF
--- a/servicex/templates/app/ingress.yaml
+++ b/servicex/templates/app/ingress.yaml
@@ -22,12 +22,6 @@ spec:
   - host: {{ .Release.Name }}.{{ .Values.app.ingress.host }}
     http:
       paths:
-      {{- if .Values.objectStore.enabled }}
-      - path: /minio
-        backend:
-          serviceName: {{ .Release.Name }}-minio
-          servicePort: 9000
-      {{- end }}
       - path: /servicex/internal
         backend:
           serviceName: {{ .Values.app.ingress.defaultBackend }}


### PR DESCRIPTION
# Problem
As pointed out by @ivukotic in ServiceX Issue #230 there is an unused ingress path to Minio from the serviceX ingress. This is not needed since we enable access to this service via the Minio helm chart.

# Approach 
Deleted the ingress path