### PR TITLE
Remove debug statement that was causing KeyError

### DIFF
--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -388,8 +388,6 @@ if __name__ == "__main__":
     with open(capabilities_file_path) as capabilities_file:
         transformer_capabilities = json.load(capabilities_file)
 
-    logger.debug('transformer capabilities', extra=transformer_capabilities)
-
     # If the user requested Parquet, but the transformer isn't capable of producing it,
     # then we will convert here....
     convert_root_to_parquet = args.result_format == 'parquet' and \


### PR DESCRIPTION
# Problem
The transformer sidecar starts with a debug log statement that include the contents of the code generator's capabilities file in the `extras` argument. This has a property called `name` which seems to clash with the inner workings of the logger.

Fixes #805 

# Approach
It's doubtful anyone ever needed this statement, so I just removed it