### PR TITLE
Minio https fixes

### DIFF
--- a/servicex/Chart.yaml
+++ b/servicex/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Install ServiceX deployment - HEP Columnar Data Delivery Service
 name: servicex
-version: 1.0.18
+version: 1.0.21
 appVersion: develop

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -115,7 +115,7 @@ data:
     MINIO_URL = '{{ .Values.objectStore.publicURL }}'
     MINIO_URL_TRANSFORMER = '{{ .Values.objectStore.publicURL }}'
     MINIO_PUBLIC_URL = '{{ .Values.objectStore.publicURL }}'
-    MINIO_SECURED = {{ ternary "True" "False" .Values.objectStore.usetls }}
+    MINIO_SECURED = {{ ternary "True" "False" .Values.objectStore.useTLS }}
       {{ else }}
     # using internal minio 
     MINIO_URL = '{{ .Release.Name }}-minio:{{ .Values.minio.service.port }}'
@@ -124,7 +124,7 @@ data:
     {{- $minio_ingress := index .Values.minio.ingress.hosts 0 -}}
     # Using minio ingress
     MINIO_PUBLIC_URL = '{{ .Values.objectStore.publicURL | default $minio_ingress }}'
-    MINIO_SECURED = {{ ternary "True" "False" (not (empty .Values.minio.ingress.tls)) }}
+    MINIO_SECURED = {{ ternary "True" "False" .Values.objectStore.useTLS }}
         {{ else }}
     {{- $internal_minio := printf "%s--minio:%v" .Release.Name .Values.minio.service.port -}}
     # No minio ingress

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -103,6 +103,13 @@ data:
 
     {{ if .Values.objectStore.enabled }}
     OBJECT_STORE_ENABLED = True
+    # default to using a https connection to the client unless explicitly
+    # turned off
+      {{ if .Values.objectStore.useClientTLS  }}
+    MINIO_CLIENT_SECURED = True
+      {{ else }}
+    MINIO_CLIENT_SECURED = False
+      {{ end }}
       {{ if not .Values.objectStore.internal }}
     # using external minio 
     MINIO_URL = '{{ .Values.objectStore.publicURL }}'

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -105,17 +105,17 @@ data:
     OBJECT_STORE_ENABLED = True
     # default to using a https connection to the client unless explicitly
     # turned off
-      {{ if .Values.objectStore.useClientTLS  }}
-    MINIO_CLIENT_SECURED = True
+      {{ if .Values.objectStore.publicClientUseTLS  }}
+    MINIO_ENCRYPT_PUBLIC = True
       {{ else }}
-    MINIO_CLIENT_SECURED = False
+    MINIO_ENCRYPT_PUBLIC = False
       {{ end }}
       {{ if not .Values.objectStore.internal }}
     # using external minio 
     MINIO_URL = '{{ .Values.objectStore.publicURL }}'
     MINIO_URL_TRANSFORMER = '{{ .Values.objectStore.publicURL }}'
     MINIO_PUBLIC_URL = '{{ .Values.objectStore.publicURL }}'
-    MINIO_SECURED = {{ ternary "True" "False" .Values.objectStore.useTLS }}
+    MINIO_ENCRYPT = {{ ternary "True" "False" .Values.objectStore.useTLS }}
       {{ else }}
     # using internal minio 
     MINIO_URL = '{{ .Release.Name }}-minio:{{ .Values.minio.service.port }}'
@@ -124,7 +124,7 @@ data:
     {{- $minio_ingress := index .Values.minio.ingress.hosts 0 -}}
     # Using minio ingress
     MINIO_PUBLIC_URL = '{{ .Values.objectStore.publicURL | default $minio_ingress }}'
-    MINIO_SECURED = {{ ternary "True" "False" .Values.objectStore.useTLS }}
+    MINIO_ENCRYPT = {{ ternary "True" "False" .Values.objectStore.useTLS }}
         {{ else }}
     {{- $internal_minio := printf "%s--minio:%v" .Release.Name .Values.minio.service.port -}}
     # No minio ingress

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -16,6 +16,9 @@ objectStore:
   # turn off https connections to minio, should be off if using internal
   # minio
   useTLS: false
+  # set clients to use a https connection to connect to minio, should be 
+  # set to true unless using a devel setup
+  useClientTLS: true
 
 # Enable deployment of a full postgres sql database. This is advisable for
 # bigger clusters where there will be several workers hitting the database

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -13,6 +13,9 @@ objectStore:
   # Enable deployment of Minio Object Store with this chart
   internal: true
   publicURL:
+  # turn off https connections to minio, should be off if using internal
+  # minio
+  useTLS: false
 
 # Enable deployment of a full postgres sql database. This is advisable for
 # bigger clusters where there will be several workers hitting the database

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -18,7 +18,7 @@ objectStore:
   useTLS: false
   # set clients to use a https connection to connect to minio, should be 
   # set to true unless using a devel setup
-  publicClientuseTLS: true
+  publicClientUseTLS: true
 
 # Enable deployment of a full postgres sql database. This is advisable for
 # bigger clusters where there will be several workers hitting the database

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -18,7 +18,7 @@ objectStore:
   useTLS: false
   # set clients to use a https connection to connect to minio, should be 
   # set to true unless using a devel setup
-  useClientTLS: true
+  publicClientuseTLS: true
 
 # Enable deployment of a full postgres sql database. This is advisable for
 # bigger clusters where there will be several workers hitting the database


### PR DESCRIPTION
Update charts to allow admins to specify using https connections for client connections and simplify logic for server https connections