### PR TITLE
Migrate to sslhep/rucio-client to get modern version of python

### DIFF
--- a/did_finder_rucio/Dockerfile
+++ b/did_finder_rucio/Dockerfile
@@ -1,4 +1,4 @@
-FROM rucio/rucio-clients:latest
+FROM sslhep/rucio-client:main
 
 LABEL maintainer Ilija Vukotic <ivukotic@cern.ch>
 
@@ -11,14 +11,6 @@ RUN mkdir -p /etc/grid-security/certificates /etc/grid-security/vomsdir
 
 RUN yum clean all
 RUN yum -y update
-
-RUN yum install -y https://repo.opensciencegrid.org/osg/3.5/osg-3.5-el7-release-latest.rpm
-
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; \
-    curl -s -o /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg http://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg; \
-    curl -s -o /etc/yum.repos.d/wlcg-centos7.repo http://linuxsoft.cern.ch/wlcg/wlcg-centos7.repo;
-
-RUN yum install osg-ca-certs voms voms-clients wlcg-voms-atlas fetch-crl -y
 
 # Okay, change our shell to specifically use our software collections.
 # (default was SHELL [ "/bin/sh", "-c" ])

--- a/did_finder_rucio/poetry.lock
+++ b/did_finder_rucio/poetry.lock
@@ -418,8 +418,8 @@ python-versions = ">=3.4"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "~3.10"
-content-hash = "afdee80115823099984e30b57490b670bbba0996bef2550e958ffa353747e56a"
+python-versions = "^3.9"
+content-hash = "8e064057df8119105af7b363a958933adfc87b5c3e29510c49a1d602e379c381"
 
 [metadata.files]
 attrs = [

--- a/did_finder_rucio/pyproject.toml
+++ b/did_finder_rucio/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "did_finder_rucio"}]
 
 [tool.poetry.dependencies]
-python = "~3.10"
+python = "^3.9"
 rucio-clients = "^1.29.7.post1"
 pika = "1.1.0"
 servicex-did-finder-lib = "1.2"

--- a/x509_secrets/Dockerfile
+++ b/x509_secrets/Dockerfile
@@ -1,4 +1,4 @@
-FROM rucio/rucio-clients:latest
+FROM sslhep/rucio-client:main
 
 USER root
 
@@ -10,14 +10,6 @@ WORKDIR /usr/src/app
 RUN mkdir -p /etc/grid-security/certificates /etc/grid-security/vomsdir
 
 RUN yum -y update
-
-RUN yum install -y https://repo.opensciencegrid.org/osg/3.5/osg-3.5-el7-release-latest.rpm
-
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; \
-    curl -s -o /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg http://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg; \
-    curl -s -o /etc/yum.repos.d/wlcg-centos7.repo http://linuxsoft.cern.ch/wlcg/wlcg-centos7.repo;
-
-RUN yum install osg-ca-certs voms voms-clients wlcg-voms-atlas wlcg-voms-cms fetch-crl -y
 
 ENV POETRY_VERSION=1.2.2
 RUN python3 -m pip install --upgrade pip

--- a/x509_secrets/pyproject.toml
+++ b/x509_secrets/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "x509_secrets"}]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.9"
 kubernetes = "^25.3.0"
 
 


### PR DESCRIPTION
# Problem
The official rucio-client image is based on a very old version of python.

# Approach
* Switch to a [locally built docker image](https://github.com/ssl-hep/rucio-client)
* Upgrade to poetry to match the goals of 1.0.34
* Clean up install of libraries that have been picked up in the base image already