### PR TITLE
Pick up transformer language and command from the code generators' capabilities file

### DIFF
--- a/code_generator_funcadl_uproot/poetry.lock
+++ b/code_generator_funcadl_uproot/poetry.lock
@@ -486,7 +486,7 @@ requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "servicex-code-gen-lib"
-version = "1.1.4a13"
+version = "1.1.4a14"
 description = "Library for creating ServiceX Code Generators"
 category = "main"
 optional = false
@@ -527,7 +527,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "typing-extensions"
-version = "4.4.0"
+version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -584,7 +584,7 @@ test-extras = ["spark-parser", "uncompyle6"]
 
 [[package]]
 name = "werkzeug"
-version = "2.2.2"
+version = "2.2.3"
 description = "The comprehensive WSGI web application library."
 category = "main"
 optional = false
@@ -613,7 +613,7 @@ email = ["email-validator"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.10"
-content-hash = "ef94202af9e98eb21cbe0a040688652db21d842efb5beae246a80b6ed945387c"
+content-hash = "6403053e205ad5eea8f5a206d4de28824759ba540c52a2decdf5d700495712c0"
 
 [metadata.files]
 aniso8601 = [
@@ -1027,8 +1027,8 @@ requests-toolbelt = [
     {file = "requests_toolbelt-0.10.1-py2.py3-none-any.whl", hash = "sha256:18565aa58116d9951ac39baa288d3adb5b3ff975c4f25eee78555d89e8f247f7"},
 ]
 servicex-code-gen-lib = [
-    {file = "servicex_code_gen_lib-1.1.4a13-py3-none-any.whl", hash = "sha256:e9754b4efc5c868e7c79a426a23d1bad3467401a4f4807237e59150e08592f44"},
-    {file = "servicex_code_gen_lib-1.1.4a13.tar.gz", hash = "sha256:1a04b6f89ff2022c91a5086dc483ce8db1ac484353dd27c810a899ca72a70c3d"},
+    {file = "servicex_code_gen_lib-1.1.4a14-py3-none-any.whl", hash = "sha256:a8a4ba6b804e37418263f2681d2bdcd06ee3c5ae03462df54f6fa9d828cbf736"},
+    {file = "servicex_code_gen_lib-1.1.4a14.tar.gz", hash = "sha256:2f35347fd31f62754414026f64caba029323fe7cab7811c6188a6e9f442bcc12"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -1043,8 +1043,8 @@ tomli = [
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
-    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
+    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
 ]
 uproot = [
     {file = "uproot-5.0.2-py3-none-any.whl", hash = "sha256:5c74fc126ec6aa76488466e345e0e51efb51239c66e32f31fbdf534e21bad030"},
@@ -1059,8 +1059,8 @@ vector = [
     {file = "vector-0.11.0.tar.gz", hash = "sha256:fded30643588226f6f8b7ecd1242048ad423d29d4cd77d8000eea277479a0396"},
 ]
 werkzeug = [
-    {file = "Werkzeug-2.2.2-py3-none-any.whl", hash = "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"},
-    {file = "Werkzeug-2.2.2.tar.gz", hash = "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f"},
+    {file = "Werkzeug-2.2.3-py3-none-any.whl", hash = "sha256:56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612"},
+    {file = "Werkzeug-2.2.3.tar.gz", hash = "sha256:2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe"},
 ]
 wtforms = [
     {file = "WTForms-3.0.1-py3-none-any.whl", hash = "sha256:837f2f0e0ca79481b92884962b914eba4e72b7a2daaf1f939c890ed0124b834b"},

--- a/code_generator_funcadl_uproot/pyproject.toml
+++ b/code_generator_funcadl_uproot/pyproject.toml
@@ -12,7 +12,7 @@ func-adl = "2.3.1"
 "func-adl.ast" = "2.3.1"
 func-adl-uproot = "1.9.0"
 qastle = "0.15.0"
-servicex-code-gen-lib = {version = "^1.1.4a13"}
+servicex-code-gen-lib = {version = "^1.1.4a14"}
 
 [tool.poetry.group.test]
 optional = true

--- a/code_generator_funcadl_xAOD/poetry.lock
+++ b/code_generator_funcadl_xAOD/poetry.lock
@@ -182,7 +182,7 @@ email = ["email-validator"]
 
 [[package]]
 name = "func-adl"
-version = "3.1.2"
+version = "3.2.2"
 description = "Functional Analysis Description Language Base Package"
 category = "main"
 optional = false
@@ -466,7 +466,7 @@ py = ">=1.4.26,<2.0.0"
 
 [[package]]
 name = "servicex-code-gen-lib"
-version = "1.1.4a13"
+version = "1.1.4a14"
 description = "Library for creating ServiceX Code Generators"
 category = "main"
 optional = false
@@ -520,7 +520,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "werkzeug"
-version = "2.2.2"
+version = "2.2.3"
 description = "The comprehensive WSGI web application library."
 category = "main"
 optional = false
@@ -549,7 +549,7 @@ email = ["email-validator"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.10"
-content-hash = "dffbec5340452bd029ba992aecc0f4a8ac1e08eb9d5d293b53a6f6fd21cdd388"
+content-hash = "2bd7b27f03970c106e1c98bd316807a39b33bfc2ea19e263007c18f877e265c2"
 
 [metadata.files]
 aniso8601 = [
@@ -747,8 +747,8 @@ flask-wtf = [
     {file = "Flask_WTF-1.1.1-py3-none-any.whl", hash = "sha256:7887d6f1ebb3e17bf648647422f0944c9a469d0fcf63e3b66fb9a83037e38b2c"},
 ]
 func-adl = [
-    {file = "func_adl-3.1.2-py3-none-any.whl", hash = "sha256:8342959663f474fda9aaf17d2154d3aa3adb4557f9f51243772510ee94d082c4"},
-    {file = "func_adl-3.1.2.tar.gz", hash = "sha256:1801a0df0a553c9f5e1a48b9dca7be170c4614bc2a33215907444d8f0cad1988"},
+    {file = "func_adl-3.2.2-py3-none-any.whl", hash = "sha256:c87721d74fe6f466cdde4820db8e1964e8e1b8934f40094ef387b69665055251"},
+    {file = "func_adl-3.2.2.tar.gz", hash = "sha256:b0858321ebdcdaade6ed5041a0a7823d68d3ef18be830bff8aeaf1de1c0aba3b"},
 ]
 func-adl-xaod = [
     {file = "func_adl_xAOD-2.0.1-py3-none-any.whl", hash = "sha256:252eda904b195691fd0770f950c5466f77ad292b75e72d1c5090365d05ca9044"},
@@ -891,8 +891,8 @@ retry = [
     {file = "retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4"},
 ]
 servicex-code-gen-lib = [
-    {file = "servicex_code_gen_lib-1.1.4a13-py3-none-any.whl", hash = "sha256:e9754b4efc5c868e7c79a426a23d1bad3467401a4f4807237e59150e08592f44"},
-    {file = "servicex_code_gen_lib-1.1.4a13.tar.gz", hash = "sha256:1a04b6f89ff2022c91a5086dc483ce8db1ac484353dd27c810a899ca72a70c3d"},
+    {file = "servicex_code_gen_lib-1.1.4a14-py3-none-any.whl", hash = "sha256:a8a4ba6b804e37418263f2681d2bdcd06ee3c5ae03462df54f6fa9d828cbf736"},
+    {file = "servicex_code_gen_lib-1.1.4a14.tar.gz", hash = "sha256:2f35347fd31f62754414026f64caba029323fe7cab7811c6188a6e9f442bcc12"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -911,8 +911,8 @@ urllib3 = [
     {file = "urllib3-1.26.14.tar.gz", hash = "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72"},
 ]
 werkzeug = [
-    {file = "Werkzeug-2.2.2-py3-none-any.whl", hash = "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"},
-    {file = "Werkzeug-2.2.2.tar.gz", hash = "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f"},
+    {file = "Werkzeug-2.2.3-py3-none-any.whl", hash = "sha256:56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612"},
+    {file = "Werkzeug-2.2.3.tar.gz", hash = "sha256:2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe"},
 ]
 wtforms = [
     {file = "WTForms-3.0.1-py3-none-any.whl", hash = "sha256:837f2f0e0ca79481b92884962b914eba4e72b7a2daaf1f939c890ed0124b834b"},

--- a/code_generator_funcadl_xAOD/pyproject.toml
+++ b/code_generator_funcadl_xAOD/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "code_generator_funcadl_xaod"}]
 [tool.poetry.dependencies]
 python = "~3.10"
 func-adl-xAOD = "2.0.1"
-servicex-code-gen-lib = {version = "^1.1.4a13"}
+servicex-code-gen-lib = {version = "^1.1.4a14"}
 
 [tool.poetry.group.test]
 optional = true

--- a/code_generator_funcadl_xAOD/transformer_capabilities.json
+++ b/code_generator_funcadl_xAOD/transformer_capabilities.json
@@ -3,5 +3,8 @@
   "description": "Two different transformers. One for ATLAS reads xAOD files. A second transformer reads CMS Run 1 AOD files",
   "limitations": "Would be good to note what isn't implemented",
   "file-formats": ["root"],
-  "stats-parser": "AODStats"
+  "stats-parser": "AODStats",
+  "language": "bash",
+  "command": "/generated/transform_single_file.sh"
+
 }

--- a/code_generator_python/poetry.lock
+++ b/code_generator_python/poetry.lock
@@ -366,7 +366,7 @@ requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "servicex-code-gen-lib"
-version = "1.1.4a13"
+version = "1.1.4a14"
 description = "Library for creating ServiceX Code Generators"
 category = "main"
 optional = false
@@ -420,7 +420,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "werkzeug"
-version = "2.2.2"
+version = "2.2.3"
 description = "The comprehensive WSGI web application library."
 category = "main"
 optional = false
@@ -449,7 +449,7 @@ email = ["email-validator"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.10"
-content-hash = "ad535f434a46405119ab2dca6600e6289aa792c2f891baa35cd63b526ee19c0b"
+content-hash = "48fc896deadaf78b60fb5f54a5c6479c8945d50cf3178fc37577c02fe1c4888e"
 
 [metadata.files]
 aniso8601 = [
@@ -759,8 +759,8 @@ requests-toolbelt = [
     {file = "requests_toolbelt-0.10.1-py2.py3-none-any.whl", hash = "sha256:18565aa58116d9951ac39baa288d3adb5b3ff975c4f25eee78555d89e8f247f7"},
 ]
 servicex-code-gen-lib = [
-    {file = "servicex_code_gen_lib-1.1.4a13-py3-none-any.whl", hash = "sha256:e9754b4efc5c868e7c79a426a23d1bad3467401a4f4807237e59150e08592f44"},
-    {file = "servicex_code_gen_lib-1.1.4a13.tar.gz", hash = "sha256:1a04b6f89ff2022c91a5086dc483ce8db1ac484353dd27c810a899ca72a70c3d"},
+    {file = "servicex_code_gen_lib-1.1.4a14-py3-none-any.whl", hash = "sha256:a8a4ba6b804e37418263f2681d2bdcd06ee3c5ae03462df54f6fa9d828cbf736"},
+    {file = "servicex_code_gen_lib-1.1.4a14.tar.gz", hash = "sha256:2f35347fd31f62754414026f64caba029323fe7cab7811c6188a6e9f442bcc12"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -779,8 +779,8 @@ urllib3 = [
     {file = "urllib3-1.26.14.tar.gz", hash = "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72"},
 ]
 werkzeug = [
-    {file = "Werkzeug-2.2.2-py3-none-any.whl", hash = "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"},
-    {file = "Werkzeug-2.2.2.tar.gz", hash = "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f"},
+    {file = "Werkzeug-2.2.3-py3-none-any.whl", hash = "sha256:56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612"},
+    {file = "Werkzeug-2.2.3.tar.gz", hash = "sha256:2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe"},
 ]
 wtforms = [
     {file = "WTForms-3.0.1-py3-none-any.whl", hash = "sha256:837f2f0e0ca79481b92884962b914eba4e72b7a2daaf1f939c890ed0124b834b"},

--- a/code_generator_python/pyproject.toml
+++ b/code_generator_python/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "code_generator_python"}]
 
 [tool.poetry.dependencies]
 python = "~3.10"
-servicex-code-gen-lib = {version = "^1.1.4a13"}
+servicex-code-gen-lib = {version = "^1.1.4a14"}
 
 [tool.poetry.group.test]
 optional = true

--- a/code_generator_python/transformer_capabilities.json
+++ b/code_generator_python/transformer_capabilities.json
@@ -1,8 +1,8 @@
 {
-  "name": "FuncADL based uproot transformer",
+  "name": "Python Uproot Transformer",
   "description": "Extracts data from flat ntuple style root files.",
   "limitations": "Would be good to note what isn't implemented",
-  "file-formats": ["parquet"],
+  "file-formats": ["parquet", "root"],
   "stats-parser": "UprootStats",
   "language": "python",
   "command": "/generated/transform_single_file.py"

--- a/servicex_app/migrations/versions/v1_1_4.py
+++ b/servicex_app/migrations/versions/v1_1_4.py
@@ -1,0 +1,27 @@
+"""Support for multiple code generators.
+
+Revision ID: v1_1_4
+Revises: v1_1_3
+Create Date: 2023-02-15
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'v1_1_4'
+down_revision = 'v1_1_3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('requests', sa.Column("transformer_language", sa.String(256), nullable=True))
+    op.add_column('requests', sa.Column("transformer_command", sa.String(256), nullable=True))
+
+
+def downgrade():
+    op.drop_column('requests', 'transformer_language')
+    op.drop_column('requests', 'transformer_command')
+

--- a/servicex_app/servicex/code_gen_adapter.py
+++ b/servicex_app/servicex/code_gen_adapter.py
@@ -38,7 +38,7 @@ class CodeGenAdapter:
     def generate_code_for_selection(
             self, request_record: TransformRequest,
             namespace: str,
-            user_codegen_name: str) -> tuple[str, str]:
+            user_codegen_name: str) -> tuple[str, str, str, str]:
         """
         Generates the C++ code for a request's selection string.
         Places the results in a ConfigMap resource in the
@@ -77,12 +77,16 @@ class CodeGenAdapter:
         decoder_parts = decoder.MultipartDecoder.from_response(result)
 
         transformer_image = (decoder_parts.parts[0].text).strip()
+        transformer_language = (decoder_parts.parts[1].text).strip()
+        transformer_command = (decoder_parts.parts[2].text).strip()
         print('Transformer Image from Codegen: ', transformer_image)
-        zipfile = decoder_parts.parts[1].content
+        zipfile = decoder_parts.parts[3].content
 
         zipfile = ZipFile(BytesIO(zipfile))
 
         return (self.transformer_manager.create_configmap_from_zip(zipfile,
                                                                    request_record.request_id,
                                                                    namespace),
-                transformer_image)
+                transformer_image,
+                transformer_language,
+                transformer_command)

--- a/servicex_app/servicex/models.py
+++ b/servicex_app/servicex/models.py
@@ -173,6 +173,8 @@ class TransformRequest(db.Model):
     failure_description = db.Column(db.String(max_string_size), nullable=True)
     app_version = db.Column(db.String(64), nullable=True)
     code_gen_image = db.Column(db.String(256), nullable=True)
+    transformer_language = db.Column(db.String(256), nullable=True)
+    transformer_command = db.Column(db.String(256), nullable=True)
 
     def save_to_db(self):
         db.session.add(self)

--- a/servicex_app/servicex/resources/internal/transform_start.py
+++ b/servicex_app/servicex/resources/internal/transform_start.py
@@ -50,7 +50,10 @@ class TransformStart(ServiceXResource):
             x509_secret=x509_secret,
             generated_code_cm=generated_code_cm,
             result_destination=request_rec.result_destination,
-            result_format=request_rec.result_format)
+            result_format=request_rec.result_format,
+            transformer_language=request_rec.transformer_language,
+            transformer_command=request_rec.transformer_command
+        )
 
     @classmethod
     def make_api(cls, transformer_manager: TransformerManager):

--- a/servicex_app/servicex/resources/transformation/submit.py
+++ b/servicex_app/servicex/resources/transformation/submit.py
@@ -155,11 +155,12 @@ class SubmitTransformationRequest(ServiceXResource):
             # sure the requested selection is correct, and generate the C++ files
             if request_rec.workflow_name == 'selection_codegen':
                 namespace = config['TRANSFORMER_NAMESPACE']
-                (request_rec.generated_code_cm, codegen_transformer_image) = \
+                (request_rec.generated_code_cm,
+                 codegen_transformer_image,
+                 request_rec.transformer_language,
+                 request_rec.transformer_command) = \
                     self.code_gen_service.generate_code_for_selection(request_rec, namespace,
                                                                       user_codegen_name)
-
-                print("Returned Transformer Image: ", codegen_transformer_image)
 
                 if not request_rec.image:
                     request_rec.image = codegen_transformer_image

--- a/servicex_app/servicex/transformer_manager.py
+++ b/servicex_app/servicex/transformer_manager.py
@@ -50,7 +50,7 @@ class TransformerManager:
     @staticmethod
     def create_job_object(request_id, image, rabbitmq_uri, workers,
                           result_destination, result_format, x509_secret,
-                          generated_code_cm, namespace):
+                          generated_code_cm, transformer_language, transformer_command):
         volume_mounts = []
         volumes = []
 
@@ -164,8 +164,8 @@ class TransformerManager:
         science_command += "cp /generated/transformer_capabilities.json {op} && " \
                            "PYTHONPATH=/generated:$PYTHONPATH " \
                            "bash {op}/scripts/watch.sh ".format(op=output_path) + \
-                           "{TL} ".format(TL=current_app.config['TRANSFORMER_LANGUAGE']) + \
-                           "{TC} ".format(TC=current_app.config['TRANSFORMER_EXEC']) + \
+                           "{TL} ".format(TL=transformer_language) + \
+                           "{TC} ".format(TC=transformer_command) + \
                            watch_path
 
         if result_destination == 'volume':
@@ -318,12 +318,14 @@ class TransformerManager:
 
     def launch_transformer_jobs(self, image, request_id, workers,
                                 rabbitmq_uri, namespace, x509_secret, generated_code_cm,
-                                result_destination, result_format
+                                result_destination, result_format, transformer_language,
+                                transformer_command
                                 ):
         api_v1 = client.AppsV1Api()
         job = self.create_job_object(request_id, image, rabbitmq_uri, workers,
                                      result_destination, result_format,
-                                     x509_secret, generated_code_cm, namespace)
+                                     x509_secret, generated_code_cm,
+                                     transformer_language, transformer_command)
 
         self._create_job(api_v1, job, namespace)
 

--- a/servicex_app/tests/resource_test_base.py
+++ b/servicex_app/tests/resource_test_base.py
@@ -144,6 +144,8 @@ class ResourceTestBase:
         transform_request.status = "Submitted"
         transform_request.app_version = '1.0.1'
         transform_request.code_gen_image = "sslhep/servicex_code_gen_func_adl_xaod:develop"
+        transform_request.transformer_language = "scala"
+        transform_request.transformer_command = "echo"
         return transform_request
 
     @fixture

--- a/servicex_app/tests/resources/internal/test_transform_start.py
+++ b/servicex_app/tests/resources/internal/test_transform_start.py
@@ -67,6 +67,8 @@ class TestTransformationStart(ResourceTestBase):
                                 namespace='my-ws',
                                 result_destination=None,
                                 result_format='arrow',
+                                transformer_command="echo",
+                                transformer_language="scala",
                                 x509_secret='my-x509-secret')
         mock_request.save_to_db.assert_called()
 

--- a/servicex_app/tests/resources/transformation/test_submit.py
+++ b/servicex_app/tests/resources/transformation/test_submit.py
@@ -185,7 +185,10 @@ class TestSubmitTransformationRequest(ResourceTestBase):
     def test_submit_transformation_with_root_file(
         self, mocker, mock_rabbit_adaptor, mock_code_gen_service, mock_app_version
     ):
-        mock_code_gen_service.generate_code_for_selection.return_value = ('my-cm', 'ssl-hep/func_adl:latest')
+        mock_code_gen_service.generate_code_for_selection.return_value = ('my-cm',
+                                                                          'scala', 'echo',
+                                                                          'ssl-hep/func_adl:latest')
+
         request = self._generate_transformation_request_xAOD_root_file()
 
         client = self._test_client(
@@ -283,6 +286,8 @@ class TestSubmitTransformationRequest(ResourceTestBase):
                                     namespace='my-ws',
                                     result_destination=submitted_request.result_destination,
                                     result_format=submitted_request.result_format,
+                                    transformer_command=None,
+                                    transformer_language=None,
                                     x509_secret='my-x509-secret')
 
     def test_submit_transformation_request_bad_image(

--- a/servicex_app/tests/test_code_gen_adapter.py
+++ b/servicex_app/tests/test_code_gen_adapter.py
@@ -59,9 +59,18 @@ class TestCodeGenAdapter:
         mock_transformer_image_part = mocker.MagicMock()
         mock_transformer_image_part.text = "my-transformer:test"
 
+        mock_transformer_language_part = mocker.MagicMock()
+        mock_transformer_language_part.text = "scala"
+
+        mock_transformer_command_part = mocker.MagicMock()
+        mock_transformer_command_part.text = "echo hello, world"
+
         mock_zip_part = mocker.MagicMock()
 
-        mock_parts.parts = [mock_transformer_image_part, mock_zip_part]
+        mock_parts.parts = [mock_transformer_image_part,
+                            mock_transformer_language_part,
+                            mock_transformer_command_part,
+                            mock_zip_part]
         mocker.patch('servicex.code_gen_adapter.decoder.MultipartDecoder.from_response',
                      return_value=mock_parts)
 
@@ -70,10 +79,12 @@ class TestCodeGenAdapter:
         mocker.patch("io.BytesIO")
 
         code_gen = CodeGenAdapter(self.code_gen_service_urls, mock_transformer_manager)
-        (config_map, transformer_image) = \
+        (config_map, transformer_image, transformer_language, transformer_command) = \
             code_gen.generate_code_for_selection(self._generate_test_request(), "servicex", "uproot")
 
         assert transformer_image == "my-transformer:test"
+        assert transformer_language == "scala"
+        assert transformer_command == "echo hello, world"
 
         mock_requests_post.assert_called()
         mock_transformer_manager.create_configmap_from_zip.assert_called_with(mock_zip(),

--- a/servicex_app/tests/test_transformer_manager.py
+++ b/servicex_app/tests/test_transformer_manager.py
@@ -100,8 +100,6 @@ class TestTransformerManager(ResourceTestBase):
             'TRANSFORMER_MIN_REPLICAS': 3,
             'TRANSFORMER_MAX_REPLICAS': 17,
             'TRANSFORMER_SIDECAR_VOLUME_PATH': '/servicex/output',
-            'TRANSFORMER_LANGUAGE': 'python',
-            'TRANSFORMER_EXEC': 'transform_data.py'
         }
 
         transformer.persistent_volume_claim_exists = mocker.Mock(return_value=True)
@@ -167,8 +165,6 @@ class TestTransformerManager(ResourceTestBase):
             'TRANSFORMER_CPU_LIMIT': 1,
             'TRANSFORMER_CPU_SCALE_THRESHOLD': 30,
             'TRANSFORMER_SIDECAR_VOLUME_PATH': '/servicex/output',
-            'TRANSFORMER_LANGUAGE': 'python',
-            'TRANSFORMER_EXEC': 'transform_data.py',
             'TRANSFORMER_SIDECAR_IMAGE': 'pondd/servicex_yt_transformer:sidecar',
             'TRANSFORMER_SIDECAR_PULL_POLICY': 'Always',
             'TRANSFORMER_SCIENCE_IMAGE_PULL_POLICY': 'Always'
@@ -184,7 +180,9 @@ class TestTransformerManager(ResourceTestBase):
                 image='sslhep/servicex-transformer:pytest', request_id='1234', workers=17,
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store', result_format='arrow', x509_secret='x509',
-                generated_code_cm=None)
+                generated_code_cm=None,
+                transformer_language="scala", transformer_command="echo"
+            )
             called_deployment = mock_api.mock_calls[1][2]['body']
             assert called_deployment.spec.replicas == 17
             mock_autoscaling.create_namespaced_horizontal_pod_autoscaler.assert_not_called()
@@ -208,8 +206,6 @@ class TestTransformerManager(ResourceTestBase):
             'TRANSFORMER_CPU_LIMIT': 1,
             'TRANSFORMER_CPU_SCALE_THRESHOLD': 30,
             'TRANSFORMER_SIDECAR_VOLUME_PATH': '/servicex/output',
-            'TRANSFORMER_LANGUAGE': 'python',
-            'TRANSFORMER_EXEC': 'transform_data.py',
             'TRANSFORMER_SIDECAR_IMAGE': 'pondd/servicex_yt_transformer:sidecar',
             'TRANSFORMER_SIDECAR_PULL_POLICY': 'Always',
             'TRANSFORMER_SCIENCE_IMAGE_PULL_POLICY': 'Always'
@@ -227,7 +223,9 @@ class TestTransformerManager(ResourceTestBase):
                 image='sslhep/servicex-transformer:pytest', request_id='1234', workers=17,
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store', result_format='arrow', x509_secret='x509',
-                generated_code_cm=None)
+                generated_code_cm=None,
+                transformer_language="scala", transformer_command="echo"
+            )
 
             called_job = mock_kubernetes.mock_calls[1][2]['body']
             container = called_job.spec.template.spec.containers[0]
@@ -255,8 +253,6 @@ class TestTransformerManager(ResourceTestBase):
             'TRANSFORMER_CPU_LIMIT': 1,
             'TRANSFORMER_CPU_SCALE_THRESHOLD': 30,
             'TRANSFORMER_SIDECAR_VOLUME_PATH': '/servicex/output',
-            'TRANSFORMER_LANGUAGE': 'python',
-            'TRANSFORMER_EXEC': 'transform_data.py',
             'TRANSFORMER_SIDECAR_IMAGE': 'pondd/servicex_yt_transformer:sidecar',
             'TRANSFORMER_SIDECAR_PULL_POLICY': 'Always',
             'TRANSFORMER_SCIENCE_IMAGE_PULL_POLICY': 'Always'
@@ -273,7 +269,9 @@ class TestTransformerManager(ResourceTestBase):
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store',
                 result_format='parquet', x509_secret='x509',
-                generated_code_cm="my-config-map")
+                generated_code_cm="my-config-map",
+                transformer_language="scala", transformer_command="echo"
+            )
             called_job = mock_kubernetes.mock_calls[1][2]['body']
             container = called_job.spec.template.spec.containers[0]
             config_map_vol_mount = container.volume_mounts[2]
@@ -302,8 +300,6 @@ class TestTransformerManager(ResourceTestBase):
             'TRANSFORMER_CPU_LIMIT': 1,
             'TRANSFORMER_CPU_SCALE_THRESHOLD': 30,
             'TRANSFORMER_SIDECAR_VOLUME_PATH': '/servicex/output',
-            'TRANSFORMER_LANGUAGE': 'python',
-            'TRANSFORMER_EXEC': 'transform_data.py',
             'TRANSFORMER_SIDECAR_IMAGE': 'pondd/servicex_yt_transformer:sidecar',
             'TRANSFORMER_SIDECAR_PULL_POLICY': 'Always',
             'TRANSFORMER_SCIENCE_IMAGE_PULL_POLICY': 'Always'
@@ -320,7 +316,9 @@ class TestTransformerManager(ResourceTestBase):
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store',
                 result_format='parquet', x509_secret='x509',
-                generated_code_cm=None)
+                generated_code_cm=None,
+                transformer_language="scala", transformer_command="echo"
+            )
             called_job = mock_kubernetes.mock_calls[1][2]['body']
             container = called_job.spec.template.spec.containers[0]
             args = container.args
