### PR TITLE
Tell gunicorn to bind to IPv6 addresses

### DIFF
--- a/code_generator_funcadl_uproot/boot.sh
+++ b/code_generator_funcadl_uproot/boot.sh
@@ -4,7 +4,7 @@
 action=${1:-web_service}
 if [ "$action" = "web_service" ] ; then
     mkdir instance
-    exec gunicorn -b :5000 --workers=2 --threads=1 --access-logfile - --error-logfile - "uproot_code_generator:create_app()"
+    exec gunicorn -b [::]:5000 --workers=2 --threads=1 --access-logfile - --error-logfile - "uproot_code_generator:create_app()"
 elif [ "$action" = "translate" ]; then
     python from_ast_to_zip.py "${@:2}"
 else

--- a/code_generator_funcadl_xAOD/boot.sh
+++ b/code_generator_funcadl_xAOD/boot.sh
@@ -4,7 +4,7 @@
 action=${1:-web_service}
 if [ "$action" = "web_service" ] ; then
     mkdir instance
-    exec gunicorn -b :5000 --workers=2 --threads=1 --log-level=info --access-logfile /tmp/access --error-logfile /tmp/error "xaod_code_generator:create_app()"
+    exec gunicorn -b [::]:5000 --workers=2 --threads=1 --log-level=info --access-logfile /tmp/access --error-logfile /tmp/error "xaod_code_generator:create_app()"
 elif [ "$action" = "translate" ]; then
     python from_ast_to_zip.py "${@:2}"
 else

--- a/code_generator_python/boot.sh
+++ b/code_generator_python/boot.sh
@@ -4,7 +4,7 @@
 action=${1:-web_service}
 if [ "$action" = "web_service" ] ; then
     mkdir instance
-    exec gunicorn -b :5000 --workers=2 -t 10000 --threads=1 --access-logfile - --error-logfile - "python_code_generator:create_app()"
+    exec gunicorn -b [::]:5000 --workers=2 -t 10000 --threads=1 --access-logfile - --error-logfile - "python_code_generator:create_app()"
 elif [ "$action" = "translate" ]; then
     python from_text_to_zip.py "${@:2}"
 else

--- a/code_generator_raw_uproot/boot.sh
+++ b/code_generator_raw_uproot/boot.sh
@@ -4,7 +4,7 @@
 action=${1:-web_service}
 if [ "$action" = "web_service" ] ; then
     mkdir instance
-    exec gunicorn -b :5000 --workers=2 --threads=1 --access-logfile - --error-logfile - "servicex.raw_uproot_code_generator:create_app()"
+    exec gunicorn -b [::]:5000 --workers=2 --threads=1 --access-logfile - --error-logfile - "servicex.raw_uproot_code_generator:create_app()"
 else
     echo "Unknown action '$action'"
 fi

--- a/servicex_app/boot.sh
+++ b/servicex_app/boot.sh
@@ -7,5 +7,5 @@ else
   FLASK_APP=servicex_app/app.py flask db upgrade;
 fi
 [ -d "/default_users" ] && python3 servicex/cli/create_default_users.py
-exec gunicorn -b :5000 --workers=5 --threads=1 --timeout 120 --log-level=warning --access-logfile /tmp/gunicorn.log --error-logfile - "servicex_app:create_app()"
+exec gunicorn -b [::]:5000 --workers=5 --threads=1 --timeout 120 --log-level=warning --access-logfile /tmp/gunicorn.log --error-logfile - "servicex_app:create_app()"
 # to log requests to stdout  --access-logfile -


### PR DESCRIPTION
By default gunicorn was binding only to IPv4 addresses, potentially causing issues with dual-stack k8s clusters. This change will make it bind to both IPv4 and IPv6 local addresses.