### PR TITLE
Slack Webhook Should be Kept Confidential

### DIFF
--- a/example_secrets.yaml
+++ b/example_secrets.yaml
@@ -13,4 +13,5 @@ data:
   minioAccessKey: <<minioAccessKey>>
   minioSecretKey: <<minioSecretKey>>
   slackSigningSecret: <<slackSigningSecret>>
+  slackSignupWebhook: <<slackSignupWebhook>>
   mailgunAPIKey: <<mailgunAPIKey>>

--- a/servicex/Chart.yaml
+++ b/servicex/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Install ServiceX deployment - HEP Columnar Data Delivery Service
 name: servicex
-version: 1.0.10
+version: 1.0.11
 appVersion: develop

--- a/servicex/templates/app/deployment.yaml
+++ b/servicex/templates/app/deployment.yaml
@@ -66,6 +66,11 @@ spec:
             secretKeyRef:
               name: {{ .Values.secrets }}
               key: slackSigningSecret
+        - name: SIGNUP_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets }}
+              key: slackSignupWebhook
         - name: MAILGUN_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
# Problem
We've moved secret values into a sealed secret so the remaining values can be safely checked into GitHub... Turns out Slack Signup Webhook needs to be kept confidential

# Approach
Added this to the list of secrets mounted into the App pod and updated the example secret file