### PR TITLE
Check and return errors while validating science image.

### DIFF
--- a/servicex_app/servicex/resources/transformation/submit.py
+++ b/servicex_app/servicex/resources/transformation/submit.py
@@ -150,8 +150,8 @@ class SubmitTransformationRequest(ServiceXResource):
                     request_rec.image = codegen_transformer_image
 
             if config['TRANSFORMER_VALIDATE_DOCKER_IMAGE']:
-                if not self.docker_repo_adapter.check_image_exists(request_rec.image):
-                    msg = f"Requested transformer docker image doesn't exist: {request_rec.image}"
+                exists, msg = self.docker_repo_adapter.check_image_exists(request_rec.image)
+                if not exists:
                     current_app.logger.error(msg, extra={'requestId': request_id})
                     return {'message': msg}, 400
 


### PR DESCRIPTION
Fixes #540.

This PR is not **ready to be merged yet**. The code works but tests need to be changed as well. How ever, I am running into issues while running tests. Firstly, the test instructions in "README" don't work as there is no "setup.py" in "servicex_app" directory. I managed to install all dependencies explicitly but some tests keep failing even in develop branch. It will be great if someone can tell me if the tests are maintained and if they are expected to succeed. 

I manually tested the change by using the science image "sslhep/sslhep/servicex_code_gen_func_adl_uproot" and the request fails (as expected) with this error:

```
servicex.utils.ServiceXException: (ServiceXException(...), 'ServiceX rejected the transformation request: (400){"message": "Unexpected error in validating transformer docker image (sslhep/sslhep/servicex_func_adl_uproot_transformer:v1.1.4), status_code: 503, msg (b\'<html><body><h1>503 Service Unavailable</h1>\\\\nNo server is available to handle this request.\\\\n</body></html>\\\\n\\\\n\')"}\n')
```

