### PR TITLE
Local Test Harness

### DIFF
--- a/local_test_harness/.env
+++ b/local_test_harness/.env
@@ -1,0 +1,6 @@
+BASH_ENV='/servicex/.bashrc'
+LOG_LEVEL=DEBUG
+SCIENCE=sslhep/servicex_func_adl_uproot_transformer:uproot5
+CODEGEN=sslhep/servicex_code_gen_raw_uproot:develop
+LOCAL_FOLDER=./temp1
+PORT=8005

--- a/local_test_harness/README.md
+++ b/local_test_harness/README.md
@@ -1,0 +1,36 @@
+Local Test Harness for running the codegen and science image for the root file
+
+### Step1. Configure the config.yml file
+```yaml
+    TestName: local test
+    codegen: 
+    port: 8005 
+    query: '[{"treename": {"nominal": "modified"}, "filter_name": ["lbn"]}]' #provide the query as string
+
+    science:
+    rootfile: root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/user/mgeyik/e7/ee/user.mgeyik.30182995._000093.out.root
+    outputfile: /generated/out.parquet
+    outputformat: root-file
+```
+
+### Step2. Configure the .env for the compose file
+```yaml
+BASH_ENV='/servicex/.bashrc'
+LOG_LEVEL=DEBUG
+SCIENCE=sslhep/servicex_func_adl_uproot_transformer:uproot5 #science image
+CODEGEN=sslhep/servicex_code_gen_raw_uproot:develop #codegen image
+LOCAL_FOLDER=./temp1 #local folder where you want output files
+PORT=8005 # port number for your codegen
+```
+
+### Step3. Setup the proxy and run
+```shell
+python test.py --proxy_image <name of proxy_image>
+```
+
+OR if you already have the proxy setup in your `/tmp`
+
+```shell
+python test.py
+```
+The default proxy image: `sslhep/x509-secrets:develop`

--- a/local_test_harness/compose.yml
+++ b/local_test_harness/compose.yml
@@ -1,0 +1,23 @@
+services:
+
+  codegen:
+    image: $CODEGEN 
+    env_file: .env
+    pull_policy: missing
+    ports:
+      - $PORT:5000
+
+  science:
+    image: $SCIENCE 
+    pull_policy: missing
+    env_file: .env
+    volumes:
+      - sidecar-volume:/servicex/output
+      - /tmp:/tmp/grid-security/
+      - $LOCAL_FOLDER:/generated
+    tty: true
+    depends_on:
+      - codegen
+
+volumes:
+  sidecar-volume:

--- a/local_test_harness/config.yml
+++ b/local_test_harness/config.yml
@@ -1,0 +1,9 @@
+TestName: local test
+codegen: 
+  port: 8005
+  query: '[{"treename": {"nominal": "modified"}, "filter_name": ["lbn"]}]'
+
+science:
+  rootfile: root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/user/mgeyik/e7/ee/user.mgeyik.30182995._000093.out.root
+  outputfile: /generated/out.parquet
+  outputformat: root-file

