### PR TITLE
Update docs link from dashboard to go to new readthedocs page

### DIFF
--- a/helm/servicex/templates/app/configmap.yaml
+++ b/helm/servicex/templates/app/configmap.yaml
@@ -20,9 +20,8 @@ data:
     # details are beyond the scope of this example
     SECRET_KEY = 'abc123!'
 
-    # Base url of documentation - autopopulated from chart version
-    # Must be activated at https://readthedocs.org/projects/servicex/versions/
-    DOCS_BASE_URL = 'https://servicex.readthedocs.io/en/{{- ternary "latest" (printf "v%s" .Chart.AppVersion) (eq .Chart.AppVersion "develop") }}'
+    # Base url of documentation from the frontend
+    DOCS_BASE_URL = 'https://servicex-frontend.readthedocs.io/en/stable/'
 
     # Enable JWT auth on public endpoints
     ENABLE_AUTH={{- ternary "True" "False" .Values.app.auth }}

--- a/servicex_app/servicex_app/templates/base.html
+++ b/servicex_app/servicex_app/templates/base.html
@@ -39,7 +39,7 @@
           <!-- Navbar Left Side -->
           <ul class="navbar-nav mr-auto">
             <li class="nav-item">
-              <a class="nav-link" href="{{ config['DOCS_BASE_URL'] }}">Docs</a>
+              <a class="nav-link" href="{{ config['DOCS_BASE_URL'] }}" target="_blank">Docs</a>
             </li>
             {% if not config['ENABLE_AUTH'] %}
             <li class="nav-item">


### PR DESCRIPTION
# Approach
We used to have docs link take users to the backend docs, which was a bit of a mess and not really 
what a user would need. Now that we have up to date client docs we will link to that instead.

Also update the <a> element to open the docs in a new tab

This resolves #316 