### PR TITLE
Only update values for the single, unified integration test env

### DIFF
--- a/.github/workflows/ci_helm_publish.yaml
+++ b/.github/workflows/ci_helm_publish.yaml
@@ -47,8 +47,7 @@ jobs:
         uses: mikefarah/yq@master
         with:
           cmd: |
-            yq -i '.spec.chart.spec.version = strenv(RELEASE_VERSION) | .spec.chart.spec.version style="double" ' flux_river_configs/servicex-int-uproot/values.yaml &&
-            yq -i '.spec.chart.spec.version = strenv(RELEASE_VERSION) | .spec.chart.spec.version style="double" ' flux_river_configs/servicex-int-xaod/values.yaml &&
+            yq -i '.spec.chart.spec.version = strenv(RELEASE_VERSION) | .spec.chart.spec.version style="double" ' flux_river_configs/servicex-int/values.yaml &&
             yq -i '.appVersion = strenv(RELEASE_VERSION) | .appVersion style="double" | .version = "'$RELEASE_VERSION'"| .version style="double" ' helm/servicex/Chart.yaml &&
             yq -i '.app.tag = strenv(DOCKER_TAG) | .app.tag style="double" |
             .didFinder.rucio.tag = strenv(DOCKER_TAG) | .didFinder.rucio.tag style="double" |

--- a/.github/workflows/ci_helm_publish.yaml
+++ b/.github/workflows/ci_helm_publish.yaml
@@ -54,7 +54,7 @@ jobs:
             .didFinder.CERNOpenData.tag = strenv(DOCKER_TAG) | .didFinder.CERNOpenData.tag style="double" |
             .transformer.sidecarTag = strenv(DOCKER_TAG) | .transformer.sidecarTag style="double" |
             .x509Secrets.tag = strenv(DOCKER_TAG) | .x509Secrets.tag style="double" ' helm/servicex/Chart.yaml &&
-            CODEGENS=$(yq '.codeGen | keys | .[]' helm/servicex/Chart.yaml) && for i in $CODEGENS; do yq -i  '.codeGen.[$i].tag=strenv(DOCKER_TAG) | .codeGen.[$i].tag style="double"' helm/servicex/Chart.yaml && yq -i '.codeGen.[$i].defaultScienceContainerTag=strenv(DOCKER_TAG) | .codeGen.[$i].tag style="double"' helm/servicex/Chart.yaml; done
+            CODEGENS=$(yq '.codeGen | keys | .[]' helm/servicex/Chart.yaml) && for i in $CODEGENS; do yq -i  '.codeGen.[$i].tag=strenv(DOCKER_TAG) | .codeGen.[$i].tag style="double"' helm/servicex/Chart.yaml && yq -i '.codeGen.[$i].defaultScienceContainerTag=strenv(DOCKER_TAG) | .codeGen.[$i].tag style="double"' flux_river_configs/servicex-int/values.yaml; done
       - name: Create helm package
         working-directory: ./helm
         run: |


### PR DESCRIPTION
# Problem 
With the merge of the multiple code-gen serviceX we no longer need the uproot and xAOD integration test environments

# Approach
Unify the update to the single `servicex-int/values.yaml`