@@ -351,8 +349,6 @@ class TestTransformerManager(ResourceTestBase):
             'TRANSFORMER_CPU_LIMIT': 1,
             'TRANSFORMER_CPU_SCALE_THRESHOLD': 30,
             'TRANSFORMER_SIDECAR_VOLUME_PATH': '/servicex/output',
-            'TRANSFORMER_LANGUAGE': 'python',
-            'TRANSFORMER_EXEC': 'transform_data.py',
             'TRANSFORMER_SIDECAR_IMAGE': 'pondd/servicex_yt_transformer:sidecar',
             'TRANSFORMER_SIDECAR_PULL_POLICY': 'Always',
             'TRANSFORMER_SCIENCE_IMAGE_PULL_POLICY': 'Always'
@@ -369,7 +365,9 @@ class TestTransformerManager(ResourceTestBase):
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store',
                 result_format='parquet', x509_secret='x509',
-                generated_code_cm=None)
+                generated_code_cm=None,
+                transformer_language="scala", transformer_command="echo"
+            )
             called_job = mock_kubernetes.mock_calls[1][2]['body']
             container = called_job.spec.template.spec.containers[0]
             args = container.args
@@ -396,8 +394,6 @@ class TestTransformerManager(ResourceTestBase):
             'TRANSFORMER_AUTOSCALE_ENABLED': False,
             'TRANSFORMER_CPU_LIMIT': 1,
             'TRANSFORMER_SIDECAR_VOLUME_PATH': '/servicex/output',
