### PR TITLE
Add option to tell rucio DID Finder to report logical names

### DIFF
--- a/docs/deployment/reference.md
+++ b/docs/deployment/reference.md
@@ -40,6 +40,7 @@ parameters for the [rabbitMQ](https://github.com/bitnami/charts/tree/master/bitn
 | `didFinder.rucio.servicex_latitude`        | Latitude of the computing center where ServiceX runs. Will be used by Rucio to return the closest input data replica.        | 41.78 |
 | `didFinder.rucio.servicex_longitude`        | Longitude of the computing center where ServiceX runs. Will be used by Rucio to return the closest input data replica.        | -87.7 |
 | `didFinder.rucio.cachePrefix`        | Prefix string to stick in front of file paths. Useful for XCache | |
+| `didFinder.rucio.reportLogicalFiles` | For CMS xCache sites, we don't want the replicas, only logical names. Set to true to get this behavior | false |
 | `didFinder.rucio.rucio_host`         | URL for Rucio service to use                     | `https://voatlasrucio-server-prod.cern.ch:443`          |
 | `didFinder.rucio.auth _host`         | URL to obtain Rucio authentication               | `https://voatlasrucio-auth-prod.cern.ch:443`            |
 | `didFinder.CERNOpenData.enabled`     | Should we deploy the CERN OpenData DID Finder?           | `true`                                              |

--- a/servicex/templates/did-finder-rucio/deployment.yaml
+++ b/servicex/templates/did-finder-rucio/deployment.yaml
@@ -39,6 +39,10 @@ spec:
           - name: CACHE_PREFIX
             value: "{{ .Values.didFinder.rucio.cachePrefix }}"
     {{- end }}
+    {{- if .Values.didFinder.rucio.reportLogicalFiles }}
+          - name: REPORT_LOGICAL_FILES
+            value: "--report-logical-files"
+    {{- end }}
           - name: RUCIO_LATITUDE
             value: "{{ .Values.didFinder.rucio.servicex_latitude }}"
           - name: RUCIO_LONGITUDE

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -75,6 +75,7 @@ didFinder:
     servicex_latitude: 41.78
     servicex_longitude: -87.7
     cachePrefix:
+    reportLogicalFiles: false
 
   CERNOpenData:
     enabled: true


### PR DESCRIPTION
# Problem
The CMS deployment of xCache assumes that the URIs for Root files is the logical name (not a replica URL)

Partial solution to [ServiceX issue 369](https://github.com/ssl-hep/ServiceX/issues/369)

# Approach
Added new value: `didFinder.rucio.reportLogicalFiles` 
 
If this is set to true, it passes an environment var down to the Rucio DID Finder telling it to return the `identity` property instead of the `url`