### PR TITLE
Add value to skip deployment of x509 certs for open data

### DIFF
--- a/docs/deployment/reference.md
+++ b/docs/deployment/reference.md
@@ -57,7 +57,8 @@ parameters for the [rabbitMQ](https://github.com/bitnami/charts/tree/master/bitn
 | `x509Secrets.vomsOrg`                | Which VOMS org to contact for proxy?             | `atlas`                                                 |
 | `rbacEnabled`                        | Specify if rbac is enabled in your cluster	      | `true`
 | `hostMount`                          | Optional path to mount in transformers as /data  | - 
-| `gridAccount`                        | CERN User account name to access Rucio           | - 
+| `gridAccount`                        | CERN User account name to access Rucio           | -
+| `noCerts`                            | Set to true to disable x509 certs and only use open data | false                                            |
 | `rabbitmq.password`                  | Override the generated RabbitMQ password         | leftfoot1 |
 | `objectstore.enabled`                | Deploy a minio object store with Servicex?       | true      |
 | `objectstore.publicURL`              | What URL should the client use to download files? If set, this is given whether ingress is enabled or not  | nil |      |

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -82,7 +82,11 @@ data:
     TRANSFORMER_MIN_REPLICAS = {{ .Values.transformer.autoscaler.minReplicas }}
     TRANSFORMER_MAX_REPLICAS = {{ .Values.transformer.autoscaler.maxReplicas }}
     TRANSFORMER_MANAGER_MODE = 'internal-kubernetes'
+    {{- if not .Values.noCerts }}
     TRANSFORMER_X509_SECRET="{{ .Release.Name }}-x509-proxy"
+    {{- else }}
+    TRANSFORMER_X509_SECRET=None
+    {{- end }}
     TRANSFORMER_VALIDATE_DOCKER_IMAGE = {{- ternary "True" "False" .Values.app.validateTransformerImage }}
 
     TRANSFORMER_MESSAGING = 'none'

--- a/servicex/templates/did-finder-rucio/deployment.yaml
+++ b/servicex/templates/did-finder-rucio/deployment.yaml
@@ -1,5 +1,8 @@
 ---
 {{ if .Values.didFinder.rucio.enabled}}
+  {{- if .Values.noCerts }}
+    {{- fail "Rucio DID Finder requires x509 Certs to be installed" }}
+  {{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/servicex/templates/preflight/deployment.yaml
+++ b/servicex/templates/preflight/deployment.yaml
@@ -22,24 +22,31 @@ spec:
             value: "/servicex/.bashrc"
           - name: INSTANCE_NAME
             value: {{ .Release.Name }}
+        {{- if not .Values.noCerts }}
         args: ["/servicex/proxy-exporter.sh & sleep 5 && python /servicex/validate_requests.py --rabbit-uri amqp://user:{{.Values.rabbitmq.auth.password}}@{{ .Release.Name }}-rabbitmq:5672/%2F"]
+        {{- else }}
+        args: ["python /servicex/validate_requests.py --rabbit-uri amqp://user:{{.Values.rabbitmq.auth.password}}@{{ .Release.Name }}-rabbitmq:5672/%2F"]
+        {{- end }}
         tty: true
         stdin: true
         imagePullPolicy: {{ .Values.preflight.pullPolicy }}
         volumeMounts:
-          - name: x509-secret
+        {{- if not .Values.noCerts }}
+        - name: x509-secret
             mountPath: /etc/grid-security-ro
             readOnly: true
-
+        {{- end }}
           {{ if .Values.hostMount }}
           - name: rootfiles
             mountPath: /data
           {{ end }}
       volumes:
+        {{- if not .Values.noCerts }}
         - name: x509-secret
           secret:
             defaultMode: 292
             secretName: {{ .Release.Name }}-x509-proxy
+        {{- end }}
         {{ if .Values.hostMount }}
         - name: rootfiles
           hostPath:

--- a/servicex/templates/x509-secrets/deployment.yaml
+++ b/servicex/templates/x509-secrets/deployment.yaml
@@ -1,3 +1,5 @@
+{{- if not .Values.noCerts }}
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -64,3 +66,4 @@ spec:
         - name: grid-certs-rw-copy
           emptyDir: {}
 
+{{- end }}

--- a/servicex/templates/x509-secrets/proxy-secret.yaml
+++ b/servicex/templates/x509-secrets/proxy-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.noCerts }}
 # This is just a skeletal secret. The details will be filled in by the X509-Secret
 # service. We are deploying this as part of the helm chart so the X509 proxy secret
 # will also be deleted when the chart is deleted.
@@ -11,3 +12,4 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ .Release.Name }}
 type: Opaque
+{{- end }}

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -152,7 +152,7 @@ minio:
 
 
 ###### Settings for Authenticating with the CERN Infrastructure #######
-
+noCerts: false
 gridAccount: <your account>
 
 rbacEnabled: True


### PR DESCRIPTION
# Problem
Deployments of pure openData serviceX still deployed an unneeded x509 secrets process which could wind up spewing errors

Partial solution to #156 

Depends on [ServiceX App PR 126](https://github.com/ssl-hep/ServiceX_App/pull/126)

# Approach
Added a new value, `noCerts` - the default is false which results in the same deployment as before.

Setting this to True prevents the deployment of the x509-secrets service. It also sets the App's `TRANSFORMER_X509_SECRET` to signal that service not to attempt to mount the secret in the transformer pod.

The preflight service runs a script at start up to stage the certs in the running pod. If noCerts is set, this command is committed.

Finally, the Rucio DID finder won't work without certs, so an error is printed if the chart is installed with noCerts, but rucio did finder enabled.
