### PR TITLE
Fix for #807

### DIFF
--- a/code_generator_funcadl_uproot/uproot_code_generator/templates/transform_single_file.py
+++ b/code_generator_funcadl_uproot/uproot_code_generator/templates/transform_single_file.py
@@ -27,10 +27,11 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
 
         if output_format == 'root-file':
             etime = time.time()
-            with uproot.recreate(output_path) as writer:
-                writer[default_tree_name] = {field: awkward_array[field] for field in
-                                             awkward_array.fields} if awkward_array.fields \
-                    else awkward_array
+            with open(output_path, 'b+w') as wfile:
+                with uproot.recreate(wfile) as writer:
+                    writer[default_tree_name] = {field: awkward_array[field] for field in
+                                                 awkward_array.fields} if awkward_array.fields \
+                        else awkward_array
             wtime = time.time()
 
         else:

--- a/code_generator_python/python_code_generator/templates/transform_single_file.py
+++ b/code_generator_python/python_code_generator/templates/transform_single_file.py
@@ -32,20 +32,21 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
                 awkward_arrays = {default_tree_name: output}
             elif isinstance(output, dict):
                 awkward_arrays = output
-            with uproot.recreate(output_path) as writer:
-                for key in awkward_arrays.keys():
-                    total_events = awkward_arrays[key].__len__()
-                    if awkward_arrays[key].fields and total_events:
-                        o_dict = {field: awkward_arrays[key][field]
-                                  for field in awkward_arrays[key].fields}
-                    elif awkward_arrays[key].fields and not total_events:
-                        o_dict = {field: np.array([])
-                                  for field in awkward_arrays[key].fields}
-                    elif not awkward_arrays[key].fields and total_events:
-                        o_dict = {default_branch_name: awkward_arrays[key]}
-                    else:
-                        o_dict = {default_branch_name: np.array([])}
-                    writer[key] = o_dict
+            with open(output_path, 'b+w') as wfile:
+                with uproot.recreate(wfile) as writer:
+                    for key in awkward_arrays.keys():
+                        total_events = awkward_arrays[key].__len__()
+                        if awkward_arrays[key].fields and total_events:
+                            o_dict = {field: awkward_arrays[key][field]
+                                      for field in awkward_arrays[key].fields}
+                        elif awkward_arrays[key].fields and not total_events:
+                            o_dict = {field: np.array([])
+                                      for field in awkward_arrays[key].fields}
+                        elif not awkward_arrays[key].fields and total_events:
+                            o_dict = {default_branch_name: awkward_arrays[key]}
+                        else:
+                            o_dict = {default_branch_name: np.array([])}
+                        writer[key] = o_dict
 
             wtime = time.time()
         elif output_format == 'raw-file':

--- a/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
+++ b/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
@@ -142,7 +142,7 @@ def run_single_query(file_path, query):
                     if 'cut' in sanitized_args:
                         sanitized_args.pop('cut')
                     arr = t.arrays(language=lang, entry_stop=0, **sanitized_args)
-                    rv_arrays_trees[outtreename] = (arr, None)
+                    rv_arrays_trees[outtreename] = (None, {{_: arr[_].type for _ in arr.fields}})
         else:
             histograms = query['copy_histograms']
             keys = fl.keys(filter_name=histograms, cycle=False)

--- a/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
+++ b/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
@@ -136,13 +136,13 @@ def run_single_query(file_path, query):
                         arr = subarr
                     else:
                         arr = ak.concatenate([arr, subarr])
-                if len(arr):
+                if arr is not None and len(arr):  # iterate will not give anything if tree empty
                     rv_arrays_trees[outtreename] = (arr, None)
-                else: # want to return empty tree, but need to extract metadata to do so
+                else:  # recent uproot handles zero-length case properly for arrays()
                     if 'cut' in sanitized_args:
                         sanitized_args.pop('cut')
-                    arr = t.arrays(language=lang, entry_stop=1, **sanitized_args)
-                    rv_arrays_trees[outtreename] = (None, {{_: arr[_].type for _ in arr.fields}})
+                    arr = t.arrays(language=lang, entry_stop=0, **sanitized_args)
+                    rv_arrays_trees[outtreename] = (arr, None)
         else:
             histograms = query['copy_histograms']
             keys = fl.keys(filter_name=histograms, cycle=False)

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -42,6 +42,7 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
                 for k, v in histograms.items():
                     writer[k] = v
                 print('writer', writer.keys())
