### PR TITLE
Update the transform request document to show the title as well as a URL for the Logs

### DIFF
--- a/servicex_app/servicex/models.py
+++ b/servicex_app/servicex/models.py
@@ -202,6 +202,7 @@ class TransformRequest(db.Model):
         iso_fmt = '%Y-%m-%dT%H:%M:%S.%fZ'
         result_obj = {
             'request_id': self.request_id,
+            'title': self.title,
             'did': self.did,
             'did_id': self.did_id,
             'selection': self.selection,

--- a/servicex_app/servicex/resources/transformation/get_one.py
+++ b/servicex_app/servicex/resources/transformation/get_one.py
@@ -51,4 +51,7 @@ class TransformationRequest(ServiceXResource):
             transform_json['minio-secured'] = current_app.config.get('MINIO_ENCRYPT_PUBLIC', True)
             transform_json['minio-access-key'] = current_app.config['MINIO_ACCESS_KEY']
             transform_json['minio-secret-key'] = current_app.config['MINIO_SECRET_KEY']
+
+        if 'LOGS_URL' in current_app.config:
+            transform_json['log-url'] = current_app.config['LOGS_URL']
         return transform_json

--- a/servicex_app/tests/resource_test_base.py
+++ b/servicex_app/tests/resource_test_base.py
@@ -139,6 +139,7 @@ class ResourceTestBase:
     def _generate_transform_request():
         transform_request = TransformRequest()
         transform_request.submit_time = datetime.min
+        transform_request.title = 'Test Transformation'
         transform_request.finish_time = None
         transform_request.request_id = 'BR549'
         transform_request.columns = 'electron.eta(), muon.pt()'

--- a/servicex_app/tests/resources/transformation/test_get_one.py
+++ b/servicex_app/tests/resources/transformation/test_get_one.py
@@ -9,9 +9,14 @@ class TestTransformationRequest(ResourceTestBase):
             servicex.models.TransformRequest,
             'lookup',
             return_value=self._generate_transform_request())
-        client = self._test_client(extra_config={'OBJECT_STORE_ENABLED': False})
+        client = self._test_client(extra_config={
+            'OBJECT_STORE_ENABLED': False,
+            'LOGS_URL': 'https://log.servicex.com'
+        })
         response = client.get('/servicex/transformation/1234')
         assert response.status_code == 200
+        assert response.json['log-url'] == 'https://log.servicex.com'
+        assert response.json['title'] == 'Test Transformation'
         transform = response.json
 
         assert transform['request_id'] == 'BR549'


### PR DESCRIPTION
# Problem
The client needs to know how to fetch error logs from Kabana. Also, when the client polls the transforms it doesn't get the transform title

# Approach
Add two fields to the transform request document