### PR TITLE
Point to develop for all codegens so releases build properly

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -65,14 +65,14 @@ codeGen:
   atlasr22:
     enabled: true
     image: sslhep/servicex_code_gen_atlas_xaod
-    tag: v1.5.1-alpha.1
+    tag: develop
     defaultScienceContainerImage: sslhep/servicex_func_adl_xaod_transformer
     defaultScienceContainerTag: 22.2.107
 
   cmssw-5-3-32:
     enabled: true
     image: sslhep/servicex_code_gen_cms_aod
-    tag: v1.5.1-alpha.1
+    tag: develop
     defaultScienceContainerImage: sslhep/servicex_func_adl_cms_aod_transformer
     defaultScienceContainerTag: cmssw-5-3-32
 


### PR DESCRIPTION
Don't reference the 1.5.1-alpha.1 tag in the `values.yaml`; we need `develop` in order for the tags to be updated correctly when we build the final helm chart for a release.