### PR TITLE
Use Rucio's site-closeness algorithm for replica ordering

### DIFF
--- a/did_finder_rucio/src/rucio_did_finder/rucio_adapter.py
+++ b/did_finder_rucio/src/rucio_did_finder/rucio_adapter.py
@@ -46,6 +46,9 @@ class RucioAdapter:
 
     def client_location(self):
         client_location = {}
+        # setting the site actually seems to work
+        if 'SITE_NAME' in os.environ:
+            client_location['site'] = os.environ['SITE_NAME']
         latitude = os.environ.get('RUCIO_LATITUDE')
         longitude = os.environ.get('RUCIO_LONGITUDE')
         if latitude and longitude:

--- a/helm/servicex/templates/did-finder-rucio/deployment.yaml
+++ b/helm/servicex/templates/did-finder-rucio/deployment.yaml
@@ -42,6 +42,10 @@ spec:
             value: "{{ .Values.didFinder.rucio.servicex_latitude }}"
           - name: RUCIO_LONGITUDE
             value: "{{ .Values.didFinder.rucio.servicex_longitude }}"
+          {{- if .Values.didFinder.rucio.site }}
+          - name: SITE_NAME
+            value: "{{ .Values.didFinder.rucio.site }}"
+          {{- end }}
           - name: INSTANCE_NAME
             value: {{ .Release.Name }}
         volumeMounts:


### PR DESCRIPTION
Propagate the environment variable SITE_NAME into the Rucio DID finder container, if `didFinder.rucio.site` is set in the `values.yaml`. If available, provide this to the rucio client to prioritize replicas.