### PR TITLE
simplify secret naming. 

### DIFF
--- a/helm/servicex/templates/app/configmap.yaml
+++ b/helm/servicex/templates/app/configmap.yaml
@@ -89,7 +89,7 @@ data:
     TRANSFORMER_MAX_REPLICAS = {{ .Values.transformer.autoscaler.maxReplicas }}
     TRANSFORMER_MANAGER_MODE = 'internal-kubernetes'
     {{- if not .Values.noCerts }}
-    TRANSFORMER_X509_SECRET="{{ .Release.Name }}-x509-proxy"
+    TRANSFORMER_X509_SECRET="x509-proxy"
     {{- else }}
     TRANSFORMER_X509_SECRET=None
     {{- end }}

--- a/helm/servicex/templates/x509-secrets/deployment.yaml
+++ b/helm/servicex/templates/x509-secrets/deployment.yaml
@@ -4,16 +4,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-x509-secrets
+  name: x509-secrets
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-x509-secrets
+      app: x509-secrets
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-x509-secrets
+        app: x509-secrets
     spec:
       serviceAccountName: {{ template "servicex.fullname" . }}
       # Before launching the main container, copy the certs and set their permissions accordingly
@@ -31,10 +31,10 @@ spec:
           - name: grid-secret
             mountPath: /etc/grid-certs-ro/
       containers:
-      - name: {{ .Release.Name }}-x509-secrets
+      - name: x509-secrets
         image: {{ .Values.x509Secrets.image }}:{{ .Values.x509Secrets.tag }}
         command: ["bash","-c"]
-        args: ["python3 x509_updater.py --secret {{ .Release.Name }}-x509-proxy --voms {{ .Values.x509Secrets.vomsOrg }}"]
+        args: ["python3 x509_updater.py --secret x509-proxy --voms {{ .Values.x509Secrets.vomsOrg }}"]
         env:
           - name: MY_POD_NAME
             valueFrom:

--- a/helm/servicex/templates/x509-secrets/proxy-secret.yaml
+++ b/helm/servicex/templates/x509-secrets/proxy-secret.yaml
@@ -5,11 +5,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-x509-proxy
+  name: x509-proxy
   labels:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app: {{ .Release.Name }}
+    app: app
 type: Opaque
 {{- end }}

--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -139,7 +139,7 @@ transformer:
   scienceContainerPullPolicy: Always
 
   language: python
-  exec: # replace me
+  exec:                # replace me
   outputDir: /servicex/output
 
   persistence:

--- a/servicex_app/app.conf.template
+++ b/servicex_app/app.conf.template
@@ -40,7 +40,7 @@ TRANSFORMER_PRIORITY_CLASS = None
 # This will be mounted into the transformer pod's /data directory
 TRANSFORMER_LOCAL_PATH="/Users/bengal1/dev/IRIS-HEP/data"
 TRANSFORMER_NAMESPACE="default"
-TRANSFORMER_X509_SECRET="aspiring-mole-x509-proxy"
+TRANSFORMER_X509_SECRET="x509-proxy"
 
 ADVERTISED_HOSTNAME= 'host.docker.internal:5000'
 

--- a/servicex_app/docker-dev.conf
+++ b/servicex_app/docker-dev.conf
@@ -21,7 +21,7 @@ RABBIT_RETRY_INTERVAL = 10
 # This will be mounted into the transformer pod's /data directory
 TRANSFORMER_LOCAL_PATH="/Users/bengal1/dev/IRIS-HEP/data"
 TRANSFORMER_NAMESPACE="default"
-TRANSFORMER_X509_SECRET="servicex-x509-proxy"
+TRANSFORMER_X509_SECRET="x509-proxy"
 TRANSFORMER_PULL_POLICY="IfNotPresent"
 
 TRANSFORMER_VALIDATE_DOCKER_IMAGE = True


### PR DESCRIPTION
makes it possible to test servicexlite against testing instances.
there is really no reason to add instance name since helm deploys in different namespaces. other secrets don't have instance name prepended.  