-            'TRANSFORMER_LANGUAGE': 'python',
-            'TRANSFORMER_EXEC': 'transform_data.py',
             'TRANSFORMER_SIDECAR_IMAGE': 'pondd/servicex_yt_transformer:sidecar',
             'TRANSFORMER_SIDECAR_PULL_POLICY': 'Always',
             'TRANSFORMER_SCIENCE_IMAGE_PULL_POLICY': 'Always'
@@ -414,7 +410,9 @@ class TestTransformerManager(ResourceTestBase):
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='volume',
                 result_format='parquet', x509_secret='x509',
-                generated_code_cm=None)
+                generated_code_cm=None,
+                transformer_language="scala", transformer_command="echo"
+            )
             called_job = mock_kubernetes.mock_calls[1][2]['body']
             container = called_job.spec.template.spec.containers[0]
             args = container.args
@@ -444,8 +442,6 @@ class TestTransformerManager(ResourceTestBase):
             'TRANSFORMER_AUTOSCALE_ENABLED': False,
             'TRANSFORMER_CPU_LIMIT': 1,
             'TRANSFORMER_SIDECAR_VOLUME_PATH': '/servicex/output',
-            'TRANSFORMER_LANGUAGE': 'python',
-            'TRANSFORMER_EXEC': 'transform_data.py',
             'TRANSFORMER_SIDECAR_IMAGE': 'pondd/servicex_yt_transformer:sidecar',
             'TRANSFORMER_SIDECAR_PULL_POLICY': 'Always',
             'TRANSFORMER_SCIENCE_IMAGE_PULL_POLICY': 'Always'
