### PR TITLE
Change api to allow running on kubernetes 1.22

### DIFF
--- a/servicex/requirements.yaml
+++ b/servicex/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami/
   - name: minio
     version: ">=9.0.0"
-    repository: https://helm.min.io/
+    repository: https://charts.bitnami.com/bitnami/
     condition: objectStore.enabled
   - name: postgresql
     version: 8.3.*

--- a/servicex/requirements.yaml
+++ b/servicex/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
     version: 7.6.*
     repository: https://charts.bitnami.com/bitnami/
   - name: minio
-    version: ">=5.0.32"
+    version: ">=9.0.0"
     repository: https://helm.min.io/
     condition: objectStore.enabled
   - name: postgresql

--- a/servicex/templates/app/ingress.yaml
+++ b/servicex/templates/app/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.app.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -23,11 +23,17 @@ spec:
     http:
       paths:
       - path: /servicex/internal
+        pathType: Prefix
         backend:
-          serviceName: {{ .Values.app.ingress.defaultBackend }}
-          servicePort: 80
+          service:
+            name: {{ .Values.app.ingress.defaultBackend }}
+            port: 
+              number: 80
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: {{ .Release.Name }}-servicex-app
-          servicePort: 8000
+          service:
+            name: {{ .Release.Name }}-servicex-app
+            port: 
+              number: 8000
 {{- end }}


### PR DESCRIPTION
We are using the deprecated extensions/v1beta1 for ingress config, that's been dropped as of [k8s 1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#:~:text=The%20extensions%2Fv1beta1%2C%20apps%2F,9.).  Update the api version and make changes to  use the new api.  

The only thing that isn't quite straightforward is the type (i.e. using Prefix vs ImplementationSpecific).  I think Prefix is what we want.