### PR TITLE
Inclusive error logging

### DIFF
--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -241,6 +241,7 @@ def transform_file(
                 "file-path": _file_paths[0],
                 "file-id": file_id,
                 "place": PLACE,
+                "transform-log": transformer_stats.log_body,
             }
             logger.error(f"Hard Failure: {transformer_stats.error_info}", extra=hf)
 

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -241,7 +241,7 @@ def transform_file(
                 "file-path": _file_paths[0],
                 "file-id": file_id,
                 "place": PLACE,
-                "transform-log": transformer_stats.log_body,
+                "log_body": transformer_stats.log_body,
             }
             logger.error(f"Hard Failure: {transformer_stats.error_info}", extra=hf)
 

--- a/transformer_sidecar/src/transformer_sidecar/transformer_stats/raw_uproot_stats.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer_stats/raw_uproot_stats.py
@@ -42,13 +42,13 @@ class RawUprootStats(TransformerStats):
             self.total_events, self.file_size = tuple(map(int, matches[0]))
 
         matches = re.findall(
-            r".*Error.*", self.log_body)
+            r"^Error.*", self.log_body)
 
         if matches:
             self.error_info = f"{matches[0]}"
 
         matches = re.findall(
-            r".*Exception.*", self.log_body)
+            r"^Exception.*", self.log_body)
 
         if matches:
             self.error_info = f"{matches[0]}"

--- a/transformer_sidecar/src/transformer_sidecar/transformer_stats/raw_uproot_stats.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer_stats/raw_uproot_stats.py
@@ -42,13 +42,13 @@ class RawUprootStats(TransformerStats):
             self.total_events, self.file_size = tuple(map(int, matches[0]))
 
         matches = re.findall(
-            r"^Error.*", self.log_body)
+            r"^\S*Error.*", self.log_body, re.MULTILINE)
 
         if matches:
             self.error_info = f"{matches[0]}"
 
         matches = re.findall(
-            r"^Exception.*", self.log_body)
+            r"^\S*Exception.*", self.log_body, re.MULTILINE)
 
         if matches:
             self.error_info = f"{matches[0]}"


### PR DESCRIPTION
Restore adding the full log body from a failed transformer to what gets logged in Kibana. Also improves the uproot-raw error reporting, very slightly (shows the exception message, not the line that raised the exception).