### PR TITLE
getting correct IPv6 vs IPv4 preferences

### DIFF
--- a/servicex_app/Dockerfile
+++ b/servicex_app/Dockerfile
@@ -17,6 +17,7 @@ RUN poetry config virtualenvs.create false && \
 COPY *.py docker-dev.conf boot.sh ./
 COPY servicex/ ./servicex
 COPY migrations migrations
+ADD gai.conf /etc/gai.conf
 
 RUN chmod +x boot.sh
 

--- a/servicex_app/gai.conf
+++ b/servicex_app/gai.conf
@@ -1,0 +1,5 @@
+label ::1/128       0
+label ::/0          1
+label 2002::/16     2
+label ::/96         3
+label ::ffff:0:0/96 4

--- a/transformer_sidecar/Dockerfile
+++ b/transformer_sidecar/Dockerfile
@@ -23,6 +23,8 @@ COPY src/ \
     scripts/watch.sh \
     ./
 
+ADD gai.conf /etc/gai.conf
+
 ENV X509_USER_PROXY=/tmp/grid-security/x509up
 ENV X509_CERT_DIR /etc/grid-security/certificates
 

--- a/transformer_sidecar/gai.conf
+++ b/transformer_sidecar/gai.conf
@@ -1,0 +1,5 @@
+label ::1/128       0
+label ::/0          1
+label 2002::/16     2
+label ::/96         3
+label ::ffff:0:0/96 4


### PR DESCRIPTION
By default, k8s deployments will preferentially use IPv4. This PR will make it prefer IPv6, just like a regular OS.

Preference is controlled by /etc/gai.conf file. On regular OS IPv6 is preferred since it is more performant. But on stock kubernetes clusters default is IPv4. 

This change will not affect performance on single stack IPv4 clusters but will improve it on dual stack ones. 