### PR TITLE
Try to fix exception propagation from REST api

### DIFF
--- a/servicex_app/servicex_app/__init__.py
+++ b/servicex_app/servicex_app/__init__.py
@@ -294,7 +294,7 @@ def create_app(test_config=None,
             app.logger.error("Supplied Transformer Persistent Volume Claim Doesn't exist")
             sys.exit(-1)
 
-        api = Api(app)
+        api = Api(app, errors=Flask.errorhandler)
 
         # ensure the instance folder exists
         try:


### PR DESCRIPTION
This fix (cribbed from https://github.com/vimalloc/flask-jwt-extended/issues/141) allows the reauthentication errors to be correctly propagated to the users as status 401 instead of 500 (I guess it installs the correct exception handlers). However of course this could potentially affect the handling of errors in other REST requests so it should get looked at carefully.

Resolves #872 