### PR TITLE
Validate that "transformer.exec" value is provided.

### DIFF
--- a/helm/servicex/templates/app/configmap.yaml
+++ b/helm/servicex/templates/app/configmap.yaml
@@ -105,7 +105,7 @@ data:
     
     TRANSFORMER_SIDECAR_VOLUME_PATH = "{{ .Values.transformer.outputDir }}"
     TRANSFORMER_LANGUAGE = "{{ .Values.transformer.language }}"
-    TRANSFORMER_EXEC = "{{ .Values.transformer.exec }}"
+    TRANSFORMER_EXEC = "{{ required "Transformer exec value is required" .Values.transformer.exec }}"
 
     TRANSFORMER_PERSISTENCE_PROVIDED_CLAIM = "{{ .Values.transformer.persistence.existingClaim }}"
     TRANSFORMER_PERSISTENCE_SUBDIR = "{{ .Values.transformer.persistence.subdir}}"


### PR DESCRIPTION
In my local test, I didn't set "transformer.exec" in values.yaml and that led to a hang while processing transform request. When "transformer.exec" is not set, its value is empty string and this results in wrong number of parameters to be passed to transform container command. Here is an example:

```
cp /generated/transformer_capabilities.json /servicex/output && 
PYTHONPATH=/generated:$PYTHONPATH 
bash /servicex/output/scripts/watch.sh python  
/servicex/output/db61f8fb-8910-4aa2aea5-79d25adb1d48
```
Notice that "exec" value which is supposed to be second command line arg is missing. That in turn results in "/servicex/output/db61f8fb-8910-4aa2aea5-79d25adb1d48" being taken as second argument and third arg will be set to empty string. Here is a snippet from "watch.sh":

```
lang=$1
cmd=$2
path=$3

while true; do
    echo "Greetings from watch script"
    ls $path
    if [ -f $path/*.json ]; then
        for file in `ls $path/*.json`; do
```
"path" will be empty string so json file won't be found and the script loops for ever. It may be worthwhile to make this script more robust but a quick solution is to fail installation if transformer exec is not provided and that is what the PR does.

I see this error when I don't provide exec value:

```
Error: INSTALLATION FAILED: execution error at (servicex/templates/app/deployment.yaml:16:28): Transformer exec value is required
```
