### PR TITLE
Add get access on persistentvolumeclaims to ServiceX service account

### DIFF
--- a/servicex/templates/rbac/role.yaml
+++ b/servicex/templates/rbac/role.yaml
@@ -15,6 +15,10 @@ rules:
 - apiGroups: ["autoscaling"]
   resources: ["horizontalpodautoscalers"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list"]
+
 
 
 ---


### PR DESCRIPTION
# Problem
On clusters with real security (as compared to DockerDesktop) - The serviceX app fails when configured for posix volumes for transformer results.
 
Solves #399 

# Approach
Add the list permission on PVCs for the ServiceX service account