### PR TITLE
Python transformer for multi-tree ROOT output

### DIFF
--- a/code_generator_python/servicex/templates/transform_single_file.py
+++ b/code_generator_python/servicex/templates/transform_single_file.py
@@ -48,7 +48,7 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
                     writer[key] = o_dict
 
             wtime = time.time()
-        elif output_format == 'file':
+        elif output_format == 'raw-file':
             etime = time.time()
             total_events = 0
             output_path = output

--- a/code_generator_python/servicex/templates/transform_single_file.py
+++ b/code_generator_python/servicex/templates/transform_single_file.py
@@ -6,8 +6,10 @@ import generated_transformer
 import awkward as ak
 import pyarrow.parquet as pq
 import uproot
+import numpy as np
 instance = os.environ.get('INSTANCE_NAME', 'Unknown')
 default_tree_name = "servicex"
+default_branch_name = "branch"
 
 
 def transform_single_file(file_path: str, output_path: Path, output_format: str):
@@ -20,20 +22,46 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
     try:
         stime = time.time()
 
-        awkward_array = generated_transformer.run_query(file_path)
-        total_events = ak.num(awkward_array, axis=0)
+        output = generated_transformer.run_query(file_path)
 
         ttime = time.time()
 
         if output_format == 'root-file':
             etime = time.time()
+            if isinstance(output, ak.Array):
+                awkward_arrays = {default_tree_name: output}
+            elif isinstance(output, dict):
+                awkward_arrays = output
             with uproot.recreate(output_path) as writer:
-                writer[default_tree_name] = {field: awkward_array[field] for field in
-                                             awkward_array.fields} if awkward_array.fields \
-                    else awkward_array
-            wtime = time.time()
+                for key in awkward_arrays.keys():
+                    total_events = awkward_arrays[key].__len__()
+                    if awkward_arrays[key].fields and total_events:
+                        o_dict = {field: awkward_arrays[key][field]
+                                  for field in awkward_arrays[key].fields}
+                    elif awkward_arrays[key].fields and not total_events:
+                        o_dict = {field: np.array([])
+                                  for field in awkward_arrays[key].fields}
+                    elif not awkward_arrays[key].fields and total_events:
+                        o_dict = {default_branch_name: awkward_arrays[key]}
+                    else:
+                        o_dict = {default_branch_name: np.array([])}
+                    writer[key] = o_dict
 
+            wtime = time.time()
+        elif output_format == 'file':
+            etime = time.time()
+            total_events = 0
+            output_path = output
+            wtime = time.time()
         else:
+            if isinstance(output, dict):
+                tree_name = list(output.keys()[0])
+                awkward_array = output[tree_name]
+                print(f'Returned type from your Python function is a dictionary - '
+                      f'Only the first key {tree_name} will be written as parquet files. '
+                      f'Please use root-file output to write all trees.')
+            else:
+                awkward_array = output
             explode_records = bool(awkward_array.fields)
             try:
                 arrow = ak.to_arrow_table(awkward_array, explode_records=explode_records)


### PR DESCRIPTION
- User's Python function can also return a dictionary `{tree-name: Awkward array}` to write multi-tree ROOT file when `output_format` is set to `root-file`
- When `parquet` is chosen as output format and a dictionary returned from the user's Python function, the Awkward array of the first key is written as parquet file
- Optionally a file written inside the user's Python function can be output of Python transformer when `output_format` is set to `raw-file` (but not implemented in the ServiceX frontend yet)