### PR TITLE
Update Ingress ClusterIssuers for River

### DIFF
--- a/river-uproot-atlas.yaml
+++ b/river-uproot-atlas.yaml
@@ -16,7 +16,7 @@ app:
 
   ingress:
     enabled: true
-    clusterIssuer: letsencrypt-prod
+    clusterIssuer: letsencrypt-prod-nginx
 
 codeGen:
   image: sslhep/servicex_code_gen_func_adl_uproot
@@ -33,6 +33,10 @@ gridAccount: changeme
 minio:
   ingress:
     enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      cert-manager.io/cluster-issuer: letsencrypt-prod-nginx
+      acme.cert-manager.io/http01-edit-in-place: "true"
     hosts:
     - "uproot-minio.servicex.ssl-hep.org"
   persistence:

--- a/river-uproot-cms-values.yaml
+++ b/river-uproot-cms-values.yaml
@@ -16,7 +16,7 @@ app:
 
   ingress:
     enabled: true
-    clusterIssuer: letsencrypt-prod
+    clusterIssuer: letsencrypt-prod-nginx
 
 codeGen:
   image: sslhep/servicex_code_gen_func_adl_uproot
@@ -36,6 +36,10 @@ gridAccount: changeme
 minio:
   ingress:
     enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      cert-manager.io/cluster-issuer: letsencrypt-prod-nginx
+      acme.cert-manager.io/http01-edit-in-place: "true"
     hosts:
     - "uproot-minio.servicex.ssl-hep.org"
   persistence:

--- a/river-xaod-values.yaml
+++ b/river-xaod-values.yaml
@@ -16,7 +16,7 @@ app:
 
   ingress:
     enabled: true
-    clusterIssuer: letsencrypt-prod
+    clusterIssuer: letsencrypt-prod-nginx
 codeGen:
   image: sslhep/servicex_code_gen_func_adl_xaod
 
@@ -35,7 +35,7 @@ minio:
     enabled: true
     annotations:
       kubernetes.io/ingress.class: nginx
-      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/cluster-issuer: letsencrypt-prod-nginx
       acme.cert-manager.io/http01-edit-in-place: "true"
     hosts:
     - "xaod-minio.servicex.ssl-hep.org"


### PR DESCRIPTION
Per Lincoln, regarding the River cluster:

> There are 2 sets of cluster issuers and ingress classes.
one is ingress.class: slate which is associated with letsencrypt-prod
and one is ingress.class: nginx which is associated with letsencrypt-prod-nginx

This PR updates our production values for the River deployments to use the `letsencrypt-prod-nginx` ClusterIssuer.