### PR TITLE
Mount secrets into App using env vars

### DIFF
--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -327,6 +327,28 @@ rabbitmq:
        cpu: 100m
   replicas: 3
 ```
+## Using SealedSecrets to Keep All Config In GitHub
+We use Bitnami's Sealed Secrets Controller to allow us to check all of the
+config into GitHub. 
+
+Install sealed secrets helm chart
+```bash
+ helm repo add sealed-secrets https://bitnami-labs.github.io/sealed-secrets       
+ helm install sealed-secrets --namespace kube-system sealed-secrets/sealed-secrets
+```
+
+You will need the `kubeseal` command on your computer. Follow instructions for
+[the various options](https://github.com/bitnami-labs/sealed-secrets#homebrew)
+
+Create a secrets file using the [example_secrets.yaml](../../example_secrets.yaml). 
+Encrypt it using kubeseal with 
+```console
+cat deployed_values/dev-secrets.yaml | kubeseal --controller-namespace kube-system --controller-name sealed-secrets --format yaml > deployed_values/dev-sealed-secrets.yaml                  
+```
+
+You can safely check `dev-sealed-secrets.yaml` into GitHub. When you deploy
+that file into the cluster, it will be unsealed and turned into a plaintext secret
+that can be mounted into the App's deployment as env vars.
 
 ## Autoscaling
 ServiceX should automatically scale up/down number of transformers. For this to work it uses Horizontal Pod Autoscaler (HPA). For the HPA to work, k8s cluster needs to be able to measure CPU utilization of the pods. This is easiest enabled by installing [metric-server](https://github.com/kubernetes-sigs/metrics-server). The latest one is easily installed and supports up to 100 nodes by default:

--- a/docs/deployment/reference.md
+++ b/docs/deployment/reference.md
@@ -6,6 +6,7 @@ parameters for the [rabbitMQ](https://github.com/bitnami/charts/tree/master/bitn
 
 | Parameter                            | Description                                      | Default                                                 |
 | ------------------------------------ | ------------------------------------------------ | ------------------------------------------------------- |
+| `secrets`                            | Name of a secret deployed into the cluster. Must follow example_secrets.yaml | -        |
 | `app.image`                          | ServiceX_App image name                          | `sslhep/servicex_app`                                   |
 | `app.tag`                            | ServiceX image tag                               | `latest`                                                |
 | `app.pullPolicy`                     | ServiceX image pull policy                       | `Always`                                          |

--- a/example_secrets.yaml
+++ b/example_secrets.yaml
@@ -1,0 +1,16 @@
+# These are the secrets that are needed if you want to override values
+# in a secure way
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: servicex_secrets
+data:
+  globusClientID: <<client ID>>
+  globusClientSecret: <<secret key>>
+  secretKey: <<secret key for app>>
+  jwtSecretKey: <<jwtSecretKey>>
+  minioAccessKey: <<minioAccessKey>>
+  minioSecretKey: <<minioSecretKey>>
+  slackSigningSecret: <<slackSigningSecret>>
+  mailgunAPIKey: <<mailgunAPIKey>>

--- a/servicex/templates/app/deployment.yaml
+++ b/servicex/templates/app/deployment.yaml
@@ -30,6 +30,48 @@ spec:
           value: "/opt/servicex/app.conf"
         - name: INSTANCE_NAME
           value: {{ .Release.Name }}
+    {{- if .Values.secrets }}
+        - name: GLOBUS_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets }}
+              key: globusClientID
+        - name: GLOBUS_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets }}
+              key: globusClientSecret
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets }}
+              key: secretKey
+        - name: JWT_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets }}
+              key: jwtSecretKey
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets }}
+              key: minioAccessKey
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets }}
+              key: minioSecretKey
+        - name: SLACK_SIGNING_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets }}
+              key: slackSigningSecret
+        - name: MAILGUN_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets }}
+              key: mailgunAPIKey
+    {{- end }}
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.app.pullPolicy }}
@@ -43,6 +85,7 @@ spec:
             mountPath: /opt/servicex
           - name: sqlite
             mountPath: /sqlite
+
         ports:
           - containerPort: 5000
 

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -2,7 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-
+# If this is provided, it must follow the example shown in example_secrets.yaml
+# The chart will mount environment variables from here into the app.
+secrets:
 
 # Enable deployment of Minio Object Store with this chart - use this if you
 # want to have the option of delivering results as parquet files


### PR DESCRIPTION
# Problem
The helm chart doesn't support sealed secrets to secure confidential app parameters.

Partial solution to #286 

# Approach
User provides the name of an unsealed secret in a new value: `secrets` - if this is set, then the environment variables are set in the app pod as part of the deployment spec.

This PR includes a template for what a secret file should look like and instructions on installing and using the `SealedSecrets` operator. 