### PR TITLE
Limit the autoscaling of transformations to the number of files in a request

### DIFF
--- a/servicex_app/servicex_app_test/test_transformer_manager.py
+++ b/servicex_app/servicex_app_test/test_transformer_manager.py
@@ -67,6 +67,7 @@ class TestTransformerManager(ResourceTestBase):
                 .assert_called_with(image=submitted_request.image,
                                     request_id=submitted_request.request_id,
                                     workers=submitted_request.workers,
+                                    max_workers=submitted_request.files,
                                     generated_code_cm=submitted_request.generated_code_cm,
                                     rabbitmq_uri='amqp://trans.rabbit',
                                     namespace='my-ws',
@@ -126,6 +127,7 @@ class TestTransformerManager(ResourceTestBase):
         with client.application.app_context():
             transformer.launch_transformer_jobs(
                 image='sslhep/servicex-transformer:pytest', request_id='1234', workers=17,
+                max_workers=17,
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store', result_format='arrow', x509_secret='x509',
                 generated_code_cm=None)
@@ -195,6 +197,7 @@ class TestTransformerManager(ResourceTestBase):
         with client.application.app_context():
             transformer.launch_transformer_jobs(
                 image='sslhep/servicex-transformer:pytest', request_id='1234', workers=17,
+                max_workers=17,
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store', result_format='arrow', x509_secret='x509',
                 generated_code_cm=None,
@@ -238,6 +241,7 @@ class TestTransformerManager(ResourceTestBase):
         with client.application.app_context():
             transformer.launch_transformer_jobs(
                 image='sslhep/servicex-transformer:pytest', request_id='1234', workers=17,
+                max_workers=17,
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store', result_format='arrow', x509_secret='x509',
                 generated_code_cm=None,
@@ -283,6 +287,7 @@ class TestTransformerManager(ResourceTestBase):
         with client.application.app_context():
             transformer.launch_transformer_jobs(
                 image='sslhep/servicex-transformer:pytest', request_id='1234', workers=17,
+                max_workers=17,
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store',
                 result_format='parquet', x509_secret='x509',
@@ -330,6 +335,7 @@ class TestTransformerManager(ResourceTestBase):
         with client.application.app_context():
             transformer.launch_transformer_jobs(
                 image='sslhep/servicex-transformer:pytest', request_id='1234', workers=17,
+                max_workers=17,
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store',
                 result_format='parquet', x509_secret='x509',
@@ -379,6 +385,7 @@ class TestTransformerManager(ResourceTestBase):
         with client.application.app_context():
             transformer.launch_transformer_jobs(
                 image='sslhep/servicex-transformer:pytest', request_id='1234', workers=17,
+                max_workers=17,
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store',
                 result_format='parquet', x509_secret='x509',
@@ -424,6 +431,7 @@ class TestTransformerManager(ResourceTestBase):
         with client.application.app_context():
             transformer.launch_transformer_jobs(
                 image='sslhep/servicex-transformer:pytest', request_id='1234', workers=17,
+                max_workers=17,
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='volume',
                 result_format='parquet', x509_secret='x509',
@@ -472,6 +480,7 @@ class TestTransformerManager(ResourceTestBase):
         with client.application.app_context():
             transformer.launch_transformer_jobs(
                 image='sslhep/servicex-transformer:pytest', request_id='1234', workers=17,
+                max_workers=17,
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='volume',
                 result_format='parquet', x509_secret='x509',
@@ -526,6 +535,7 @@ class TestTransformerManager(ResourceTestBase):
         with client.application.app_context():
             transformer.launch_transformer_jobs(
                 image='sslhep/servicex-transformer:pytest', request_id='1234', workers=17,
+                max_workers=17,
                 rabbitmq_uri='ampq://test.com', namespace='my-ns',
                 result_destination='object-store', result_format='arrow', x509_secret=None,
                 generated_code_cm=None,


### PR DESCRIPTION
Since we have file granularity for transformations, it does not make sense to autoscale beyond the total number of files in a transform request. In fact this can be damaging since the autoscaler may be too enthusiastic at first, then scale the pod down, killing running jobs. Provide a hint to not scale too aggressively.

* datasets with known sizes have the max number of replicas set immediately

No action is taken for datasets which have to be looked up, since we don't know how many files there will be, and we do not want to shut down pods by force if we find we've spawned too many once the lookup is done (let the autoscaler take the blame for this one).