### PR TITLE
Mark Datasets as Stale to Force Requery

### DIFF
--- a/servicex_app/migrations/versions/v1_5_5.py
+++ b/servicex_app/migrations/versions/v1_5_5.py
@@ -21,10 +21,16 @@ def upgrade():
                                         sa.Boolean(),
                                         nullable=False,
                                         server_default='false'))
+
+    # Name is no longer unique, so we need to drop the unique index
+    # op.drop_index('datasets_name_key', table_name='datasets')
+
+    op.drop_constraint('datasets_name_key', 'datasets')
     # This was never used, so a fine time to delete it
     op.drop_column('transform_result', 'did')
 
 
 def downgrade():
+    op.create_unique_constraint('datasets_name_key', 'datasets', ['name'])
     op.drop_column('datasets', 'stale')
     # No need to add the transform_result.did column back in

--- a/servicex_app/migrations/versions/v1_5_5.py
+++ b/servicex_app/migrations/versions/v1_5_5.py
@@ -23,9 +23,9 @@ def upgrade():
                                         server_default='false'))
 
     # Name is no longer unique, so we need to drop the unique index
+    op.drop_constraint('datasets_name_key', 'datasets')
     # op.drop_index('datasets_name_key', table_name='datasets')
 
-    op.drop_constraint('datasets_name_key', 'datasets')
     # This was never used, so a fine time to delete it
     op.drop_column('transform_result', 'did')
 
@@ -33,4 +33,5 @@ def upgrade():
 def downgrade():
     op.create_unique_constraint('datasets_name_key', 'datasets', ['name'])
     op.drop_column('datasets', 'stale')
-    # No need to add the transform_result.did column back in
+
+    op.add_column('transform_result', sa.Column('did', sa.String(), nullable=True))

