### PR TITLE
Add user commands to list and approve users

### DIFF
--- a/servicex_app/servicex/__init__.py
+++ b/servicex_app/servicex/__init__.py
@@ -38,7 +38,7 @@ from flask_bootstrap import Bootstrap5
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
 from flask_restful import Api
-from servicex.cli.add_user import add_user
+from servicex.cli.user_commands import add_user, list_users, approve_user
 from servicex.code_gen_adapter import CodeGenAdapter
 from servicex.docker_repo_adapter import DockerRepoAdapter
 from servicex.lookup_result_processor import LookupResultProcessor
@@ -136,7 +136,7 @@ def create_app(test_config=None,
     """Create and configure an instance of the Flask application."""
     app = Flask(__name__, instance_relative_config=True)
 
-    """Flask CLI Plugin to create user using CLI"""
+    """Flask CLI Plugin to manage users"""
     user_cli = AppGroup('user')
 
     @user_cli.command('create')
@@ -151,6 +151,15 @@ def create_app(test_config=None,
                  name=name,
                  institution=institution,
                  refresh_token=refresh_token)
+
+    @user_cli.command('list')
+    def list_users_command():
+        list_users()
+
+    @user_cli.command('approve')
+    @click.argument('sub')
+    def approve_user_command(sub):
+        approve_user(sub)
 
     app.cli.add_command(user_cli)
 

--- a/servicex_app/servicex/cli/user_commands.py
+++ b/servicex_app/servicex/cli/user_commands.py
@@ -25,3 +25,23 @@ def add_user(sub, email, name, institution, refresh_token):
             new_user.save_to_db()
     except Exception as ex:
         print(str(ex))
+
+
+def list_users() -> None:
+    users = UserModel.query.all()
+    print("Sub, Email, Name, Institution, Pending?")
+    for user in users:
+        print(", ".join([user.sub, user.email, user.name, user.institution,
+                         "Pending" if user.pending else "Approved"]))
+
+
+def approve_user(sub: str) -> None:
+    user = UserModel.find_by_sub(sub)
+    if user and user.pending:
+        user.pending = False
+        user.save_to_db()
+        print(f"User {sub} approved")
+    elif user and not user.pending:
+        print(f"User {sub} already approved")
+    else:
+        print(f"User {sub} not found")


### PR DESCRIPTION
# Problem
Some sites can't use the slack approval workflow. They need a way for admins to approve new users

Fixes #636 
# Approach
Add new flask commands. Admins will have to create a shell into a running app pod to execute the commands

New commands
`flask user list` - lists all users in the database along with their pending status

`flask user approve <sub>` - Approve a pending user

Changed the name of the python file containing these commands since they do more than just create user