### PR TITLE
Use fixed version of x509 secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unrelased]
+### Added
+### Changed
+### Fixed
+- Bug in X509 secrets where it would error out when secret exists
+### Removed
+
 ## [1.0.0-RC.3] - 2020-10-8
 ### Added
 - Globus Auth for new authentication system

--- a/servicex/Chart.yaml
+++ b/servicex/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Install ServiceX deployment - HEP Columnar Data Delivery Service
 name: servicex
-version: 1.0.1
+version: 1.0.2
 appVersion: develop

--- a/servicex/templates/x509-secrets/deployment.yaml
+++ b/servicex/templates/x509-secrets/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - name: {{ .Release.Name }}-x509-secrets
         image: {{ .Values.x509Secrets.image }}:{{ .Values.x509Secrets.tag }}
         command: ["bash","-c"]
-        args: ["python x509_updater.py --secret {{ .Release.Name }}-x509-proxy --voms {{ .Values.x509Secrets.vomsOrg }}"]
+        args: ["python3 x509_updater.py --secret {{ .Release.Name }}-x509-proxy --voms {{ .Values.x509Secrets.vomsOrg }}"]
         env:
           - name: MY_POD_NAME
             valueFrom:


### PR DESCRIPTION
# Problem
The new x509 secrets service requires the service to be run with `python3` instead of the default `python`.

Partial solution to [X509 Issue 10](https://github.com/ssl-hep/X509_Secrets/issues/10)

# Approach
Change the command in the x509 deployment template