### PR TITLE
Make celery worker dockerfiles work on OpenShift

### DIFF
--- a/did_finder_cernopendata/Dockerfile
+++ b/did_finder_cernopendata/Dockerfile
@@ -5,10 +5,10 @@ LABEL maintainer="Gordon Watts <gwatts@uw.edu>"
 USER root
 
 # Create app directory
-WORKDIR /usr/src/app
+WORKDIR /opt/servicex
 
-# Create celery user
-RUN useradd -ms /bin/bash celery
+# Create celery user. Assign them to group zero since that is the group OpenShift will run the container as
+RUN useradd -g 0 -ms /bin/bash celery
 
 ENV  POETRY_VERSION=1.5.1
 
@@ -25,19 +25,23 @@ COPY poetry.lock poetry.lock
 
 # Bring over the main scripts
 COPY . .
-# Change ownership of the app directory to celery user
-RUN chown -R celery:celery /usr/src/app
+
+ENV XDG_CONFIG_HOME=/opt/servicex
+RUN poetry config virtualenvs.in-project true
+RUN poetry install --no-root --no-interaction --no-ansi
+
+# Change ownership of the app directory to celery user. Also set the group to zero since
+# that is the group OpenShift will run the container as
+RUN chown -R celery:0 /opt/servicex
+RUN chmod -R g=u /opt/servicex
 
 # Switch to celery user
 USER celery
 
-RUN  poetry install --no-root --no-interaction --no-ansi
-
 # Make sure python isn't buffered
 ENV PYTHONUNBUFFERED=1
 
-ENV PYTHONPATH=/usr/src/app/src
-
+ENV PYTHONPATH=/opt/servicex/src
 ENV BROKER_URL="amqp://guest:guest@localhost:5672//"
 
 ENTRYPOINT [ "scripts/start_celery_worker.sh"]

--- a/did_finder_rucio/Dockerfile
+++ b/did_finder_rucio/Dockerfile
@@ -3,10 +3,10 @@ FROM sslhep/rucio-client:main
 LABEL maintainer="Ilija Vukotic <ivukotic@uchicago.edu>"
 
 # Create app directory
-WORKDIR /usr/src/app
+WORKDIR /opt/servicex
 
-# Create celery user
-RUN useradd -ms /bin/bash celery
+# Create celery user. Assign them to group zero since that is the group OpenShift will run the container as
+RUN useradd -g 0 -ms /bin/bash celery
 
 # for CA certificates
 RUN mkdir -p /etc/grid-security/certificates /etc/grid-security/vomsdir
@@ -22,24 +22,24 @@ ENV POETRY_VERSION=1.2.2
 RUN python3 -m pip install --upgrade pip
 
 RUN pip install poetry==$POETRY_VERSION
+RUN mkdir -p /opt/servicex/pypoetry
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock
 
-RUN poetry config virtualenvs.create false && \
-    poetry install --no-root --no-interaction --no-ansi
+ENV XDG_CONFIG_HOME=/opt/servicex
+RUN poetry config virtualenvs.in-project true
+RUN poetry install --no-root --no-interaction --no-ansi
 
 COPY . .
 
-# Change ownership of the app directory to celery user
-RUN chown -R celery:celery /usr/src/app
-
-
-# build
-RUN echo "Timestamp:" `date --utc` | tee /image-build-info.txt
+# Change ownership of the app directory to celery user. Also set the group to zero since
+# that is the group OpenShift will run the container as
+RUN chown -R celery:0 /opt/servicex
+RUN chmod -R g=u /opt/servicex
 
 ENV X509_USER_PROXY=/tmp/grid-security/x509up
 ENV X509_CERT_DIR=/etc/grid-security/certificates
-ENV PYTHONPATH=/usr/src/app/src
+ENV PYTHONPATH=/opt/servicex/src
 
 ENV BROKER_URL="amqp://guest:guest@localhost:5672//"
 

--- a/did_finder_rucio/scripts/start_celery_worker.sh
+++ b/did_finder_rucio/scripts/start_celery_worker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-/usr/src/app/proxy-exporter.sh &
+/opt/servicex/proxy-exporter.sh &
 
 while true; do
     date

--- a/did_finder_xrootd/Dockerfile
+++ b/did_finder_xrootd/Dockerfile
@@ -3,10 +3,11 @@ FROM python:3.10
 LABEL maintainer="Peter Onyisi <ponyisi@utexas.edu>"
 
 # Create app directory
-WORKDIR /usr/src/app
+WORKDIR /opt/servicex
 
-# Create celery user
-RUN useradd -ms /bin/bash celery
+# Create celery user. Assign them to group zero since that is the group OpenShift will run the container as
+RUN useradd -g 0 -ms /bin/bash celery
+RUN chmod -R g=u /opt/servicex
 
 ENV  POETRY_VERSION=1.5.1
 
@@ -18,22 +19,24 @@ RUN pip install poetry==$POETRY_VERSION
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock
 
-# Change ownership of the app directory to celery user
-RUN chown -R celery:celery /usr/src/app
-
-# Switch to celery user
-USER celery
-
-RUN  poetry install --no-root --no-interaction --no-ansi
+ENV XDG_CONFIG_HOME=/opt/servicex
+RUN poetry config virtualenvs.in-project true
+RUN poetry install --no-root --no-interaction --no-ansi
 
 # Bring over the main scripts
 COPY . .
 
+# Change ownership of the app directory to celery user. Also set the group to zero since
+# that is the group OpenShift will run the container as
+RUN chown -R celery:0 /opt/servicex
+
+# Switch to celery user
+USER celery
 
 # Make sure python isn't buffered
 ENV PYTHONUNBUFFERED=1
 
-ENV PYTHONPATH=/usr/src/app/src
+ENV PYTHONPATH=/opt/servicex/src
 
 ENV BROKER_URL="amqp://guest:guest@localhost:5672//"
 


### PR DESCRIPTION
# Problem
OpenShift creates unique users to run inside the pods. This disables all user management configured in the Dockerfile. DID Finder pods were all failing with permission errors.

# Approach
Following this [OpenShift guide](https://developers.redhat.com/blog/2020/10/26/adapting-docker-and-kubernetes-containers-to-run-on-red-hat-openshift-container-platform#) we use the assumption that no matter who the user is, OpenShift will run the container in group 0.

Updated the Dockerfiles:
1. Create the celery user  in group 0 to insure compatibility with non-openshift clusters
2. Change the group ownership of the /opt/servicex directory to zero 
3. Update read and write permissions to include anyone in group 0
4. Make sure that all poetry file and directory creation occurs as root, before we change to the `celery` user and update permissions (some files were being created after this and didn't get updated permissions)
5. During testing, I became suspicious of putting the source code in `/usr/app` and moved everything to the more expected `/opt/servicex` directory.