### PR TITLE
Update postgres bitnami chart to 11.6.*

### DIFF
--- a/servicex/requirements.lock
+++ b/servicex/requirements.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 11.2.11
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami/
-  version: 8.3.4
-digest: sha256:06c9361299b31de58cc5bde106099cfe7716c99e9a8d3abf5c684fbaee7c6d2e
-generated: "2022-04-18T12:02:07.598205798-05:00"
+  version: 11.6.10
+digest: sha256:2e7d64d841c1efd41ce43f63a430de2d4545d3823ea262871860a7d3ab816b29
+generated: "2022-06-27T16:55:15.599815683-05:00"

--- a/servicex/requirements.yaml
+++ b/servicex/requirements.yaml
@@ -7,6 +7,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami/
     condition: objectStore.internal, objectStore.enabled
   - name: postgresql
-    version: 8.3.*
+    version: 11.6.*
     repository: https://charts.bitnami.com/bitnami/
     condition: postgres.enabled

--- a/servicex/templates/NOTES.txt
+++ b/servicex/templates/NOTES.txt
@@ -39,9 +39,9 @@ You can also connect to the deployed postgres server with your favorite SQL clie
 
 and connect with this JDBC Connection String:
 {{ if .Values.secrets }}
-    postgresql://{{  .Values.postgresql.postgresqlUsername }}:[postgresql-password from {{.Values.secrets}} ]@localhost:5432/{{ .Values.postgresql.postgresqlDatabase }}
+    postgresql://{{  .Values.postgresql.auth.username}}:[postgresql-password from {{.Values.secrets}} ]@localhost:5432/{{ .Values.postgresql.auth.database }}
 {{ else }}
-    postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@localhost:5432/{{ .Values.postgresql.postgresqlDatabase }}
+    postgresql://{{  .Values.postgresql.auth.username}}:{{ .Values.postgresql.auth.password }}@localhost:5432/{{ .Values.postgresql.auth.database }}
 {{ end }}
 {{ end }}
 

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -51,7 +51,7 @@ data:
     MAILGUN_DOMAIN = '{{ .Values.app.mailgunDomain }}'
 
     {{ if .Values.postgres.enabled }}
-    SQLALCHEMY_DATABASE_URI = 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
+    SQLALCHEMY_DATABASE_URI = 'postgresql://{{  .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.auth.database }}'
     {{ else }}
     SQLALCHEMY_DATABASE_URI = 'sqlite:////sqlite/app.db'
     {{ end }}

--- a/servicex/templates/app/deployment.yaml
+++ b/servicex/templates/app/deployment.yaml
@@ -26,10 +26,10 @@ spec:
                   name: {{ .Values.secrets }}
                   key: postgresql-password
             - name: PG_URI
-              value: 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:$(PG_PASS)@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
+              value: 'postgresql://{{ .Values.postgresql.auth.username }}:$(PG_PASS)@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.auth.database }}'
         {{- else }}
             - name: PG_URI
-              value: 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
+              value: 'postgresql://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.auth.database }}'
         {{- end }}
       {{- end }}
       containers:
@@ -106,7 +106,7 @@ spec:
     {{- if .Values.secrets }}
           {{- if .Values.postgres.enabled }}
         - name: SQLALCHEMY_DATABASE_URI
-          value: "postgresql://{{  .Values.postgresql.postgresqlUsername }}:$(PG_PASS)@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}"
+          value: "postgresql://{{ .Values.postgresql.auth.username }}:$(PG_PASS)@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.auth.database }}"
           {{- end }}
     {{- end }}
         tty: true

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -153,8 +153,10 @@ rabbitmq:
 
 # Values for the Postgresql Chart
 postgresql:
-  postgresqlDatabase: servicex
-  postgresqlPassword: leftfoot1
+  auth:
+    username: servicex-db
+    database: servicex
+    password: leftfoot1
   persistence:
     enabled: false
 


### PR DESCRIPTION
This updates the postgres bitnami chart to 11.6.*

The keys for the postgresql password and database have changed in the
values.yaml file:

postgresql.postgresqlDatabase -> postgresql.auth.database
postgresql.postgresqlPassword -> postgresql.auth.password

And an additional value for the database user
(postgresql.auth.username) is provided.