### PR TITLE
Add init container to app to wait for DB to be available before starting

### DIFF
--- a/servicex/Chart.yaml
+++ b/servicex/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Install ServiceX deployment - HEP Columnar Data Delivery Service
 name: servicex
-version: 1.0.6
+version: 1.0.7
 appVersion: develop

--- a/servicex/templates/app/deployment.yaml
+++ b/servicex/templates/app/deployment.yaml
@@ -14,6 +14,14 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     spec:
       serviceAccountName: {{ template "servicex.fullname" . }}
+      {{- if .Values.postgres.enabled }}
+      initContainers:
+        - name: check-postgresql
+          image: "ncsa/checks:latest"
+          env:
+            - name: PG_URI
+              value: 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-servicex-app
         image: {{ .Values.app.image }}:{{ .Values.app.tag }}


### PR DESCRIPTION
# Problem
The Postgres deployment can take some time to come up on a new deployment. The app can start up before that and fail the migrations due to lack of access to db.

Fixes [ServiceX_App issue 110](https://github.com/ssl-hep/ServiceX_App/issues/110)

# Approach
Use the [NCSA Check](https://github.com/ncsa/checks) image as an init container. It will wait for the DB to respond before allowing the startup to continue