### PR TITLE
Switch default atlasr21 image to something actually versioned

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -57,7 +57,7 @@ codeGen:
 
   atlasr21:
     enabled: true
-    image: sslhep/servicex_code_gen_func_adl_xaod
+    image: sslhep/servicex_code_gen_atlas_xaod
     pullPolicy: Always
     tag: develop
     defaultScienceContainerImage: sslhep/servicex_func_adl_xaod_transformer


### PR DESCRIPTION
Change the image reference `sslhep/servicex_code_gen_func_adl_xaod` to `sslhep/servicex_code_gen_atlas_xaod` (which is what we are calling it now, and which is built as part of a release) for `atlasr21` in the values.yaml 