### PR TITLE
Split app version from chart version

### DIFF
--- a/servicex/Chart.yaml
+++ b/servicex/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
 description: Install ServiceX deployment - HEP Columnar Data Delivery Service
 name: servicex
-version: develop
+version: 1.0.1
+appVersion: develop

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -17,7 +17,7 @@ data:
 
     # Base url of documentation - autopopulated from chart version
     # Must be activated at https://readthedocs.org/projects/servicex/versions/
-    DOCS_BASE_URL = 'https://servicex.readthedocs.io/en/{{- ternary "latest" (printf "v%s" .Chart.Version) (eq .Chart.Version "develop") }}'
+    DOCS_BASE_URL = 'https://servicex.readthedocs.io/en/{{- ternary "latest" (printf "v%s" .Chart.AppVersion) (eq .Chart.AppVersion "develop") }}'
 
     # Enable JWT auth on public endpoints
     ENABLE_AUTH={{- ternary "True" "False" .Values.app.auth }}


### PR DESCRIPTION
# Problem
It doesn't make sense for the chart version to be tied to the microservice versions. It makes it hard to push new updates to the repo.

# Approach
Make `Chart.Version` be it's own semantic version stream, and tie `Chart.AppVersion` to the micro services

Solution to #242 