### PR TITLE
ci: Add Dependabot config to group update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Maintain dependencies for poetry
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "python"


### PR DESCRIPTION
Add config file for Dependabot updates that groups any updates for GitHub Actions or for poetry into weekly PRs to avoid lots of noisy PRs if there are multiple updates. This would make PRs like PR https://github.com/ssl-hep/ServiceX/pull/700 automated.
- c.f. https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

More info in the [Scientific Python Development Guide](https://learn.scientific-python.org/development/guides/gha-basic/#GH200) also.