### PR TITLE
Update the chart's values.yaml to use released images

### DIFF
--- a/.github/workflows/ci_helm_publish.yaml
+++ b/.github/workflows/ci_helm_publish.yaml
@@ -40,18 +40,34 @@ jobs:
           echo "DOCKER_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
           echo "$DOCKER_TAG"
 
-      - name: Set version in flux_river_configs
+      - name: Set version in helm values.yaml
+        # Update the tags for images in the helm Chart.yaml and values.yaml to match
+        # The deployed docker image tag
         uses: mikefarah/yq@v4.44.3
         with:
           cmd: |
-            yq -i '.spec.chart.spec.version = strenv(RELEASE_VERSION) | .spec.chart.spec.version style="double" ' flux_river_configs/servicex-int/values.yaml &&
+            # Update the version of the helm chart
             yq -i '.appVersion = strenv(RELEASE_VERSION) | .appVersion style="double" | .version = "'$RELEASE_VERSION'"| .version style="double" ' helm/servicex/Chart.yaml &&
+            
+            # Update the tags for the well known images in the helm values.yaml
             yq -i '.app.tag = strenv(DOCKER_TAG) | .app.tag style="double" |
-            .didFinder.rucio.tag = strenv(DOCKER_TAG) | .didFinder.rucio.tag style="double" |
-            .didFinder.CERNOpenData.tag = strenv(DOCKER_TAG) | .didFinder.CERNOpenData.tag style="double" |
             .transformer.sidecarTag = strenv(DOCKER_TAG) | .transformer.sidecarTag style="double" |
-            .x509Secrets.tag = strenv(DOCKER_TAG) | .x509Secrets.tag style="double" ' helm/servicex/Chart.yaml &&
-            CODEGENS=$(yq '.spec.values.codeGen | keys | .[]' flux_river_configs/servicex-int/values.yaml) && for i in $CODEGENS; do yq -i  '.spec.values.codeGen.[$i].tag=strenv(DOCKER_TAG) | .spec.values.codeGen.[$i].tag style="double"' flux_river_configs/servicex-int/values.yaml; done
+            .minioCleanup.tag = strenv(DOCKER_TAG) | .minioCleanup.tag style="double" |
+            .x509Secrets.tag = strenv(DOCKER_TAG) | .x509Secrets.tag style="double" ' helm/servicex/values.yaml &&
+            
+            # Loop over each of the DID Finders to update the tags for each
+            DIDFINDERS=$(yq '.didFinder | keys | .[]' helm/servicex/values.yaml) && 
+                for i in $DIDFINDERS; do yq -i  '.didFinder.[$i].tag=strenv(DOCKER_TAG) | .didFinder.[$i].tag style="double"' helm/servicex/values.yaml; done &&
+
+            # Loop over each of the Codegens to update the tags for each
+            CODEGENS=$(yq '.codeGen | keys | .[]' helm/servicex/values.yaml) && 
+                for i in $CODEGENS; do yq -i  '.codeGen.[$i].tag=strenv(DOCKER_TAG) | .codeGen.[$i].tag style="double"' helm/servicex/values.yaml; done
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.9.2
+
       - name: Create helm package
         working-directory: ./helm
         run: |
@@ -59,6 +75,7 @@ jobs:
           helm package servicex
           mv servicex-$RELEASE_VERSION.tgz ../ssl-helm-charts
           helm repo index ../ssl-helm-charts --url https://ssl-hep.github.io/ssl-helm-charts/
+
       - name: Pushes to ssl-helm-packages repository
         uses: cpina/github-action-push-to-another-repository@v1.7.2
         env:
@@ -69,6 +86,14 @@ jobs:
           destination-repository-name: 'ssl-helm-charts'
           target-branch: 'gh-pages'
           user-email: 'bengal1@illinois.edu'
+
+      - name: Set version in flux_river_config for the production environment
+        uses: mikefarah/yq@v4.44.3
+        with:
+          cmd: |
+            # Update the chart version to pick up
+            yq -i '.spec.chart.spec.version = strenv(RELEASE_VERSION) | .spec.chart.spec.version style="double" ' flux_river_configs/servicex-prod/values.yaml 
+
       - name: Pushes to flux-river-configs repository
         uses: cpina/github-action-push-to-another-repository@v1.7.2
         env:
@@ -79,6 +104,7 @@ jobs:
           destination-repository-name: 'flux_river_configs'
           target-branch: 'main'
           user-email: 'bengal1@illinois.edu'
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2.0.8


### PR DESCRIPTION
# Problems
1. When a helm chart is released, the docker image tags in `values.yaml` are stuck pointing to `develop` images instead of the tagged images for the release.
2. Releases of the service are deployed to _ServiceX-int_ namespace (which is broken) instead of to `-Prod` namespace.

Resolves #852 
Resolves #851 

# Approach
For (2) simplified the values update step and directed it to the -prod values

For (1) I dug deeper into the yq expressions and performed the transformations on the checked out `values.yaml`