### PR TITLE
tag_and_release script

### DIFF
--- a/tag_and_release.sh
+++ b/tag_and_release.sh
@@ -31,6 +31,14 @@
 #
 if [ "$#" -ne 2 ]; then
     echo "Usage: tag_release.sh serviceX_version chart_version"
+    exit 1
+fi
+
+if [ ! -d "../ssl-helm-charts" ]; then
+  echo "Helm chart repo not available. Creating one now"
+  pushd ..
+  git clone https://github.com/ssl-hep/ssl-helm-charts.git
+  popd
 fi
 
 git checkout develop

--- a/tag_and_release.sh
+++ b/tag_and_release.sh
@@ -29,6 +29,7 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 #
+set -e
 if [ "$#" -ne 2 ]; then
     echo "Usage: tag_release.sh serviceX_version chart_version"
     exit 1


### PR DESCRIPTION
# Problem
There are several steps to create a new helm chart release that has docker images pinned to a tag. We want to do this often.

Solution to issue #385 

# Approach
Create a helm chart release pinned to tagged serviceX docker images. The approach taken is that the chart on the `develop` branch will always point to the released docker images. If you want to test out some of the development images you have to explicitly set this in your personal `values.yaml`.

This script will update `values.yaml` to point to the released tags, push to develop, tag `develop` branch and publish the helm chart. 