### PR TITLE
Simplify names of Rucio DID Finder containers

### DIFF
--- a/helm/servicex/templates/did-finder-rucio/deployment.yaml
+++ b/helm/servicex/templates/did-finder-rucio/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app: {{ .Release.Name }}-did-finder-rucio
     spec:
       containers:
-      - name: {{ .Release.Name }}-did-finder-rucio
+      - name: did-finder
         image: {{ .Values.didFinder.rucio.image }}:{{ .Values.didFinder.rucio.tag }}
         command: ["/usr/src/app/runme.sh"]
         imagePullPolicy: {{ .Values.didFinder.rucio.pullPolicy }}
@@ -62,7 +62,7 @@ spec:
             mountPath: /etc/grid-security-ro
             readOnly: true
       {{- if ((.Values.didFinder.rucio.memcache).enabled) }}
-      - name: {{ .Release.Name }}-did-finder-rucio-memcache
+      - name: memcache
         image: {{ .Values.didFinder.rucio.memcache.image }}:{{ .Values.didFinder.rucio.memcache.tag }}
       {{- end }}
       volumes:


### PR DESCRIPTION
# Problem
Even though pod container names are namespaces by the pod, the Rucio DID Finder's two containers have names that include the helm deployment name. This is cumbersome when you want to read the logs for the DID finder since you have to specify which container with a `-c` argument.

# Approach
Removed the helm deployment from the container names