### PR TITLE
Don't Allow Transformer Pod to Die While there are still files to upload to object stpore

### DIFF
--- a/transformer_sidecar/src/transformer_sidecar/object_store_uploader.py
+++ b/transformer_sidecar/src/transformer_sidecar/object_store_uploader.py
@@ -25,8 +25,8 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import os
 import logging
+import os
 import threading
 from pathlib import Path
 from queue import Queue
@@ -61,10 +61,10 @@ class ObjectStoreUploader(threading.Thread):
     def service_work_queue(self):
         while True:
             item = self.input_queue.get()
-            self.logger.info("OSU Item received!", extra={
-                             'requestId': self.request_id, "place": PLACE})
+
+            # When we receive the poison pill, we're done.
             if item.is_complete():
-                self.logger.info("OSU Queue done!",
+                self.logger.info("Object store uploader done!",
                                  extra={'requestId': self.request_id, "place": PLACE})
                 break
             else:
@@ -77,9 +77,15 @@ class ObjectStoreUploader(threading.Thread):
                     file_to_upload = item.source_path
                     object_name = item.source_path.name
 
+                self.logger.info("Uploading file to object store.",
+                                 extra={'requestId': self.request_id, "place": PLACE,
+                                        "objectName": object_name})
                 self.object_store.upload_file(self.request_id,
                                               object_name,
                                               file_to_upload.as_posix())
+                self.logger.info("File uploaded to object store.",
+                                 extra={'requestId': self.request_id, "place": PLACE,
+                                        "objectName": object_name})
 
     def convert_to_parquet(self, source_path: Path) -> Optional[Path]:
         """


### PR DESCRIPTION
# Problem
As soon as a transform of a file is complete, the sidecar notifies the app. Meanwhile a separate thread is responsible for uploading the transformed files to Object Store. When the app decides that the last file has been transformed it sends the signal to shutdown all of the transformers. The problem is that the uploads to S3 may still be pending and so we lose files.

# Approach
The Kubernetes control plan sends a SIGTERM signal to the main process in the pod container to terminate the transformers. This PR adds a handler for this which sends a poison pill message through the queue to the object store uploader. When that thread reaches this item it shuts down cleanly.

Then transformer app now waits for this thread to exit before exiting which then clears the way for the pod to terminate.

We increase the termination grace period to 5 minutes to really make sure we can save all of the files. At this time we can also remove the sleep that was added between the last file processed notice being received and the transformers being shut down in the app.

In working on this PR I discovered that the RabbitMQManager constructor blocked. I made it it's own thread and start it too.
