### PR TITLE
update to helm dependences

### DIFF
--- a/servicex/requirements.lock
+++ b/servicex/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami/
-  version: 7.6.8
+  version: 7.6.*
 - name: minio
   repository: https://helm.min.io/
   version: '>=5.0.32'
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami/
-  version: 8.3.4
-digest: sha256:7b19032f8bac923b0cdaaeb13ebc9c80e047dc79f39acc939d72dfa464828ff1
-generated: "2021-01-14T15:01:46.2717256-06:00"
+  version: 8.3.*
+digest: sha256:1760cc553d96a0c237dccab3583e8a413111bed2989052417ec53e8456da42ff
+generated: "2021-01-14T15:46:39.7763619-06:00"

--- a/servicex/requirements.lock
+++ b/servicex/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
-  - name: rabbitmq
-    repository: https://charts.bitnami.com/bitnami/
-    version: 7.6.8
-  - name: minio
-    repository: https://kubernetes-charts.storage.googleapis.com/
-    version: 5.0.33
-  - name: postgresql
-    repository: https://kubernetes-charts.storage.googleapis.com/
-    version: 8.3.4
-digest: sha256:b706d44b74c23a4cebd95ef24fcd759183bd6fa92d0c009ca8afa25d27d70511
-generated: "2020-10-08T10:02:00.687411-05:00"
+- name: rabbitmq
+  repository: https://charts.bitnami.com/bitnami/
+  version: 7.6.8
+- name: minio
+  repository: https://helm.min.io/
+  version: '>=5.0.32'
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami/
+  version: 8.3.4
+digest: sha256:7b19032f8bac923b0cdaaeb13ebc9c80e047dc79f39acc939d72dfa464828ff1
+generated: "2021-01-14T15:01:46.2717256-06:00"

--- a/servicex/requirements.yaml
+++ b/servicex/requirements.yaml
@@ -1,12 +1,12 @@
 dependencies:
   - name: rabbitmq
-    version: 7.6.*
+    version: 7.6.8
     repository: https://charts.bitnami.com/bitnami/
   - name: minio
-    version: 5.0.*
+    version: ">=5.0.32"
     repository: https://helm.min.io/
     condition: objectStore.enabled
   - name: postgresql
-    version: 8.3.*
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 8.3.4
+    repository: https://charts.bitnami.com/bitnami/
     condition: postgres.enabled

--- a/servicex/requirements.yaml
+++ b/servicex/requirements.yaml
@@ -1,12 +1,12 @@
 dependencies:
   - name: rabbitmq
-    version: 7.6.8
+    version: 7.6.*
     repository: https://charts.bitnami.com/bitnami/
   - name: minio
     version: ">=5.0.32"
     repository: https://helm.min.io/
     condition: objectStore.enabled
   - name: postgresql
-    version: 8.3.4
+    version: 8.3.*
     repository: https://charts.bitnami.com/bitnami/
     condition: postgres.enabled


### PR DESCRIPTION
This PR addresses the [deprecation](https://helm.sh/blog/charts-repo-deprecation/) of the https://github.com/helm/charts repo (aka "stable") by Google. PostgreSQL has migrated to https://github.com/bitnami/charts/ (as RabbitMQ did), so our requirement needs to point there instead. 
This PR is cleans up #245  to remove the unrelated commit that goes with a change to the DID finder 

@AndrewEckart wrote:
Minio has migrated to its own chart repo, https://github.com/minio/charts, which has only 5.0.32 (they never published 5.0.33 to this repo but they have published new several major chart versions and are up to 8.x.x, which is a separate issue - see #247). Requiring `>=5.0.32` should avoid any breaking changes while also preventing the chart bug fixed in 5.0.16 (see #215).

LGTM. Thanks Ilija! 
