### PR TITLE
Migrate all of the codegens from -prod into values.yaml

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -28,42 +28,55 @@ app:
   tag: develop
   tokenExpires: false
   validateTransformerImage: true
+
 codeGen:
-  atlasxaod:
-    enabled: true
-    image: sslhep/servicex_code_gen_func_adl_xaod
-    pullPolicy: Always
-    tag: develop
-    defaultScienceContainerImage: sslhep/servicex_func_adl_xaod_transformer
-    defaultScienceContainerTag: develop
-  uproot:
-    enabled: true
-    image: sslhep/servicex_code_gen_func_adl_uproot
-    pullPolicy: Always
-    tag: develop
-    defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
-    defaultScienceContainerTag: develop
   uproot-raw:
     enabled: true
     image: sslhep/servicex_code_gen_raw_uproot
     pullPolicy: Always
     tag: develop
     defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
-    defaultScienceContainerTag: develop
-  cms:
+    defaultScienceContainerTag: uproot5
+
+  uproot:
     enabled: true
-    image: sslhep/servicex_code_gen_cms_aod
+    image: sslhep/servicex_code_gen_func_adl_uproot
     pullPolicy: Always
     tag: develop
-    defaultScienceContainerImage: sslhep/servicex_func_adl_cms_aod_transformer
-    defaultScienceContainerTag: develop
+    defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
+    defaultScienceContainerTag: uproot5
+
   python:
     enabled: true
     image: sslhep/servicex_code_gen_python
     pullPolicy: Always
     tag: develop
     defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
-    defaultScienceContainerTag: develop
+    defaultScienceContainerTag: uproot5
+
+    atlasr21:
+      enabled: true
+      image: sslhep/servicex_code_gen_func_adl_xaod
+      pullPolicy: Always
+      tag: develop
+      defaultScienceContainerImage: sslhep/servicex_func_adl_xaod_transformer
+      defaultScienceContainerTag: 21.2.231
+
+    atlasr22:
+      enabled: true
+      image: sslhep/servicex_code_gen_atlas_xaod
+      tag: v1.5.1-alpha.1
+      defaultScienceContainerImage: sslhep/servicex_func_adl_xaod_transformer
+      defaultScienceContainerTag: 22.2.107
+
+    cmssw-5-3-32:
+      enabled: true
+      image: sslhep/servicex_code_gen_cms_aod
+      tag: v1.5.1-alpha.1
+      defaultScienceContainerImage: sslhep/servicex_func_adl_cms_aod_transformer
+      defaultScienceContainerTag: cmssw-5-3-32
+
+
 didFinder:
   CERNOpenData:
     enabled: true


### PR DESCRIPTION
The chart's values.yaml will serve as the definitive list of codegens and we can keep -prod values.yaml sweet and simple