### PR TITLE
Stop celery eating all the sidecar logging

### DIFF
--- a/servicex_app/servicex_app/lookup_result_processor.py
+++ b/servicex_app/servicex_app/lookup_result_processor.py
@@ -56,7 +56,9 @@ class LookupResultProcessor:
                                     })
 
             current_app.logger.info("Added file to processing queue", extra={
+                                    "paths": file_record.paths.split(','),
                                     "task_id": self.celery_task_name(request.request_id)})
 
         current_app.logger.info("Added files to processing queue", extra={
+            "num_files": len(files),
             'requestId': request.request_id})

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -490,7 +490,6 @@ def prepend_xcache(file_paths: list[str]) -> list[str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
-    import logging
     start_time = timeit.default_timer()
 
     parser = TransformerArgumentParser(description="ServiceX Transformer")

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -490,6 +490,7 @@ def prepend_xcache(file_paths: list[str]) -> list[str]:
 
 
 if __name__ == "__main__":  # pragma: no cover
+    import logging
     start_time = timeit.default_timer()
 
     parser = TransformerArgumentParser(description="ServiceX Transformer")
@@ -501,6 +502,7 @@ if __name__ == "__main__":  # pragma: no cover
     ]
     app.conf.task_create_missing_queues = False
     app.conf.worker_hijack_root_logger = False
+    app.conf.worker_redirect_stdouts_level = logging.DEBUG
     init(_args, app)
 
     logger.debug(

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -500,6 +500,7 @@ if __name__ == "__main__":  # pragma: no cover
                     durable=False, auto_delete=True)
     ]
     app.conf.task_create_missing_queues = False
+    app.conf.worker_hijack_root_logger = False
     init(_args, app)
 
     logger.debug(

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -502,7 +502,7 @@ if __name__ == "__main__":  # pragma: no cover
     ]
     app.conf.task_create_missing_queues = False
     app.conf.worker_hijack_root_logger = False
-    app.conf.worker_redirect_stdouts_level = logging.DEBUG
+    app.conf.worker_redirect_stdouts_level = 'DEBUG'
     init(_args, app)
 
     logger.debug(

--- a/transformer_sidecar/src/transformer_sidecar/transformer_logging/__init__.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer_logging/__init__.py
@@ -30,13 +30,15 @@ import logstash
 import os
 
 import logging
+import celery.signals
 
 from transformer_sidecar.transformer_logging.logstash_formatter import LogstashFormatter
 from transformer_sidecar.transformer_logging.stream_formatter import StreamFormatter
 instance = os.environ.get('INSTANCE_NAME', 'Unknown')
 
 
-def initialize_logging():
+@celery.signals.after_setup_logger.connect
+def initialize_logging(log=None):
     """
     Get a logger and initialize it so that it outputs the correct format
     :param request: Request id to insert into log messages
@@ -46,7 +48,8 @@ def initialize_logging():
     # Don't let the object store uploader get to chatty
     logging.getLogger('transformer_sidecar.object_store_uploader').setLevel(logging.INFO)
 
-    log = logging.getLogger()
+    if log is None:
+        log = logging.getLogger()
     log.level = getattr(logging, os.environ.get('LOG_LEVEL', "INFO"))
 
     stream_handler = logging.StreamHandler()

--- a/transformer_sidecar/src/transformer_sidecar/transformer_logging/__init__.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer_logging/__init__.py
@@ -38,7 +38,7 @@ instance = os.environ.get('INSTANCE_NAME', 'Unknown')
 
 
 @celery.signals.after_setup_logger.connect
-def initialize_logging(log=None, *args, **kwargs):
+def initialize_logging(logger=None, *args, **kwargs):
     """
     Get a logger and initialize it so that it outputs the correct format
     :param request: Request id to insert into log messages
@@ -48,8 +48,10 @@ def initialize_logging(log=None, *args, **kwargs):
     # Don't let the object store uploader get to chatty
     logging.getLogger('transformer_sidecar.object_store_uploader').setLevel(logging.INFO)
 
-    if log is None:
+    if logger is None:
         log = logging.getLogger()
+    else:
+        log = logger
     log.level = getattr(logging, os.environ.get('LOG_LEVEL', "INFO"))
 
     stream_handler = logging.StreamHandler()

--- a/transformer_sidecar/src/transformer_sidecar/transformer_logging/__init__.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer_logging/__init__.py
@@ -30,15 +30,13 @@ import logstash
 import os
 
 import logging
-import celery.signals
 
 from transformer_sidecar.transformer_logging.logstash_formatter import LogstashFormatter
 from transformer_sidecar.transformer_logging.stream_formatter import StreamFormatter
 instance = os.environ.get('INSTANCE_NAME', 'Unknown')
 
 
-@celery.signals.after_setup_logger.connect
-def initialize_logging(logger=None, *args, **kwargs):
+def initialize_logging():
     """
     Get a logger and initialize it so that it outputs the correct format
     :param request: Request id to insert into log messages
@@ -48,10 +46,7 @@ def initialize_logging(logger=None, *args, **kwargs):
     # Don't let the object store uploader get to chatty
     logging.getLogger('transformer_sidecar.object_store_uploader').setLevel(logging.INFO)
 
-    if logger is None:
-        log = logging.getLogger()
-    else:
-        log = logger
+    log = logging.getLogger()
     log.level = getattr(logging, os.environ.get('LOG_LEVEL', "INFO"))
 
     stream_handler = logging.StreamHandler()

--- a/transformer_sidecar/src/transformer_sidecar/transformer_logging/__init__.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer_logging/__init__.py
@@ -38,7 +38,7 @@ instance = os.environ.get('INSTANCE_NAME', 'Unknown')
 
 
 @celery.signals.after_setup_logger.connect
-def initialize_logging(log=None):
+def initialize_logging(log=None, *args, **kwargs):
     """
     Get a logger and initialize it so that it outputs the correct format
     :param request: Request id to insert into log messages


### PR DESCRIPTION
This fixes an issue where celery changes the root logger for tasks, meaning that the sidecar output was being swallowed. Separately a small fix for more information in transformation submission.