### PR TITLE
Update chart to use latest version of bitnami postgres subchart

### DIFF
--- a/river-uproot-cms-values.yaml
+++ b/river-uproot-cms-values.yaml
@@ -54,9 +54,10 @@ postgresql:
     enabled: false
     serviceMonitor:
       enabled: false
-  persistence:
-    enabled: true
-    storageClass: rook-ceph-block
+  primary:
+    persistence:
+      enabled: true
+      storageClass: rook-ceph-block
 rabbitmq:
   metrics:
     enabled: false

--- a/river-xaod-values.yaml
+++ b/river-xaod-values.yaml
@@ -55,9 +55,11 @@ postgresql:
     enabled: false
     serviceMonitor:
       enabled: false
-  persistence:
-    enabled: true
-    storageClass: rook-ceph-block
+  primary:
+    persistence:
+      enabled: true
+      storageClass: rook-ceph-block
+
 rabbitmq:
   metrics:
     enabled: false

--- a/servicex/requirements.lock
+++ b/servicex/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 8.24.13
 - name: minio
   repository: https://charts.bitnami.com/bitnami/
-  version: 11.2.11
+  version: 11.2.16
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami/
-  version: 8.3.4
-digest: sha256:06c9361299b31de58cc5bde106099cfe7716c99e9a8d3abf5c684fbaee7c6d2e
-generated: "2022-04-18T12:02:07.598205798-05:00"
+  version: 11.6.15
+digest: sha256:33bceb44adfe831598734041ad88f465ed4ba9ba199d253f4118dc6cc6a1c0be
+generated: "2022-07-06T12:33:29.905593-05:00"

--- a/servicex/requirements.yaml
+++ b/servicex/requirements.yaml
@@ -7,6 +7,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami/
     condition: objectStore.internal, objectStore.enabled
   - name: postgresql
-    version: 8.3.*
+    version: 11.6.*
     repository: https://charts.bitnami.com/bitnami/
     condition: postgres.enabled

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -51,7 +51,7 @@ data:
     MAILGUN_DOMAIN = '{{ .Values.app.mailgunDomain }}'
 
     {{ if .Values.postgres.enabled }}
-    SQLALCHEMY_DATABASE_URI = 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
+    SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:{{ .Values.postgresql.global.postgresql.auth.postgresPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.global.postgresql.auth.database }}'
     {{ else }}
     SQLALCHEMY_DATABASE_URI = 'sqlite:////sqlite/app.db'
     {{ end }}

--- a/servicex/templates/app/deployment.yaml
+++ b/servicex/templates/app/deployment.yaml
@@ -26,10 +26,10 @@ spec:
                   name: {{ .Values.secrets }}
                   key: postgresql-password
             - name: PG_URI
-              value: 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:$(PG_PASS)@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
+              value: 'postgresql://postgres:$(PG_PASS)@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.global.postgresql.auth.database }}'
         {{- else }}
             - name: PG_URI
-              value: 'postgresql://{{  .Values.postgresql.postgresqlUsername }}:{{ .Values.postgresql.postgresqlPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}'
+              value: 'postgresql://postgres:{{ .Values.postgresql.global.postgresql.auth.postgresPassword }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.global.postgresql.auth.database }}'
         {{- end }}
       {{- end }}
       containers:
@@ -106,7 +106,7 @@ spec:
     {{- if .Values.secrets }}
           {{- if .Values.postgres.enabled }}
         - name: SQLALCHEMY_DATABASE_URI
-          value: "postgresql://{{  .Values.postgresql.postgresqlUsername }}:$(PG_PASS)@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresqlDatabase }}"
+          value: "postgresql://postgres:$(PG_PASS)@{{ .Release.Name }}-postgresql:5432/{{ .Values.postgresql.postgresql.auth.database }}"
           {{- end }}
     {{- end }}
         tty: true

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -153,10 +153,14 @@ rabbitmq:
 
 # Values for the Postgresql Chart
 postgresql:
-  postgresqlDatabase: servicex
-  postgresqlPassword: leftfoot1
-  persistence:
-    enabled: false
+  global:
+    postgresql:
+      auth:
+        postgresPassword: leftfoot1
+        database: servicex
+  primary:
+    persistence:
+      enabled: false
 
 # Values for Minio Chart
 minio:


### PR DESCRIPTION
# Problem
The bitnami Postgres sub chart was pinned to 8.3 - this chart has been deprecated and archived and no longer is available

# Approach
Update the dependency to the latest version of the sub chart. There are some changes to the names of the values we depend on. Updated `values.yaml` and the templates that pull these values. Also updated the example values files