@@ -462,7 +458,9 @@ class TestTransformerManager(ResourceTestBase):
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='volume',
                 result_format='parquet', x509_secret='x509',
-                generated_code_cm=None)
+                generated_code_cm=None,
+                transformer_language="scala", transformer_command="echo"
+            )
             called_job = mock_kubernetes.mock_calls[1][2]['body']
             container = called_job.spec.template.spec.containers[0]
             args = container.args
@@ -499,8 +497,6 @@ class TestTransformerManager(ResourceTestBase):
             'TRANSFORMER_MAX_REPLICAS': 17,
             'TRANSFORMER_X509_SECRET': None,
             'TRANSFORMER_SIDECAR_VOLUME_PATH': '/servicex/output',
-            'TRANSFORMER_LANGUAGE': 'python',
-            'TRANSFORMER_EXEC': 'transform_data.py',
             'TRANSFORMER_SIDECAR_IMAGE': 'pondd/servicex_yt_transformer:sidecar',
             'TRANSFORMER_SIDECAR_PULL_POLICY': 'Always',
             'TRANSFORMER_SCIENCE_IMAGE_PULL_POLICY': 'Always'
@@ -515,7 +511,9 @@ class TestTransformerManager(ResourceTestBase):
                 image='sslhep/servicex-transformer:pytest', request_id='1234', workers=17,
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store', result_format='arrow', x509_secret=None,
-                generated_code_cm=None)
+                generated_code_cm=None,
+                transformer_language="scala", transformer_command="echo"
+            )
             called_deployment = mock_api.mock_calls[1][2]['body']
             assert len(called_deployment.spec.template.spec.containers) == 2
             container = called_deployment.spec.template.spec.containers[0]


### PR DESCRIPTION
The python and xaod transformers use different commands in the science package. Previously this was recorded in `values.yaml` for the deployment. This will no longer work with multiple code generators.

# Approach
Each code generator has a json file describing the associated transformer. Added two new properties to these files, `language` and `command` - these values will be picked up in the code generator and passed back to the app as additional multipart-mime entities.

They are saved in the transform request and picked up at transformer launch time