--- a/local_test_harness/test.py
+++ b/local_test_harness/test.py
@@ -1,0 +1,101 @@
+"""
+Step 0: Start the codegen container
+Step 1: Send the request with the query
+Step 3: Set up the x509 proxy at /tmp -- do this manually because you have to provide passphrase
+Step 4: Run the docker compose up with the relevant root file
+
+Input: Query, Root file and output format
+"""
+import requests
+import subprocess
+import os
+from requests_toolbelt.multipart import decoder
+from io import BytesIO
+from zipfile import ZipFile
+import time
+import yaml
+import argparse
+
+
+class ConfigReader:
+    
+    def __init__(self, file):
+        self._file = file
+        self._config = None
+
+    def read_config_file(self):
+        with open(self._file) as yaml_file:
+            self._config = yaml.safe_load(yaml_file.read())
+
+    def get_config(self):
+        return self._config
+
+def docker_compose_up():
+    subprocess.run(["docker", "compose", "up", "-d", "--remove-orphans"])
+
+def docker_compose_down():
+    subprocess.run(["docker", "compose", "down"])
+
+def send_request(query, port):
+    post_url = f"http://localhost:{port}"
+    postObj = {"code": query}
+    result = requests.post(post_url + "/servicex/generated-code", json=postObj)
+    return result
+
+
+def generate_zipfile(result, output_folder):
+    decoder_parts = decoder.MultipartDecoder.from_response(result)
+    zipfile = decoder_parts.parts[3].content
+    zipfile = ZipFile(BytesIO(zipfile))
+
+    if not os.path.exists(output_folder):
+        os.mkdir(output_folder)
+    zipfile.extractall(output_folder)
+
+
+def run_docker_compose_for_science(image, filepath):
+    subprocess.run(["docker", "compose", "up", "-d", "--remove-orphans"])
+
+
+def send_root_file_to_science(root_file, output_file, output_format):
+    subprocess.run(["docker", "compose", "run", "science", "python",
+                    "/generated/transform_single_file.py",
+                    root_file, output_file, output_format])
+
+
+def run_x509_proxy(proxy_image = "sslhep/x509-secrets:develop"):
+    my_env = os.environ.copy()
+    subprocess.run(["docker" ,"run", "-it", "--mount", f"type=bind,source={my_env['HOME']}/.globus,readonly,target=/globus",
+                    "-v", "/tmp:/tmp", "--rm", proxy_image,
+                    "voms-proxy-init", "-voms", "atlas", "-cert",
+                    "/globus/usercert.pem", "-key", "/globus/userkey.pem" ,"-out", "/tmp/x509up"
+                    ]
+                    )
+
+
+if __name__ == "__main__":
+    try:
+        parser = argparse.ArgumentParser(description='Run the servicex codegen and science container')
+        parser.add_argument('--proxy_image', help='Run the x509 proxy for image')
+        args = parser.parse_args()
+        if args.proxy_image:
+            run_x509_proxy(proxy_image = args.proxy_image)
+        
+        a = ConfigReader("config.yml")
+        a.read_config_file()
+        docker_compose_up()
+        time.sleep(10)
+
+        result = send_request(
+                            query=a.get_config()['codegen']['query'] , #query,#,
+                            port=a.get_config()['codegen']['port'])
+        generate_zipfile(result, output_folder="temp1")
+
+
+        send_root_file_to_science(
+            root_file= a.get_config()['science']['rootfile'],
+            output_file=a.get_config()['science']['outputfile'],
+            output_format=a.get_config()['science']['outputformat']
+        )
+    finally:
+        docker_compose_down()


### PR DESCRIPTION
## Local Test Harness for running the codegen and science image for the root file

### Step1. Configure the config.yml file
```yaml
    TestName: local test
    codegen: 
    port: 8005 
    query: '[{"treename": {"nominal": "modified"}, "filter_name": ["lbn"]}]' #provide the query as string

    science:
    rootfile: root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/user/mgeyik/e7/ee/user.mgeyik.30182995._000093.out.root
    outputfile: /generated/out.parquet
    outputformat: root-file
```

### Step2. Configure the .env for the compose file
```yaml
BASH_ENV='/servicex/.bashrc'
LOG_LEVEL=DEBUG
SCIENCE=sslhep/servicex_func_adl_uproot_transformer:uproot5 #science image
CODEGEN=sslhep/servicex_code_gen_raw_uproot:develop #codegen image
LOCAL_FOLDER=./temp1 #local folder where you want output files
PORT=8005 # port number for your codegen
```

### Step3. Setup the proxy and run
```shell
python test.py --proxy_image <name of proxy_image>
```

OR if you already have the proxy setup in your `/tmp`

```shell
python test.py
```
The default proxy image: `sslhep/x509-secrets:develop`