### PR TITLE
fix: Set workflow output parameters with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci_helm_tests.yaml
+++ b/.github/workflows/ci_helm_tests.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} )
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/ci_servicex.yaml
+++ b/.github/workflows/ci_servicex.yaml
@@ -27,7 +27,7 @@ jobs:
           content="${content//$'\n'/'%0A'}"
           content="${content//$'\r'/'%0D'}"
           # end of optional handling for multi line json
-          echo "::set-output name=matrix::$content"
+          echo "matrix=$content" >> $GITHUB_OUTPUT
       - run: |
           echo "${{ steps.set-matrix.outputs.matrix }}"
 
@@ -85,12 +85,12 @@ jobs:
       - name: Extract tag name
         working-directory: ${{ matrix.app.dir_name }}
         shell: bash
-        run: echo "##[set-output name=imagetag;]$(echo sslhep/${{matrix.app.image_name}}:${GITHUB_REF##*/})"
+        run: echo "imagetag=$(echo sslhep/${{ matrix.app.image_name }}:${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
         id: extract_tag_name
       - name: Extract Cache Dir
         working-directory: ${{ matrix.app.dir_name }}
         shell: bash
-        run: echo "##[set-output name=cachetag;]$(echo sslhep/${{matrix.app.image_name}}:buildcache)"
+        run: echo "cachetag=$(echo sslhep/${{ matrix.app.image_name }}:buildcache)" >> $GITHUB_OUTPUT
         id: extract_cache_name
       - name: Print Cache Tag Name
         shell: bash

--- a/code_generator_funcadl_uproot/.github/workflows/ci.yaml
+++ b/code_generator_funcadl_uproot/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Extract tag name
         shell: bash
-        run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
+        run: echo "imagetag=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
         id: extract_tag_name
 
       - name: Build Uproot Image

--- a/code_generator_funcadl_xAOD/.github/workflows/ci.yaml
+++ b/code_generator_funcadl_xAOD/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Extract tag name
         shell: bash
-        run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
+        run: echo "imagetag=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
         id: extract_tag_name
 
       - name: Build ATLAS xAOD Image

--- a/code_generator_python/.github/workflows/ci.yaml
+++ b/code_generator_python/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Extract tag name
         shell: bash
-        run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
+        run: echo "imagetag=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
         id: extract_tag_name
 
       - name: Build Uproot Image

--- a/did_finder_cernopendata/.github/workflows/publish.yaml
+++ b/did_finder_cernopendata/.github/workflows/publish.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Extract tag name
         shell: bash
-        run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
+        run: echo "imagetag=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
         id: extract_tag_name
 
       - name: Build DID-Finder Image

--- a/did_finder_rucio/.github/workflows/ci.yaml
+++ b/did_finder_rucio/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Extract tag name
         shell: bash
-        run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
+        run: echo "imagetag=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
         id: extract_tag_name
 
       - name: Build DID-Finder Image

--- a/helm/.github/workflows/check-chart.yaml
+++ b/helm/.github/workflows/check-chart.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} )
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/servicex_app/.github/workflows/ci.yaml
+++ b/servicex_app/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Extract tag name
         shell: bash
-        run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
+        run: echo "imagetag=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
         id: extract_tag_name
 
       - name: Build Docker Image

--- a/transformer_sidecar/.github/workflows/buildpush.yaml
+++ b/transformer_sidecar/.github/workflows/buildpush.yaml
@@ -14,7 +14,7 @@ jobs:
 
     - name: Extract tag name
       shell: bash
-      run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
+      run: echo "imagetag=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
       id: extract_tag_name
 
     - name: Build Sidecar Transformer Image

--- a/x509_secrets/.github/workflows/ci.yaml
+++ b/x509_secrets/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Extract tag name
       shell: bash
-      run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
+      run: echo "imagetag=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
       id: extract_tag_name
 
     - name: Build X509 Image


### PR DESCRIPTION
* Update to use the new GitHub workflow GITHUB_OUTPUT environmental file to avoid problems when the setting 'set-output' via stdout is deprecated in 2023. c.f.:
   - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
   - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
   - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-setting-an-output-parameter