### PR TITLE
Add server status links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 # ServiceX - Data Delivery for the HEP Community
 
+![Uproot Status](https://github.com/ssl-hep/servicex-backend-tests/actions/workflows/daily_servicex_uproot_test_af.yml/badge.svg) 
+![xAOD Status](https://github.com/ssl-hep/servicex-backend-tests/actions/workflows/daily_servicex_xaod_test_af.yml/badge.svg)
+
 ServiceX is an on-demand service that delivers data straight from the grid to high energy physics analysts in an easy, flexible, and highly performant manner.
 
 ## Features

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -32,6 +32,9 @@ University of Chicago's Analysis Facility cluster:
 | <https://xaod.servicex.af.uchicago.edu/>        | ATLAS         | xaod   | xAOD files   |
 | <https://uproot-atlas.servicex.af.uchicago.edu/>  | ATLAS         | uproot | Flat ntuples |
 
+You can view the status of these production servers along with our current
+development servers by viewing the [Server Status Dashboard](https://dashboard-integration.servicex.ssl-hep.org).
+
 Visit the instance that meets your needs. Click on the _Sign-in_ button in the
 upper right hand corner. You will be asked to authenticate via GlobusAuth and
 complete a registration form. Once this form is submitted, it will be reviewed


### PR DESCRIPTION
# Problem
Users need to know that the production ServiceX instances are up and running

Solves #383 

# Approach
Add links to the GitActionBoard from the README and the _Getting Started_ guide.

