### PR TITLE
Secret name fix

### DIFF
--- a/example_secrets.yaml
+++ b/example_secrets.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   globusClientID: <<client ID>>
   globusClientSecret: <<secret key>>
-  secretKey: <<secret key for app>>
+  flaskSecretKey: <<secret key for flask webapp>>
   jwtSecretKey: <<jwtSecretKey>>
   slackSigningSecret: <<slackSigningSecret>>
   slackSignupWebhook: <<slackSignupWebhook>>

--- a/servicex/Chart.yaml
+++ b/servicex/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Install ServiceX deployment - HEP Columnar Data Delivery Service
 name: servicex
-version: 1.0.15
+version: 1.0.16
 appVersion: develop

--- a/servicex/Chart.yaml
+++ b/servicex/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Install ServiceX deployment - HEP Columnar Data Delivery Service
 name: servicex
-version: 1.0.16
+version: 1.0.17
 appVersion: develop

--- a/servicex/templates/app/deployment.yaml
+++ b/servicex/templates/app/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ .Values.secrets }}
-              key: secretKey
+              key: flaskSecretKey
         - name: JWT_SECRET_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
This fixes an issue where the chart uses secretkey and secretKey to do too different things.  secretkey is used by the minio chart and secretKey is used by the web app to for flask.  secretKey is changed to use flaskSecretKey in order to disambiguate the two.