### PR TITLE
Update default science image for python codegen

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -62,7 +62,7 @@ codeGen:
     image: sslhep/servicex_code_gen_python
     pullPolicy: Always
     tag: develop
-    defaultScienceContainerImage: sslhep/servicex_func_adl_xaod_transformer
+    defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
     defaultScienceContainerTag: develop
 didFinder:
   CERNOpenData:


### PR DESCRIPTION
Noticed that the default science image for the python code-gen won't work - seems to be an old mistake that is usually overridden in our deployments