### PR TITLE
Test for bucket exists before attempting to delete

### DIFF
--- a/servicex_app/servicex_app/object_store_manager.py
+++ b/servicex_app/servicex_app/object_store_manager.py
@@ -41,6 +41,10 @@ class ObjectStoreManager:
         return self.minio_client.list_buckets()
 
     def delete_bucket_and_contents(self,  bucket_name):
+        if not self.minio_client.bucket_exists(bucket_name):
+            print(f"Bucket '{bucket_name}' does not exist. Nothing to delete.")
+            return
+
         # List all objects in the bucket
         objects = self.minio_client.list_objects(bucket_name, recursive=True)
 


### PR DESCRIPTION
# Problem 
If the Minio Cleanup task gets to our bucket before we attempt to delete, we will get an exception when attempting to delete the transform:
```
    self.object_store.delete_bucket_and_contents(transform_req.request_id)
  File "/home/servicex/servicex_app/object_store_manager.py", line 48, in delete_bucket_and_contents
    for obj in objects:
  File "/usr/local/lib/python3.10/site-packages/minio/api.py", line 3109, in _list_objects
    response = self._execute(
  File "/usr/local/lib/python3.10/site-packages/minio/api.py", line 437, in _execute
    region = self._get_region(bucket_name)
  File "/usr/local/lib/python3.10/site-packages/minio/api.py", line 494, in _get_region
    response = self._url_open(
  File "/usr/local/lib/python3.10/site-packages/minio/api.py", line 423, in _url_open
    raise response_error
minio.error.S3Error: S3 operation failed; code: NoSuchBucket, message: The specified bucket does not exist, resource: /692f4ced-99f5-435f-82ac-6f170507d4a8, request_id: 180883343E6EED2B, host_id: 2fc60b84-3aa4-4ca2-9902-680ef5ea0d80, bucket_name: 692f4ced-99f5-435f-82ac-6f170507d4a8
```

# Aproach
Add a simple check to see that the bucket exists and just print a little warning out and move on if not