### PR TITLE
Raise ack timeout for transformers to one month

### DIFF
--- a/servicex_app/servicex_app/celery_task_router.py
+++ b/servicex_app/servicex_app/celery_task_router.py
@@ -36,7 +36,8 @@ def route_task(name, args, kwargs, options, task=None, **kw):
         return {
             "queue": Queue(name=f"transformer-{kwargs['request_id']}",
                            durable=False,
-                           auto_delete=True)
+                           auto_delete=True,
+                           queue_arguments={'x-consumer-timeout': 2_629_746_000})
         }
 
     did_finder_match = re.search(did_finder_pattern, name)

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -503,7 +503,8 @@ if __name__ == "__main__":  # pragma: no cover
     app = Celery("transformer_sidecar", broker=_args.rabbit_uri)
     app.conf.task_queues = [
         kombu.Queue(name=f"transformer-{_args.request_id}",
-                    durable=False, auto_delete=True)
+                    durable=False, auto_delete=True,
+                    queue_arguments={'x-consumer-timeout': 2_629_746_000})
     ]
     app.conf.task_create_missing_queues = False
     app.conf.worker_hijack_root_logger = False


### PR DESCRIPTION
Resolves #893: changes queue configuration for transformer queues so that ACK timeout intervals are now the very long length of one month.