### PR TITLE
Update minio.ingress to minio.apiIngress

### DIFF
--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -60,17 +60,16 @@ different value, such as `traefik`.
 
 ### Adding an Ingress to Minio
 ServiceX stores files in a Minio object store which is deployed as a 
-subchart. The Helm chart for Minio has it's own support for an Ingress,
+subchart. The Helm chart for Minio has its own support for an Ingress,
 which we can activate like so:
 
 ```yaml
 minio:
-  ingress:
+  apiIngress:
     enabled: true
     annotations:
       kubernetes.io/ingress.class: <ingress class>
-    hosts:
-    - my-release-minio.servicex.ssl-hep.org
+    hostname: my-release-minio.servicex.ssl-hep.org
 ```
 
 Unlike the ServiceX Ingress, the subchart doesn't know the name of our 
@@ -159,16 +158,16 @@ Adding TLS to the Minio subchart is slightly different.
 The configuration is as follows:
 ```yaml
 minio:
-  ingress:
+  apiIngress:
     enabled: true
     annotations:
       kubernetes.io/ingress.class: <ingress class>
-    hosts:
-    - my-release-minio.servicex.ssl-hep.org
-    tls:
-    - hosts:
-      - my-release-minio.servicex.ssl-hep.org
-      secretName: my-release-minio-tls
+    hostname: my-release-minio.servicex.ssl-hep.org
+    tls: true
+    extraTls:
+      - hosts:
+        - my-release-minio.servicex.ssl-hep.org
+        secretName: my-release-minio-tls
 ```
 Remember to replace `my-release` and `servicex.ssl-hep.org` with your Helm release name and app ingress host, respectively. 
 Here, you must specify a secret name; there is no default.
@@ -201,18 +200,18 @@ For more information, see the cert-manager [guide to securing nginx-ingress](htt
 To enable TLS for Minio, use the following configuration:
 ```yaml
 minio:
-  ingress:
+  apiIngress:
     enabled: true
     annotations:
       kubernetes.io/ingress.class: <ingress class>
       cert-manager.io/cluster-issuer: letsencrypt-prod
       acme.cert-manager.io/http01-edit-in-place: "true"
-    hosts:
-    - my-release-minio.servicex.ssl-hep.org
-    tls:
-    - hosts:
-      - my-release-minio.servicex.ssl-hep.org
-      secretName: my-release-minio-tls
+    hostname: my-release-minio.servicex.ssl-hep.org
+    tls: true
+    extraTls:
+       - hosts:
+         - my-release-minio.servicex.ssl-hep.org
+         secretName: my-release-minio-tls
 ```
 Once again, remember to replace `my-release` and `servicex.ssl-hep.org` with 
 your Helm release name and app ingress host, respectively.

--- a/docs/deployment/reference.md
+++ b/docs/deployment/reference.md
@@ -70,8 +70,8 @@ parameters for the [rabbitMQ](https://github.com/bitnami/charts/tree/master/bitn
 | `postgres.enabled`                   | Deploy a postgres database into cluster? If not, we use a sqllite db | false  |
 | `minio.auth.rootUser`                | Username to log into minio                       | miniouser |
 | `minio.auth.rootPassword`            | Password key to log into minio                   | leftfoot1 |
-| `minio.ingress.enabled`              | Should minio chart deploy an ingress to the service? | false |
-| `minio.ingress.hostname`             | Hostname  associate with ingress controller      | nil |
+| `minio.apiIngress.enabled`              | Should minio chart deploy an ingress to the service? | false |
+| `minio.apiIngress.hostname`             | Hostname  associate with ingress controller      | nil |
 | `transformer.autoscaler.enabled`     | Enable/disable horizontal pod autoscaler for transformers |  True |
 | `transformer.autoscaler.cpuScaleThreshold` | CPU percentage threshold for pod scaling   | 30 |
 | `transformer.autoscaler.minReplicas` | Minimum number of transformer pods per request   | 1 |

--- a/servicex/templates/NOTES.txt
+++ b/servicex/templates/NOTES.txt
@@ -55,10 +55,10 @@ with a http connection.
     {{ end }}
 
 
-  {{ else if .Values.minio.ingress.enabled }}
+  {{ else if .Values.minio.apiIngress.enabled }}
 
 Since you declared an internet ingress to Minio you can access it at
-{{ .Values.objectStore.publicURL | default .Values.minio.ingress.hostname }}
+{{ .Values.objectStore.publicURL | default .Values.minio.apiIngress.hostname }}
   {{ else }}
 Finally, you can interact with the minio object store with another Port-Forward:
   export MINIO_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app=minio,release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")

--- a/servicex/templates/app/configmap.yaml
+++ b/servicex/templates/app/configmap.yaml
@@ -122,9 +122,9 @@ data:
     # using internal minio 
     MINIO_URL = '{{ .Release.Name }}-minio:{{ .Values.minio.service.ports.api }}'
     MINIO_URL_TRANSFORMER = '{{ .Release.Name }}-minio:{{ .Values.minio.service.ports.api }}'
-        {{ if .Values.minio.ingress.enabled }}
+        {{ if .Values.minio.apiIngress.enabled }}
     # Using minio ingress
-    MINIO_PUBLIC_URL = '{{ .Values.objectStore.publicURL | default .Values.minio.ingress.hostname }}'
+    MINIO_PUBLIC_URL = '{{ .Values.objectStore.publicURL | default .Values.minio.apiIngress.hostname }}'
     MINIO_ENCRYPT = {{ ternary "True" "False" .Values.objectStore.useTLS }}
         {{ else }}
     {{- $internal_minio := printf "%s--minio:%v" .Release.Name .Values.minio.service.ports.api -}}


### PR DESCRIPTION
The minio subchart now has a minio.ingress option (for console) and
a minio.apiIngress option (for the API).  In addition, some of the
TLS options have changed.