### PR TITLE
[WIP] Documentation pass

### DIFF
--- a/docs/deployment/basic.md
+++ b/docs/deployment/basic.md
@@ -136,7 +136,7 @@ x509Secrets:
 Deploy the chart to your cluster with
 
 ```
-helm install -f values.yaml --version v1.0.0-rc.3 servicex ssl-hep/servicex
+helm install -f values.yaml --version v1.4.1 servicex ssl-hep/servicex
 ```
 
 Initial deployment is typically rapid, with RabbitMQ requiring up to a minute to

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -47,7 +47,7 @@ app:
 ```
 and you deployed the helm chart with
 ```
-helm install -f values.yaml --version v1.0.0-rc.3 my-release ssl-hep/servicex
+helm install -f values.yaml --version v1.4.1 my-release ssl-hep/servicex
 ```
 then the instance's URL would be `my-release.servicex.ssl-hep.org`.
 


### PR DESCRIPTION
This PR is tracking documentations as I go through the docs as a first time user. I will also put some commentary here as I go.

1. Updated the suggested Helm chart version to v1.4.1 in the deployment guide* 


*One thing that would be useful to me is to know what versions are available without installing the Helm tools. I snooped around and found the list of releases here: https://github.com/ssl-hep/ssl-helm-charts/tree/gh-pages