+                print('file path?', writer.file_path)
             wtime = time.time()
 
         else:

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -47,7 +47,6 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
             for treename, subarray in awkward_array_dict.items():
                 subarray['treename'] = treename
             awkward_array = awkward_array_dict.popitem()[1]
-            print(ak.type(awkward_array))
             for treename, subarray in awkward_array_dict.items():
                 awkward_array = ak.concatenate([awkward_array, subarray])
                 print(ak.type(subarray), ak.type(awkward_array))

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -34,7 +34,7 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
             with open(output_path, 'b+w') as wfile:
                 with uproot.recreate(wfile) as writer:
                     for k, v in awkward_array_dict.items():
-                        if v[0] is not None:
+                        if v[0] is not None and len(v[0]) > 0:
                             writer[k] = {field: v[0][field] for field in
                                          v[0].fields} if v[0].fields \
                                 else v[0]

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -25,11 +25,13 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
                             if awkward_array[0] is not None), 0)
 
         ttime = time.time()
+        print(total_events, output_path, output_format, awkward_array_dict, histograms)
 
         if output_format == 'root-file':
             import uproot
             etime = time.time()
             with uproot.recreate(output_path) as writer:
+                print('got in here')
                 for k, v in awkward_array_dict.items():
                     if v[0] is not None:
                         writer[k] = {field: v[0][field] for field in

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -31,7 +31,7 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
             import uproot
             etime = time.time()
             with uproot.recreate(output_path) as writer:
-                print('got in here')
+                print('got in here', writer)
                 for k, v in awkward_array_dict.items():
                     if v[0] is not None:
                         writer[k] = {field: v[0][field] for field in
@@ -41,6 +41,7 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
                         writer.mktree(k, v[1])
                 for k, v in histograms.items():
                     writer[k] = v
+                print('writer', writer.keys())
             wtime = time.time()
 
         else:

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -34,7 +34,7 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
             with open(output_path, 'b+w') as wfile:
                 with uproot.recreate(wfile) as writer:
                     for k, v in awkward_array_dict.items():
-                        if v[0] is not None and len(v[0]) > 0:
+                        if v[0] is not None:
                             writer[k] = {field: v[0][field] for field in
                                          v[0].fields} if v[0].fields \
                                 else v[0]

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -30,7 +30,7 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
         if output_format == 'root-file':
             import uproot
             etime = time.time()
-            with uproot.recreate(output_path) as writer:
+            with uproot.recreate(Path(output_path)) as writer:
                 print('got in here', writer)
                 for k, v in awkward_array_dict.items():
                     if v[0] is not None:

--- a/code_generator_raw_uproot/tests/test_src.py
+++ b/code_generator_raw_uproot/tests/test_src.py
@@ -50,7 +50,7 @@ def test_generate_code():
                              'filter_name': ['lbn']},
                             {'copy_histograms': 'CutBookkeeper*'}
                             ])
-        expected_hash = "15733130589c04ecef2e7724fe544583"
+        expected_hash = "39d5be3ad995e2c17559c6678960cf84"
         result = translator.generate_code(query, tmpdirname)
 
         # is the generated code at least syntactically valid Python?

--- a/code_generator_raw_uproot/tests/test_src.py
+++ b/code_generator_raw_uproot/tests/test_src.py
@@ -50,7 +50,7 @@ def test_generate_code():
                              'filter_name': ['lbn']},
                             {'copy_histograms': 'CutBookkeeper*'}
                             ])
-        expected_hash = "0fa47fd44a792a80fe70ec023a99a41d"
+        expected_hash = "15733130589c04ecef2e7724fe544583"
         result = translator.generate_code(query, tmpdirname)
 
         # is the generated code at least syntactically valid Python?


### PR DESCRIPTION
When using `uproot.iterate` with an empty tree, or one where the cuts remove all output, the existing code will encounter a condition where it tries to take the length of `None`. Protect against this, and also update later logic since newer uproot versions will handle `arrays` on an empty tree properly.

Also introduce workarounds for `uproot` 5.3.9 handling of colons in filenames (it incorrectly applies URL cleanups).