### PR TITLE
Add route to list datasets

### DIFF
--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -393,7 +393,7 @@ class TransformationResult(db.Model):
         db.session.flush()
 
 
-class DatasetStatus(Enum):
+class DatasetStatus(str, Enum):
     created = "created"
     looking = "looking"
     complete = "complete"
@@ -439,6 +439,14 @@ class Dataset(db.Model):
     @classmethod
     def find_by_id(cls, id) -> Optional['Dataset']:
         return cls.query.get(id)
+
+    @classmethod
+    def get_by_did_finder(cls, did_finder) -> List[Dataset]:
+        return cls.query.filter_by(did_finder=did_finder)
+
+    @classmethod
+    def get_all(cls):
+        return cls.query.all()
 
 
 class DatasetFile(db.Model):

--- a/servicex_app/servicex_app/resources/datasets/__init__.py
+++ b/servicex_app/servicex_app/resources/datasets/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2024, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/servicex_app/servicex_app/resources/datasets/get_all.py
+++ b/servicex_app/servicex_app/resources/datasets/get_all.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2024, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from flask_restful import reqparse
+
+from servicex_app.decorators import auth_required
+from servicex_app.models import Dataset
+from servicex_app.resources.servicex_resource import ServiceXResource
+
+parser = reqparse.RequestParser()
+parser.add_argument('did-finder', type=str, location='args', required=False)
+
+
+class AllDatasets(ServiceXResource):
+    @auth_required
+    def get(self):
+        args = parser.parse_args()
+        if 'did-finder' in args and args['did-finder']:
+            did_finder = args['did-finder']
+            datasets = Dataset.get_by_did_finder(did_finder)
+        else:
+            datasets = Dataset.get_all()
+
+        return {
+            "datasets": [dataset.to_json() for dataset in datasets]
+        }

--- a/servicex_app/servicex_app/routes.py
+++ b/servicex_app/servicex_app/routes.py
@@ -27,6 +27,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from flask import current_app as app
 
+from servicex_app.resources.datasets.get_all import AllDatasets
+
 
 def add_routes(api, transformer_manager, rabbit_mq_adaptor,
                object_store, code_gen_service,
@@ -124,6 +126,8 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
 
     # Client public endpoints
     api.add_resource(Info, '/servicex')
+    api.add_resource(AllDatasets, '/servicex/datasets')
+
     prefix = "/servicex/transformation"
     api.add_resource(SubmitTransformationRequest, prefix)
     api.add_resource(AllTransformationRequests, prefix)

--- a/servicex_app/servicex_app_test/resources/datasets/__init__.py
+++ b/servicex_app/servicex_app_test/resources/datasets/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2024, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/servicex_app/servicex_app_test/resources/datasets/test_get_all.py
+++ b/servicex_app/servicex_app_test/resources/datasets/test_get_all.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2024, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from datetime import datetime
+from unittest.mock import patch
+from pytest import fixture
+
+from servicex_app.models import Dataset
+from servicex_app_test.resource_test_base import ResourceTestBase
+
+
+class TestDatasetsGetAll(ResourceTestBase):
+    @fixture
+    def datasets(self):
+        return [
+            Dataset(last_used=datetime(2022, 1, 1),
+                    last_updated=datetime(2022, 1, 1),
+                    id='123',
+                    name='dataset1',
+                    events=100,
+                    size=1000,
+                    n_files=1,
+                    lookup_status='looking',
+                    did_finder='rucio'),
+        ]
+
+    @patch('servicex_app.models.Dataset.get_by_did_finder')
+    def test_get_all_rucio(self, mock_get_by_did_finder, datasets):
+        mock_get_by_did_finder.return_value = datasets
+        client = self._test_client()
+        response = client.get('/servicex/datasets?did-finder=rucio')
+        mock_get_by_did_finder.assert_called_with('rucio')
+        assert response.status_code == 200
+
+        assert response.json == {
+            "datasets": [
+                {
+                    "last_used": "2022-01-01T00:00:00.000000Z",
+                    "last_updated": "2022-01-01T00:00:00.000000Z",
+                    "id": "123",
+                    "did_finder": "rucio",
+                    'lookup_status': 'looking',
+                    'name': 'dataset1',
+                    'size': 1000,
+                    'events': 100,
+                    'n_files': 1
+                }
+            ]
+        }
+
+    @patch('servicex_app.models.Dataset.get_all')
+    def test_get_all(self, mock_get, datasets):
+        mock_get.return_value = datasets
+        client = self._test_client()
+        response = client.get('/servicex/datasets')
+        mock_get.assert_called()
+        assert response.status_code == 200


### PR DESCRIPTION
As an initial step to being able to manage cached datasets, we need an ability to report on the datasets in the system.

Adds a REST endpoint that returns datasets as a JSON list. The endpoint accepts an optional argument to filter on DID Finder (i.e. 'rucio' or 'user')
