### PR TITLE
transform_file task uses ack_late=True

### DIFF
--- a/transformer_sidecar/src/transformer_sidecar/object_store_uploader.py
+++ b/transformer_sidecar/src/transformer_sidecar/object_store_uploader.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import logging
 import os
+import signal
 from multiprocessing import Process
 from pathlib import Path
 from queue import Queue
@@ -58,11 +59,18 @@ class ObjectStoreUploader(Process):
     def __init__(self, request_id: str, input_queue: Queue,
                  logger: logging.Logger,
                  convert_root_to_parquet: bool):
+
         super().__init__(target=self.service_work_queue)
         self.request_id = request_id
         self.input_queue = input_queue
         self.logger = logger
         self.convert_root_to_parquet = convert_root_to_parquet
+
+        signal.signal(signal.SIGTERM, self.handle_sigterm)
+
+    def handle_sigterm(self, signum, frame):
+        # This method will be called when SIGTERM is received
+        print("SIGTERM received, but ignored.")
 
     def service_work_queue(self):
         import time

--- a/transformer_sidecar/src/transformer_sidecar/object_store_uploader.py
+++ b/transformer_sidecar/src/transformer_sidecar/object_store_uploader.py
@@ -70,7 +70,11 @@ class ObjectStoreUploader(Process):
 
     def handle_sigterm(self, signum, frame):
         # This method will be called when SIGTERM is received
-        print("SIGTERM received, but ignored.")
+        self.logger.debug(
+            "SIGTERM received, but ignored",
+            extra={'requestId': self.request_id,
+                   "place": PLACE,
+                   "qsize": self.input_queue.qsize()})
 
     def service_work_queue(self):
         import time

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -508,6 +508,7 @@ if __name__ == "__main__":  # pragma: no cover
     app.conf.task_create_missing_queues = False
     app.conf.worker_hijack_root_logger = False
     app.conf.worker_redirect_stdouts_level = 'DEBUG'
+    app.conf.worker_prefetch_multiplier = 1
     init(_args, app)
 
     logger.debug(

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -509,6 +509,7 @@ if __name__ == "__main__":  # pragma: no cover
     app.conf.worker_hijack_root_logger = False
     app.conf.worker_redirect_stdouts_level = 'DEBUG'
     app.conf.worker_prefetch_multiplier = 1
+    app.conf.broker_connection_retry_on_startup = True
     init(_args, app)
 
     logger.debug(


### PR DESCRIPTION
We found that when the autoscaler decides to scale down the number of transformers that the science image dies immediatly which  causes the "sync" call to fail. When this happens we need to put the transform request back onto rabbit queue and die gracefully.

Add the acks_late propoerty to the transform_file request and now the failure to receive the sync command from the science container is a fatal error.