### PR TITLE
273 did finders

### DIFF
--- a/docs/deployment/basic.md
+++ b/docs/deployment/basic.md
@@ -1,6 +1,6 @@
 # How to deploy ServiceX
 ServiceX is deployed using a Helm chart. The full list of configuration 
-options can be found in the [refence section](reference.md).
+options can be found in the [reference section](reference.md).
 
 This guide is aimed at those interested in learning how to deploy ServiceX 
 with minimal configuration. For more advanced topics, such as making a 

--- a/docs/deployment/basic.md
+++ b/docs/deployment/basic.md
@@ -1,4 +1,6 @@
 # How to deploy ServiceX
+ServiceX is deployed using a Helm chart. The full list of configuration 
+options can be found in the [refence section](reference.md).
 
 This guide is aimed at those interested in learning how to deploy ServiceX 
 with minimal configuration. For more advanced topics, such as making a 

--- a/docs/deployment/reference.md
+++ b/docs/deployment/reference.md
@@ -31,7 +31,7 @@ parameters for the [rabbitMQ](https://github.com/bitnami/charts/tree/master/bitn
 | `app.mailgunApiKey`                  | API key to send Mailgun emails to newly approved users | -
 | `app.mailgunDomain`                  | Sender domain for emails (should be verified through Mailgun) | -
 | `app.defaultDIDFinderScheme`         | DID Finder scheme if none provided in request    | `rucio`                                                 |
-| `app.allowedDIDSchemes`              | List of valid DID finder schemes to accept       | `rucio`                                                 |
+| `app.allowedDIDSchemes`              | List of valid DID finder schemes to accept       | [`rucio`]                                                 |
 | `app.validateTransformerImage`       | Should docker image name be validated at DockerHub? | `true`                                               | 
 | `didFinder.image`                    | DID Finder image name                            | `sslhep/servicex-did-finder`                            |
 | `didFinder.tag`                      | DID Finder image tag                             | `latest`                                                |

--- a/docs/deployment/reference.md
+++ b/docs/deployment/reference.md
@@ -30,7 +30,7 @@ parameters for the [rabbitMQ](https://github.com/bitnami/charts/tree/master/bitn
 | `app.newSignupWebhook`               | Slack webhook URL for new signups                | -
 | `app.mailgunApiKey`                  | API key to send Mailgun emails to newly approved users | -
 | `app.mailgunDomain`                  | Sender domain for emails (should be verified through Mailgun) | -
-| `app.defaultDIDFinderSchema`         | DID Finder schema if none provided in request    | `rucio`                                                 |
+| `app.defaultDIDFinderScheme`         | DID Finder scheme if none provided in request    | `rucio`                                                 |
 | `app.validateTransformerImage`       | Should docker image name be validated at DockerHub? | `true`                                               | 
 | `didFinder.image`                    | DID Finder image name                            | `sslhep/servicex-did-finder`                            |
 | `didFinder.tag`                      | DID Finder image tag                             | `latest`                                                |

--- a/docs/deployment/reference.md
+++ b/docs/deployment/reference.md
@@ -30,6 +30,7 @@ parameters for the [rabbitMQ](https://github.com/bitnami/charts/tree/master/bitn
 | `app.newSignupWebhook`               | Slack webhook URL for new signups                | -
 | `app.mailgunApiKey`                  | API key to send Mailgun emails to newly approved users | -
 | `app.mailgunDomain`                  | Sender domain for emails (should be verified through Mailgun) | -
+| `app.defaultDIDFinderSchema`         | DID Finder schema if none provided in request    | `rucio`                                                 |
 | `app.validateTransformerImage`       | Should docker image name be validated at DockerHub? | `true`                                               | 
 | `didFinder.image`                    | DID Finder image name                            | `sslhep/servicex-did-finder`                            |
 | `didFinder.tag`                      | DID Finder image tag                             | `latest`                                                |

--- a/docs/deployment/reference.md
+++ b/docs/deployment/reference.md
@@ -31,6 +31,7 @@ parameters for the [rabbitMQ](https://github.com/bitnami/charts/tree/master/bitn
 | `app.mailgunApiKey`                  | API key to send Mailgun emails to newly approved users | -
 | `app.mailgunDomain`                  | Sender domain for emails (should be verified through Mailgun) | -
 | `app.defaultDIDFinderScheme`         | DID Finder scheme if none provided in request    | `rucio`                                                 |
+| `app.allowedDIDSchemes`              | List of valid DID finder schemes to accept       | `rucio`                                                 |
 | `app.validateTransformerImage`       | Should docker image name be validated at DockerHub? | `true`                                               | 
 | `didFinder.image`                    | DID Finder image name                            | `sslhep/servicex-did-finder`                            |
 | `didFinder.tag`                      | DID Finder image tag                             | `latest`                                                |

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -115,3 +115,5 @@ data:
     {{ end }}
 
     DID_FINDER_DEFAULT_SCHEME = '{{ .Values.app.defaultDIDFinderScheme }}'
+    VALID_DID_SCHEMES = [ "{{ join "\",\"" .Values.app.allowedDIDSchemes }}" ]
+

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -113,3 +113,5 @@ data:
     CODE_GEN_SERVICE_URL = 'http://{{ .Release.Name }}-code-gen:8000'
     CODE_GEN_IMAGE = '{{ .Values.codeGen.image }}:{{ .Values.codeGen.tag }}'
     {{ end }}
+
+    DID_FINDER_DEFAULT_SCHEME = '{{ .Values.app.defaultDIDFinderSchema }}'

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -114,4 +114,4 @@ data:
     CODE_GEN_IMAGE = '{{ .Values.codeGen.image }}:{{ .Values.codeGen.tag }}'
     {{ end }}
 
-    DID_FINDER_DEFAULT_SCHEME = '{{ .Values.app.defaultDIDFinderSchema }}'
+    DID_FINDER_DEFAULT_SCHEME = '{{ .Values.app.defaultDIDFinderScheme }}'

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -41,6 +41,10 @@ app:
   mailgunApiKey:
   mailgunDomain:
 
+  # If user provides DID that lacks a schema, route the requests to this
+  # particular DID Finder
+  defaultDIDFinderSchema: rucio
+
   ingress:
     enabled: false
     class: nginx
@@ -57,7 +61,7 @@ app:
     retries: 12
     retry_interval: 10 # seconds
 
-# Settings for the DID Finder
+# Settings for the Rucio DID Finder
 didFinder:
   image: sslhep/servicex-did-finder
   tag: develop

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -44,6 +44,8 @@ app:
   # If user provides DID that lacks a schema, route the requests to this
   # particular DID Finder
   defaultDIDFinderScheme: rucio
+  allowedDIDSchemes:
+    - rucio
 
   ingress:
     enabled: false

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -43,7 +43,7 @@ app:
 
   # If user provides DID that lacks a schema, route the requests to this
   # particular DID Finder
-  defaultDIDFinderSchema: rucio
+  defaultDIDFinderScheme: rucio
 
   ingress:
     enabled: false


### PR DESCRIPTION
# Problem
The service only allows for a single DID finder implementation.

This is partial solution to #273 

Related PRs:
* [DID Finder](https://github.com/ssl-hep/ServiceX-DID-finder/pull/27)
* [App](https://github.com/ssl-hep/ServiceX_App/pull/88)

# Approach
In this PR we added a new setting in `values.yaml` - `app.defaultDIDFinderSchema`. It is set to `rucio` which allows the service to function exactly as before.
