### PR TITLE
Env value expects a quoted string

### DIFF
--- a/servicex/templates/did-finder-rucio/deployment.yaml
+++ b/servicex/templates/did-finder-rucio/deployment.yaml
@@ -36,9 +36,9 @@ spec:
             value: amqp://user:{{ .Values.rabbitmq.auth.password }}@{{ .Release.Name }}-rabbitmq:5672
     {{- end }}
           - name: RUCIO_LATITUDE
-            value: {{ .Values.didFinder.rucio.servicex_latitude }}
+            value: "{{ .Values.didFinder.rucio.servicex_latitude }}"
           - name: RUCIO_LONGITUDE
-            value: {{ .Values.didFinder.rucio.servicex_longitude }}
+            value: "{{ .Values.didFinder.rucio.servicex_longitude }}"
           - name: DID_THREADS
             value: "{{ .Values.didFinder.rucio.threads }}"
           - name: INSTANCE_NAME


### PR DESCRIPTION
Sigh, I should have tested this before merging...

# Problem 
When deploying the rucio did finder you get this error from helm:
```
Error: UPGRADE FAILED: failed to create resource: Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found 4, error found in #10 byte of ...|,"value":41.78},{"na|..., bigger context ...|rabbitmq:5672"},{"name":"RUCIO_LATITUDE","value":41.78},{"name":"RUCIO_LONGITUDE","value":-87.7},{"n|...
```