### PR TITLE
Increase rabbitMQ consumer timeout to one hour.

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -121,6 +121,9 @@ rabbitmq:
     enabled: false
   volumePermissions:
     enabled: true
+  extraConfiguration: |-
+    consumer_timeout = 3600000
+
 rbacEnabled: true
 secrets: null
 transformer:


### PR DESCRIPTION
During IDAP 200Gb challenge testing we found that very large datasets can take longer than 30 minutes to report from the DID finder back to the app. There is a default setting of 1/2 hour for a message to be ack-ed before closing the channel and putting the message back in the queue.

Increasing this value to 1 hour to avoid this problem.