### PR TITLE
Fix logging env

### DIFF
--- a/servicex/Chart.yaml
+++ b/servicex/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Install ServiceX deployment - HEP Columnar Data Delivery Service
 name: servicex
-version: 1.0.31
-appVersion: 20220831-0243-stable
+version: 1.0.32-RC.1
+appVersion: 20220926-1720-stable
 maintainers:
   - name: BenGalewsky
     url: https://github.com/BenGalewsky

--- a/servicex/templates/app/deployment.yaml
+++ b/servicex/templates/app/deployment.yaml
@@ -39,16 +39,16 @@ spec:
         - name: APP_CONFIG_FILE
           value: "/opt/servicex/app.conf"
         - name: INSTANCE_NAME
-          value: {{ .Release.Name }}
+          value: "{{ .Release.Name }}"
         - name: LOG_LEVEL
-          value: {{ .Values.app.logLevel | upper }}
+          value: "{{ .Values.app.logLevel | upper }}"
         {{- if .Values.logging.logstash.enabled }}
         - name: LOGSTASH_HOST
-          value: {{ .Values.logging.logstash.host }}
+          value: "{{ .Values.logging.logstash.host }}"
         - name: LOGSTASH_PORT
-          value: {{ .Values.logging.logstash.port }}
+          value: "{{ .Values.logging.logstash.port }}"
         - name: LOGSTASH_PROTOCOL
-          value: {{ .Values.logging.logstash.protocol }}
+          value: "{{ .Values.logging.logstash.protocol }}"
         {{- end }}
     {{- if .Values.secrets }}
         - name: GLOBUS_CLIENT_ID

--- a/servicex/values.yaml
+++ b/servicex/values.yaml
@@ -133,7 +133,7 @@ transformer:
   priorityClassName:
   cpuLimit: 1
   defaultTransformerImage: sslhep/servicex_func_adl_xaod_transformer
-  defaultTransformerTag: 20220831-0243-stable
+  defaultTransformerTag: 20220926-1720-stable
 
   # For enabling volume output destination for transformers. Supports attaching
   # an existing PVC to transformers
@@ -145,7 +145,7 @@ transformer:
 
   # For uproot deployment
   #  defaultTransformerImage:  sslhep/servicex_func_adl_uproot_transformer
-  #  defaultTransformerTag: 20220831-0243-stable
+  #  defaultTransformerTag: 20220926-1720-stable
 
 x509Secrets:
   image: sslhep/x509-secrets


### PR DESCRIPTION
# Problem 
The helm chart doesn't deploy due to missing quotes around string values in the App's environment vars