--- a/servicex_app/migrations/versions/v1_5_5.py
+++ b/servicex_app/migrations/versions/v1_5_5.py
@@ -1,0 +1,30 @@
+"""
+Mark dataset rows as stale
+
+Revision ID: v1_5_5
+Revises: v1_3_0
+Create Date: 2024-11-11 16:06:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'v1_5_5'
+down_revision = 'v1_3_0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('datasets', sa.Column('stale',
+                                        sa.Boolean(),
+                                        nullable=False,
+                                        server_default='false'))
+    # This was never used, so a fine time to delete it
+    op.drop_column('transform_result', 'did')
+
+
+def downgrade():
+    op.drop_column('datasets', 'stale')
+    # No need to add the transform_result.did column back in

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -428,7 +428,7 @@ class Dataset(db.Model):
             'last_used': str(self.last_used.strftime(iso_fmt)),
             'last_updated': str(self.last_updated.strftime(iso_fmt)),
             'lookup_status': self.lookup_status,
-            'is-stale': self.stale
+            'is_stale': self.stale
         }
         return result_obj
 
@@ -441,12 +441,18 @@ class Dataset(db.Model):
         return cls.query.get(id)
 
     @classmethod
-    def get_by_did_finder(cls, did_finder) -> List[Dataset]:
-        return cls.query.filter_by(did_finder=did_finder, stale=False)
+    def get_by_did_finder(cls, did_finder, show_deleted: bool = False) -> List[Dataset]:
+        if show_deleted:
+            return cls.query.filter_by(did_finder=did_finder)
+        else:
+            return cls.query.filter_by(did_finder=did_finder, stale=False)
 
     @classmethod
-    def get_all(cls):
-        return cls.query.filter_by(stale=False)
+    def get_all(cls, show_deleted: bool = False) -> List[Dataset]:
+        if show_deleted:
+            return cls.query.all()
+        else:
+            return cls.query.filter_by(stale=False)
 
 
 class DatasetFile(db.Model):

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -401,7 +401,7 @@ class Dataset(db.Model):
     __tablename__ = 'datasets'
 
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(1024), unique=True, nullable=False, index=True)
+    name = db.Column(db.String(1024), unique=False, nullable=False, index=True)
     last_used = db.Column(db.DateTime, nullable=False)
     last_updated = db.Column(db.DateTime, nullable=True)
     did_finder = db.Column(db.String(64), nullable=False)
@@ -427,13 +427,14 @@ class Dataset(db.Model):
             'events': self.events,
             'last_used': str(self.last_used.strftime(iso_fmt)),
             'last_updated': str(self.last_updated.strftime(iso_fmt)),
-            'lookup_status': self.lookup_status
+            'lookup_status': self.lookup_status,
+            'is-stale': self.stale
         }
         return result_obj
 
     @classmethod
     def find_by_name(cls, name) -> Optional['Dataset']:
-        return cls.query.filter_by(name=name).first()
+        return cls.query.filter_by(name=name, stale=False).first()
 
     @classmethod
     def find_by_id(cls, id) -> Optional['Dataset']:
@@ -441,11 +442,11 @@ class Dataset(db.Model):
 
     @classmethod
     def get_by_did_finder(cls, did_finder) -> List[Dataset]:
-        return cls.query.filter_by(did_finder=did_finder)
+        return cls.query.filter_by(did_finder=did_finder, stale=False)
 
     @classmethod
     def get_all(cls):
-        return cls.query.all()
+        return cls.query.filter_by(stale=False)
 
 
 class DatasetFile(db.Model):

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -359,7 +359,6 @@ class TransformationResult(db.Model):
     __tablename__ = 'transform_result'
 
     id = db.Column(db.Integer, primary_key=True)
-    did = db.Column(db.String(512), unique=False, nullable=False)
     file_id = db.Column(db.Integer, ForeignKey('files.id'))
     file_path = db.Column(db.String(512), unique=False, nullable=False)
     request_id = db.Column(db.String(48), unique=False, nullable=False)
@@ -378,7 +377,6 @@ class TransformationResult(db.Model):
         return {
             'id': x.id,
             'request-id': x.request_id,
-            'did': x.did,
             'file-id': x.id,
             'file-path': x.file_path,
             'transform_status': x.transform_status,
@@ -411,6 +409,7 @@ class Dataset(db.Model):
     size = db.Column(db.BigInteger, default=0, nullable=True)
     events = db.Column(db.BigInteger, default=0, nullable=True)
     lookup_status = db.Column(db.Enum(DatasetStatus), nullable=False)
+    stale = db.Column(db.Boolean, default=False, nullable=False)
     files = relationship("DatasetFile", back_populates="dataset")
 
     def save_to_db(self):

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -462,6 +462,15 @@ class DatasetFile(db.Model):
     paths = db.Column(db.Text(), unique=False, nullable=False)
     dataset = relationship("Dataset", back_populates="files")
 
+    def to_json(self):
+        return {
+            'id': self.id,
+            'adler32': self.adler32,
+            'file_size': self.file_size,
+            'file_events': self.file_events,
+            'paths': self.paths
+        }
+
     def save_to_db(self):
         db.session.add(self)
         db.session.flush()

--- a/servicex_app/servicex_app/resources/datasets/delete_dataset.py
+++ b/servicex_app/servicex_app/resources/datasets/delete_dataset.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2024, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from servicex_app.decorators import auth_required
+from servicex_app.models import Dataset
+from servicex_app.resources.servicex_resource import ServiceXResource
+
+
+class OneDataset(ServiceXResource):
+    @auth_required
+    def get(self, dataset_id):
+        dataset = Dataset.find_by_id(dataset_id)
+        result = dataset.to_json()
+        result['files'] = [f.to_json() for f in dataset.files]
+        return result

--- a/servicex_app/servicex_app/resources/datasets/get_all.py
+++ b/servicex_app/servicex_app/resources/datasets/get_all.py
@@ -33,17 +33,19 @@ from servicex_app.resources.servicex_resource import ServiceXResource
 
 parser = reqparse.RequestParser()
 parser.add_argument('did-finder', type=str, location='args', required=False)
+parser.add_argument('show-deleted', type=bool, location='args', required=False)
 
 
 class AllDatasets(ServiceXResource):
     @auth_required
     def get(self):
         args = parser.parse_args()
+        show_deleted = args['show-deleted'] if 'show-deleted' in args else False
         if 'did-finder' in args and args['did-finder']:
             did_finder = args['did-finder']
-            datasets = Dataset.get_by_did_finder(did_finder)
+            datasets = Dataset.get_by_did_finder(did_finder, show_deleted)
         else:
-            datasets = Dataset.get_all()
+            datasets = Dataset.get_all(show_deleted)
 
         return {
             "datasets": [dataset.to_json() for dataset in datasets]

--- a/servicex_app/servicex_app/resources/datasets/get_one.py
+++ b/servicex_app/servicex_app/resources/datasets/get_one.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2024, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from servicex_app.decorators import auth_required
+from servicex_app.models import Dataset
+from servicex_app.resources.servicex_resource import ServiceXResource
+
+
+class OneDataset(ServiceXResource):
+    @auth_required
+    def get(self, dataset_id):
+        dataset = Dataset.find_by_id(dataset_id)
+        result = dataset.to_json()
+        result['files'] = [f.to_json() for f in dataset.files]
+        return result

--- a/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
+++ b/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
@@ -98,7 +98,6 @@ class TransformerFileComplete(ServiceXResource):
            )
     def save_transform_result(transform_req: TransformRequest, info: dict[str, str]):
         rec = TransformationResult(
-            did=transform_req.did,
             file_id=info['file-id'],
             request_id=transform_req.request_id,
             file_path=info['file-path'],

--- a/servicex_app/servicex_app/routes.py
+++ b/servicex_app/servicex_app/routes.py
@@ -28,6 +28,7 @@
 from flask import current_app as app
 
 from servicex_app.resources.datasets.get_all import AllDatasets
+from servicex_app.resources.datasets.get_one import OneDataset
 
 
 def add_routes(api, transformer_manager, rabbit_mq_adaptor,
@@ -127,6 +128,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     # Client public endpoints
     api.add_resource(Info, '/servicex')
     api.add_resource(AllDatasets, '/servicex/datasets')
+    api.add_resource(OneDataset, '/servicex/datasets/<int:dataset_id>')
 
     prefix = "/servicex/transformation"
     api.add_resource(SubmitTransformationRequest, prefix)

--- a/servicex_app/servicex_app/routes.py
+++ b/servicex_app/servicex_app/routes.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from flask import current_app as app
 
+from servicex_app.resources.datasets.delete_dataset import DeleteDataset
 from servicex_app.resources.datasets.get_all import AllDatasets
 from servicex_app.resources.datasets.get_one import OneDataset
 
@@ -129,6 +130,7 @@ def add_routes(api, transformer_manager, rabbit_mq_adaptor,
     api.add_resource(Info, '/servicex')
     api.add_resource(AllDatasets, '/servicex/datasets')
     api.add_resource(OneDataset, '/servicex/datasets/<int:dataset_id>')
+    api.add_resource(DeleteDataset, '/servicex/datasets/<int:dataset_id>')
 
     prefix = "/servicex/transformation"
     api.add_resource(SubmitTransformationRequest, prefix)

--- a/servicex_app/servicex_app_test/resources/datasets/test_delete.py
+++ b/servicex_app/servicex_app_test/resources/datasets/test_delete.py
@@ -29,54 +29,59 @@ from datetime import datetime
 from unittest.mock import patch
 from pytest import fixture
 
-from servicex_app.models import Dataset
+from servicex_app.models import Dataset, DatasetFile
 from servicex_app_test.resource_test_base import ResourceTestBase
 
 
-class TestDatasetsGetAll(ResourceTestBase):
+class TestDatasetsDelete(ResourceTestBase):
     @fixture
-    def datasets(self):
-        return [
-            Dataset(last_used=datetime(2022, 1, 1),
-                    last_updated=datetime(2022, 1, 1),
-                    id='123',
-                    name='dataset1',
-                    events=100,
-                    size=1000,
-                    n_files=1,
-                    lookup_status='looking',
-                    did_finder='rucio'),
+    def dataset(self):
+        dataset = Dataset(last_used=datetime(2022, 1, 1),
+                          last_updated=datetime(2022, 1, 1),
+                          id='123',
+                          stale=False,
+                          name='dataset1',
+                          events=100,
+                          size=1000,
+                          n_files=1,
+                          lookup_status='looking',
+                          did_finder='rucio')
+        dataset.files = [
+            DatasetFile(
+                id=12,
+                dataset_id=dataset.id,
+                file_size=100,
+                file_events=100,
+                paths=['root://root.cern.ch/file1.root']
+            )
         ]
+        return dataset
 
-    @patch('servicex_app.models.Dataset.get_by_did_finder')
-    def test_get_all_rucio(self, mock_get_by_did_finder, datasets):
-        mock_get_by_did_finder.return_value = datasets
+    @patch('servicex_app.models.Dataset.find_by_id')
+    def test_delete_dataset(self, mock_get, dataset, mocker):
+        dataset.stale = False
+        mock_get.return_value = dataset
+        dataset.save_to_db = mocker.Mock()
         client = self._test_client()
-        response = client.get('/servicex/datasets?did-finder=rucio')
-        mock_get_by_did_finder.assert_called_with('rucio')
-        assert response.status_code == 200
-
-        assert response.json == {
-            "datasets": [
-                {
-                    "last_used": "2022-01-01T00:00:00.000000Z",
-                    "last_updated": "2022-01-01T00:00:00.000000Z",
-                    "id": "123",
-                    'is-stale': None,
-                    "did_finder": "rucio",
-                    'lookup_status': 'looking',
-                    'name': 'dataset1',
-                    'size': 1000,
-                    'events': 100,
-                    'n_files': 1
-                }
-            ]
-        }
-
-    @patch('servicex_app.models.Dataset.get_all')
-    def test_get_all(self, mock_get, datasets):
-        mock_get.return_value = datasets
-        client = self._test_client()
-        response = client.get('/servicex/datasets')
+        response = client.delete('/servicex/datasets/123')
         mock_get.assert_called()
+        assert dataset.stale
+        dataset.save_to_db.assert_called()
         assert response.status_code == 200
+
+    @patch('servicex_app.models.Dataset.find_by_id')
+    def test_delete_dataset_not_found(self, mock_get):
+        mock_get.return_value = None
+        client = self._test_client()
+        response = client.delete('/servicex/datasets/123')
+        mock_get.assert_called()
+        assert response.status_code == 404
+
+    @patch('servicex_app.models.Dataset.find_by_id')
+    def test_delete_dataset_already_deleted(self, mock_get, dataset):
+        dataset.stale = True
+        mock_get.return_value = dataset
+        client = self._test_client()
+        response = client.delete('/servicex/datasets/123')
+        mock_get.assert_called()
+        assert response.status_code == 400

--- a/servicex_app/servicex_app_test/resources/datasets/test_get_all.py
+++ b/servicex_app/servicex_app_test/resources/datasets/test_get_all.py
@@ -53,7 +53,7 @@ class TestDatasetsGetAll(ResourceTestBase):
         mock_get_by_did_finder.return_value = datasets
         client = self._test_client()
         response = client.get('/servicex/datasets?did-finder=rucio')
-        mock_get_by_did_finder.assert_called_with('rucio')
+        mock_get_by_did_finder.assert_called_with('rucio', None)
         assert response.status_code == 200
 
         assert response.json == {
@@ -62,7 +62,7 @@ class TestDatasetsGetAll(ResourceTestBase):
                     "last_used": "2022-01-01T00:00:00.000000Z",
                     "last_updated": "2022-01-01T00:00:00.000000Z",
                     "id": "123",
-                    'is-stale': None,
+                    'is_stale': None,
                     "did_finder": "rucio",
                     'lookup_status': 'looking',
                     'name': 'dataset1',

--- a/servicex_app/servicex_app_test/resources/datasets/test_get_one.py
+++ b/servicex_app/servicex_app_test/resources/datasets/test_get_one.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2024, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from datetime import datetime
+from unittest.mock import patch
+from pytest import fixture
+
+from servicex_app.models import Dataset, DatasetFile
+from servicex_app_test.resource_test_base import ResourceTestBase
+
+
+class TestDatasetsGetOne(ResourceTestBase):
+    @fixture
+    def datasets(self):
+        dataset = Dataset(last_used=datetime(2022, 1, 1),
+                          last_updated=datetime(2022, 1, 1),
+                          id='123',
+                          name='dataset1',
+                          events=100,
+                          size=1000,
+                          n_files=1,
+                          lookup_status='looking',
+                          did_finder='rucio')
+        dataset.files = [
+            DatasetFile(
+                id=12,
+                dataset_id=dataset.id,
+                file_size=100,
+                file_events=100,
+                paths=['root://root.cern.ch/file1.root']
+            )
+        ]
+        return dataset
+
+    @patch('servicex_app.models.Dataset.find_by_id')
+    def test_get_one(self, mock_get, datasets):
+        mock_get.return_value = datasets
+        client = self._test_client()
+        response = client.get('/servicex/datasets/123')
+        mock_get.assert_called()
+        assert response.status_code == 200


### PR DESCRIPTION
# Problem
Once a dataset is cached in the service there is no way to evict them from the cache and force a reload. This can cause problems if the replicas move or if the dataset is updated.

Resolves #850 

# Approach
1. Add a new value to the dataset table, `stale` - this is set to True to evict a dataset from the cache
2. The find_by_name and get_all methods on Dataset model now filter out datasets where stale is True
3. Updated the data model so that did_name is no longer unique
4. Added REST endpoints to delete a dataset (which sets stale to True)
5. During development it made sense to add an endpoint to get the details of a single dataset
6. Added an argument to the REST call that retrieves datasets to also show the deleted datasets with stale=True

