### PR TITLE
Force restart of app Pod when configuration changes.

### DIFF
--- a/helm/servicex/templates/app/deployment.yaml
+++ b/helm/servicex/templates/app/deployment.yaml
@@ -12,6 +12,8 @@ spec:
       labels:
         app: {{ .Release.Name }}-servicex-app
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/app/configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "servicex.fullname" . }}
       {{- if .Values.postgres.enabled }}


### PR DESCRIPTION
Fixes #297.

I tested the fix as follows:

- Installed chart from local directory.
- Changed "objectStore.publicURL", did ``helm upgrade``, and verified that app pod didn't restart. 

I repeated above steps with the fix and I could see that app pod is restarted.

Thanks to @AndrewEckart for his suggestion in #297.