### PR TITLE
Add chart values for autoscaler min and max replicas

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -208,10 +208,12 @@ or [mino](https://github.com/helm/charts/tree/master/stable/minio#configuration)
 | `minio.accessKey`                    | Secret key to log into minio                     | leftfoot1 |
 | `minio.ingress.enabled`              | Should minio chart deploy an ingress to the service? | false |
 | `minio.ingress.hosts`                | List of hosts to associate with ingress controller | nil |
-| `transformer.autoscalerEnabled`      | Set to True to enable the pod horizontal autoscaler for transformers |  True        |
+| `transformer.autoscaler.enabled`     | Enable/disable horizontal pod autoscaler for transformers |  True |
+| `transformer.autoscaler.cpuScaleThreshold` | CPU percentage threshold for pod scaling   | 30 |
+| `transformer.autoscaler.minReplicas` | Minimum number of transformer pods per request   | 1 |
+| `transformer.autoscaler.maxReplicas` | Maximum number of transformer pods per request   | 20 |
 | `transformer.pullPolicy`             | Pull policy for transformer pods (Image name specified in REST Request) | Always |
 | `transformer.cpuLimit`               | Set CPU resource limit for pod in number of cores | 1 |
-| `transformer.cpuScaleThreshold`      | Set CPU percentage threshold for pod scaling | 30 |
 | `transformer.defaultTransformerImage` | Default image for the transformers - must match the codeGen | 'sslhep/servicex_func_adl_xaod_transformer:1.0.0-RC.3' | 
 | `elasticsearchLogging.enabled`       | Set to True to enable writing of reports to an external ElasticSearch system | False |
 | `elasticsearchLogging.host`          | Hostname for external ElasticSearch server | |

--- a/docs/deployment/reference.md
+++ b/docs/deployment/reference.md
@@ -60,10 +60,12 @@ parameters for the [rabbitMQ](https://github.com/bitnami/charts/tree/master/bitn
 | `minio.accessKey`                    | Secret key to log into minio                     | leftfoot1 |
 | `minio.ingress.enabled`              | Should minio chart deploy an ingress to the service? | false |
 | `minio.ingress.hosts`                | List of hosts to associate with ingress controller | nil |
-| `transformer.autoscalerEnabled`      | Set to True to enable the pod horizontal autoscaler for transformers |  True          |
+| `transformer.autoscaler.enabled`     | Enable/disable horizontal pod autoscaler for transformers |  True |
+| `transformer.autoscaler.cpuScaleThreshold` | CPU percentage threshold for pod scaling   | 30 |
+| `transformer.autoscaler.minReplicas` | Minimum number of transformer pods per request   | 1 |
+| `transformer.autoscaler.maxReplicas` | Maximum number of transformer pods per request   | 20 |
 | `transformer.pullPolicy`             | Pull policy for transformer pods (Image name specified in REST Request) | Always |
 | `transformer.cpuLimit`               | Set CPU resource limit for pod in number of cores | 1 |
-| `transformer.cpuScaleThreshold`      | Set CPU percentage threshold for pod scaling | 30 |
 | `transformer.defaultTransformerImage` | Default image for the transformers - must match the codeGen | 'sslhep/servicex_func_adl_xaod_transformer:1.0.0-RC.3' | 
 | `elasticsearchLogging.enabled`       | Set to True to enable writing of reports to an external ElasticSearch system | False |
 | `elasticsearchLogging.host`          | Hostname for external ElasticSearch server | |

--- a/river-uproot-atlas.yaml
+++ b/river-uproot-atlas.yaml
@@ -77,7 +77,8 @@ rabbitmq:
       enabled: true
       storageClass: rook-ceph-block
 transformer:
-  autoscalerEnabled: false
+  autoscaler:
+    enabled: false
   pullPolicy: Always
   defaultTransformerImage: sslhep/servicex_func_adl_uproot_transformer:v1.0.0-rc.3
 

--- a/river-xaod-values.yaml
+++ b/river-xaod-values.yaml
@@ -79,6 +79,7 @@ rabbitmq:
       enabled: true
       storageClass: rook-ceph-block
 transformer:
-  autoscalerEnabled: false
+  autoscaler:
+    enabled: false
   pullPolicy: Always
   defaultTransformerImage: sslhep/servicex_func_adl_xaod_transformer:v1.0.0-rc.3

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -74,9 +74,11 @@ data:
 
     TRANSFORMER_MANAGER_ENABLED = True
 
-    TRANSFORMER_AUTOSCALE_ENABLED = {{- ternary "True" "False" .Values.transformer.autoscalerEnabled }}
+    TRANSFORMER_AUTOSCALE_ENABLED = {{- ternary "True" "False" .Values.transformer.autoscaler.enabled }}
     TRANSFORMER_CPU_LIMIT = {{ .Values.transformer.cpuLimit }}
-    TRANSFORMER_CPU_SCALE_THRESHOLD = {{ .Values.transformer.cpuScaleThreshold }}
+    TRANSFORMER_CPU_SCALE_THRESHOLD = {{ .Values.transformer.autoscaler.cpuScaleThreshold }}
+    TRANSFORMER_MIN_REPLICAS = {{ .Values.transformer.autoscaler.minReplicas }}
+    TRANSFORMER_MAX_REPLICAS = {{ .Values.transformer.autoscaler.maxReplicas }}
     TRANSFORMER_MANAGER_MODE = 'internal-kubernetes'
     TRANSFORMER_X509_SECRET="{{ .Release.Name }}-x509-proxy"
     TRANSFORMER_VALIDATE_DOCKER_IMAGE = {{- ternary "True" "False" .Values.app.validateTransformerImage }}

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -91,10 +91,13 @@ codeGen:
 # Pull policy for the worker pods - the image and version are specified as
 # part of the transform request
 transformer:
-  autoscalerEnabled: true
+  autoscaler: 
+    enabled: true
+    cpuScaleThreshold: 30
+    minReplicas: 1
+    maxReplicas: 20
   pullPolicy: Always
   cpuLimit: 1
-  cpuScaleThreshold: 30
   defaultTransformerImage: sslhep/servicex_func_adl_xaod_transformer:develop
   # For uproot deployment
   #  defaultTransformerImage: sslhep/servicex_func_adl_uproot_transformer:develop


### PR DESCRIPTION
This PR contains the following chart changes to support autoscaling:
- New: `transformer.autoscaler.minReplicas`
- New: `transformer.autoscaler.maxReplicas`
- Renamed: ~~`transformer.autoscalerEnabled`~~ -> `transformer.autoscaler.enabled`
- Renamed: ~~`transformer.cpuScaleThreshold`~~ -> `transformer.autoscaler.cpuScaleThreshold`
All autoscaling configuration is now nested under `transformer.autoscaler` for consistency.

Companion to ssl-hep/ServiceX_App#77.