### PR TITLE
add priorityClassName config to transfomer deployment

### DIFF
--- a/docs/deployment/reference.md
+++ b/docs/deployment/reference.md
@@ -74,6 +74,7 @@ parameters for the [rabbitMQ](https://github.com/bitnami/charts/tree/master/bitn
 | `transformer.autoscaler.minReplicas` | Minimum number of transformer pods per request   | 1 |
 | `transformer.autoscaler.maxReplicas` | Maximum number of transformer pods per request   | 20 |
 | `transformer.pullPolicy`             | Pull policy for transformer pods (Image name specified in REST Request) | Always |
+| `transformer.priorityClassName`      | priorityClassName for transformer pods (Not setting it means getting global default) | Not Set |
 | `transformer.cpuLimit`               | Set CPU resource limit for pod in number of cores | 1 |
 | `transformer.defaultTransformerImage` | Default image for the transformers - must match the codeGen | 'sslhep/servicex_func_adl_xaod_transformer:1.0.0-RC.3' |
 | `transformer.persistence.existingClaim` | Existing persistent volume claim | nil |

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -72,6 +72,10 @@ data:
 
     TRANSFORMER_NAMESPACE="{{ .Release.Namespace }}"
 
+    {{ if .Values.transformer.priorityClassName }}
+    TRANSFORMER_PRIORITY_CLASS="{{ .Values.transformer.priorityClassName }}"
+    {{ end }}
+
     TRANSFORMER_PULL_POLICY = '{{ .Values.transformer.pullPolicy }}'
 
     TRANSFORMER_MANAGER_ENABLED = True

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -112,6 +112,9 @@ transformer:
     minReplicas: 1
     maxReplicas: 20
   pullPolicy: Always
+  # Add priorityClassName to control priority and preemption of the transformer
+  # pods, Priorityclass needs to be created in the cluster  
+  # priorityClassName: 
   cpuLimit: 1
   defaultTransformerImage: sslhep/servicex_func_adl_xaod_transformer:develop
 

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -112,9 +112,7 @@ transformer:
     minReplicas: 1
     maxReplicas: 20
   pullPolicy: Always
-  # Add priorityClassName to control priority and preemption of the transformer
-  # pods, Priorityclass needs to be created in the cluster  
-  # priorityClassName: 
+  priorityClassName: 
   cpuLimit: 1
   defaultTransformerImage: sslhep/servicex_func_adl_xaod_transformer:develop
 


### PR DESCRIPTION
This is to enable passing priorityClassName to the transformer pods.