### PR TITLE
Move migrate to init and remove redundant db.init

### DIFF
--- a/servicex_app/servicex/__init__.py
+++ b/servicex_app/servicex/__init__.py
@@ -46,10 +46,11 @@ from servicex.object_store_manager import ObjectStoreManager
 from servicex.rabbit_adaptor import RabbitAdaptor
 from servicex.routes import add_routes
 from servicex.transformer_manager import TransformerManager
-
+from flask_migrate import Migrate
 from servicex.models import db
 
 instance = os.environ.get('INSTANCE_NAME', 'Unknown')
+migrate = Migrate()
 
 
 class StreamFormatter(logging.Formatter):
@@ -198,7 +199,12 @@ def create_app(test_config=None,
 
     with app.app_context():
         db.init_app(app)
-        db.create_all()
+
+        if test_config:
+            db.create_all()
+
+        migrate.init_app(app, db)
+
         # Validate did-finder scheme
         schemes = app.config['VALID_DID_SCHEMES']
         if app.config['DID_FINDER_DEFAULT_SCHEME'] not in schemes:

--- a/servicex_app/servicex/app.py
+++ b/servicex_app/servicex/app.py
@@ -26,13 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from flask_migrate import Migrate
-
-from servicex.models import db
 
 from . import create_app
 
 app = create_app()
-db.init_app(app)
-
-migrate = Migrate(app, db)


### PR DESCRIPTION
Previously we initialised the db twice, once inside create_app() and once in app.py, and SQLAlchemy/Flask did not seem to mind. Now, we are not allowed to initalise the db more than once per flask app.  We now initialise the db and perform migrations (without the db.create_all() call, as the migrations take care of the create_all() function call) for the happy case. 