### PR TITLE
Reduce number of logging messages from Celery operations

### DIFF
--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -399,7 +399,7 @@ def init(args: Union[Namespace, SimpleNamespace], app: Celery) -> None:
             "--without-mingle",
             "--without-gossip",
             "--without-heartbeat",
-            "--loglevel=info",
+            "--loglevel=warning",
             "-Q", f"transformer-{args.request_id}",
             "-n",
             f"transformer-{args.request_id}@%h",

--- a/transformer_sidecar/tests/test_transformer.py
+++ b/transformer_sidecar/tests/test_transformer.py
@@ -146,7 +146,7 @@ def test_transformer_init(args, mock_celery, transformer_capabilities,
                 '--without-mingle',
                 '--without-gossip',
                 '--without-heartbeat',
-                "--loglevel=info",
+                "--loglevel=warning",
                 '-Q', 'transformer-1234',
                 "-n", "transformer-1234@%h",
             ]


### PR DESCRIPTION
Celery by default is quite noisy (e.g. starting and stopping queues results in lots of broadcast messages). Try to reduce this a bit.