### PR TITLE
Update readthedocs build to Python 3.10

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,7 @@ formats:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.10"
 
 python:
   install:


### PR DESCRIPTION
Readthedocs build has been failing due the specified Python version being too old for the `requirements.txt`.