### PR TITLE
Clean up transaction management for file_complete handler

### DIFF
--- a/servicex_app/migrations/versions/1.5.7.py
+++ b/servicex_app/migrations/versions/1.5.7.py
@@ -1,0 +1,24 @@
+"""Add unique constraint to TransformResult on request_id and file_id
+
+Revision ID: 1.5.7
+Revises: v1_5_6
+Create Date: 2025-01-13
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'v1_5_7'
+down_revision = 'v1_5_6'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    # Add unique constraint
+    op.create_unique_constraint('uix_file_request', 'transform_result', ['file_id', 'request_id'])
+
+
+def downgrade():
+    # Remove unique constraint
+    op.drop_constraint('uix_file_request', 'transform_result', type_='unique')

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -279,24 +279,6 @@ class TransformRequest(db.Model):
         except NoResultFound:
             return []
 
-    @classmethod
-    def file_transformed_successfully(cls, key: Union[str, int]) -> None:
-        req = cls.query.filter_by(request_id=key).one()
-        req.files_completed = cls.files_completed + 1
-        db.session.commit()
-
-    @classmethod
-    def file_transformed_unsuccessfully(cls, key: Union[str, int]) -> None:
-        req = cls.query.filter_by(request_id=key).one()
-        req.files_failed = cls.files_failed + 1
-        db.session.commit()
-
-    @classmethod
-    def add_a_file(cls, key) -> None:
-        req = cls.query.filter_by(request_id=key).one()
-        req.files = TransformRequest.files + 1
-        db.session.commit()
-
     @property
     def age(self) -> timedelta:
         return datetime.utcnow() - self.submit_time

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -357,6 +357,10 @@ class TransformationResult(db.Model):
     total_bytes = db.Column(db.BigInteger, nullable=True)
     avg_rate = db.Column(db.Float, nullable=True)
 
+    __table_args__ = (
+        db.UniqueConstraint('file_id', 'request_id', name='uix_file_request'),
+    )
+
     @classmethod
     def to_json_list(cls, a_list):
         return [TransformationResult.to_json(msg) for msg in a_list]

--- a/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
+++ b/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
@@ -26,23 +26,59 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import logging
+import time
 from datetime import datetime, timezone
+from functools import wraps
 from logging import Logger
 
 from flask import request, current_app
+from sqlalchemy.orm import Session
 from tenacity import retry, stop_after_attempt, wait_exponential_jitter, \
     before_sleep_log, after_log
 
 from servicex_app import TransformerManager
 from servicex_app.models import TransformRequest, TransformationResult, db, TransformStatus
 from servicex_app.resources.servicex_resource import ServiceXResource
-import time
+
+
+def file_complete_ops_retry(func):
+    """
+    A decorator that applies a standard retry mechanism for file complete operations.
+
+    This decorator wraps the target function with a retry mechanism using the tenacity library.
+    It attempts to execute the function up to 3 times, with exponential backoff and jitter
+    between retries. The decorator also logs retry attempts and results.
+
+    Note:
+    This decorator is designed to work both within and outside of a Flask application context.
+    It dynamically evaluates the logger at runtime to support usage in various environments,
+    including unit tests.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+
+        try:
+            from flask import current_app
+            logger = current_app.logger
+        except RuntimeError:
+            logger = logging.getLogger(__name__)
+
+        return retry(
+            stop=stop_after_attempt(3),
+            wait=wait_exponential_jitter(initial=0.1, max=30),
+            before_sleep=before_sleep_log(logger, logging.INFO),
+            after=after_log(logger, logging.INFO)
+        )(func)(*args, **kwargs)
+
+    return wrapper
 
 
 class TransformerFileComplete(ServiceXResource):
     @classmethod
-    def make_api(cls, transformer_manager):
+    def make_api(cls, transformer_manager, logger=None):
         cls.transformer_manager = transformer_manager
+        cls.logger = logger or logging.getLogger(__name__)
         return cls
 
     def put(self, request_id):
@@ -50,16 +86,24 @@ class TransformerFileComplete(ServiceXResource):
         info = request.get_json()
         logger = current_app.logger
         logger.info("FileComplete", extra={'requestId': request_id, 'metric': info})
-        transform_req = self.record_file_complete(current_app.logger, request_id, info)
+
+        session = db.session
+
+        # Lookup the transformation request and increment either the successful or failed file count
+        transform_req = self.record_file_complete(session, current_app.logger, request_id, info)
 
         if transform_req is None:
             return "Request not found", 404
 
-        self.save_transform_result(transform_req, info)
+        # Add the transformation result to the database
+        files_remaining = self.save_transform_result(transform_req, info, session)
 
-        files_remaining = transform_req.files_remaining
+        # Now we can see if we are done with the transformation and
+        # can shut down the transformers. Files remaining is None if
+        # we are still waiting for final results from the DID finder
+
         if files_remaining is not None and files_remaining == 0:
-            self.transform_complete(current_app.logger, transform_req, self.transformer_manager)
+            self.transform_complete(session, current_app.logger, transform_req, self.transformer_manager)
 
         current_app.logger.info("FileComplete. Request state.", extra={
             'requestId': request_id,
@@ -71,57 +115,55 @@ class TransformerFileComplete(ServiceXResource):
         return "Ok"
 
     @staticmethod
-    @retry(stop=stop_after_attempt(3),
-           wait=wait_exponential_jitter(initial=0.1, max=30),
-           before_sleep=before_sleep_log(current_app.logger, logging.INFO),
-           after=after_log(current_app.logger, logging.INFO),
-           )
-    def record_file_complete(logger: Logger, request_id: str, info: dict[str, str]) -> TransformRequest | None:
-        transform_req = TransformRequest.lookup(request_id)
-        if transform_req is None:
-            msg = f"Request not found with id: '{request_id}'"
-            logger.error(msg, extra={'requestId': request_id})
-            return None
+    @file_complete_ops_retry
+    def record_file_complete(session: Session, logger: Logger, request_id: str,
+                             info: dict[str, str]) -> TransformRequest | None:
 
-        if info['status'] == 'success':
-            TransformRequest.file_transformed_successfully(request_id)
-        else:
-            TransformRequest.file_transformed_unsuccessfully(request_id)
+        with session.begin():
+            # Lock the row for update
+            transform_req = session.query(TransformRequest).filter_by(
+                request_id=request_id).with_for_update().one_or_none()
+
+            if transform_req is None:
+                msg = f"Request not found with id: '{request_id}'"
+                logger.error(msg, extra={'requestId': request_id})
+                return None
+
+            if info['status'] == 'success':
+                transform_req.files_completed += 1
+            else:
+                transform_req.files_failed += 1
+
+        session.flush()  # Flush the changes to the database
 
         return transform_req
 
     @staticmethod
-    @retry(stop=stop_after_attempt(3),
-           wait=wait_exponential_jitter(initial=0.1, max=30),
-           before_sleep=before_sleep_log(current_app.logger, logging.INFO),
-           after=after_log(current_app.logger, logging.INFO),
-           )
-    def save_transform_result(transform_req: TransformRequest, info: dict[str, str]):
-        rec = TransformationResult(
-            file_id=info['file-id'],
-            request_id=transform_req.request_id,
-            file_path=info['file-path'],
-            transform_status=info['status'],
-            transform_time=info['total-time'],
-            total_bytes=info['total-bytes'],
-            total_events=info['total-events'],
-            avg_rate=info['avg-rate']
-        )
-        rec.save_to_db()
-        db.session.commit()
+    @file_complete_ops_retry
+    def save_transform_result(transform_req: TransformRequest, info: dict[str, str], session: Session):
+        with session.begin():
+            rec = TransformationResult(
+                file_id=info['file-id'],
+                request_id=transform_req.request_id,
+                file_path=info['file-path'],
+                transform_status=info['status'],
+                transform_time=info['total-time'],
+                total_bytes=info['total-bytes'],
+                total_events=info['total-events'],
+                avg_rate=info['avg-rate']
+            )
+            session.add(rec)
+            return transform_req.files_remaining
 
     @staticmethod
-    @retry(stop=stop_after_attempt(3),
-           wait=wait_exponential_jitter(initial=0.1, max=30),
-           before_sleep=before_sleep_log(current_app.logger, logging.INFO),
-           after=after_log(current_app.logger, logging.INFO),
-           )
-    def transform_complete(logger: Logger, transform_req: TransformRequest,
+    @file_complete_ops_retry
+    def transform_complete(session: Session, logger: Logger, transform_req: TransformRequest,
                            transformer_manager: TransformerManager):
-        transform_req.status = TransformStatus.complete
-        transform_req.finish_time = datetime.now(tz=timezone.utc)
-        transform_req.save_to_db()
-        db.session.commit()
+        with session.begin():
+            transform_req.status = TransformStatus.complete
+            transform_req.finish_time = datetime.now(tz=timezone.utc)
+            session.add(transform_req)
+
         logger.info("Request completed. Shutting down transformers",
                     extra={'requestId': transform_req.request_id})
         namespace = current_app.config['TRANSFORMER_NAMESPACE']

--- a/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
+++ b/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
@@ -31,13 +31,15 @@ from datetime import datetime, timezone
 from functools import wraps
 from logging import Logger
 
-from flask import request, current_app
+from flask import current_app, request
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
-from tenacity import retry, stop_after_attempt, wait_exponential_jitter, \
-    before_sleep_log, after_log
+from tenacity import after_log, before_sleep_log, retry, retry_if_not_exception_type, \
+    stop_after_attempt, wait_exponential_jitter
 
 from servicex_app import TransformerManager
-from servicex_app.models import TransformRequest, TransformationResult, db, TransformStatus
+from servicex_app.models import TransformRequest, TransformStatus, TransformationResult, \
+    db
 from servicex_app.resources.servicex_resource import ServiceXResource
 
 
@@ -65,7 +67,8 @@ def file_complete_ops_retry(func):
             logger = logging.getLogger(__name__)
 
         return retry(
-            stop=stop_after_attempt(3),
+            retry=retry_if_not_exception_type(IntegrityError),
+            stop=stop_after_attempt(5),
             wait=wait_exponential_jitter(initial=0.1, max=30),
             before_sleep=before_sleep_log(logger, logging.INFO),
             after=after_log(logger, logging.INFO)
@@ -85,39 +88,59 @@ class TransformerFileComplete(ServiceXResource):
         start_time = time.time()
         info = request.get_json()
         logger = current_app.logger
-        logger.info("FileComplete", extra={'requestId': request_id, 'metric': info})
+        log_extra = {
+                    'requestId': request_id,
+                    'file-id': info['file-id']
+        }
 
-        session = db.session
+        logger.info("FileComplete", extra={**log_extra, 'metric': info})
+        try:
+            session = db.session
 
-        # Lookup the transformation request and increment either the successful or failed file count
-        transform_req = self.record_file_complete(session, current_app.logger, request_id, info)
+            try:
+                # Add the transformation result to the database and verify that
+                # we've not processed this file already
+                self.save_transform_result(request_id, info, session)
+            except IntegrityError:
+                logger.warning("Ignoring duplicate result report",
+                               extra=log_extra)
+                return "Ignoring duplicate result report", 200
 
-        if transform_req is None:
-            return "Request not found", 404
+            # Lookup the transformation request and increment either the successful or failed file count
+            transform_req = self.record_file_complete(session,
+                                                      current_app.logger,
+                                                      request_id,
+                                                      info, log_extra)
 
-        # Add the transformation result to the database
-        files_remaining = self.save_transform_result(transform_req, info, session)
+            if transform_req is None:
+                logger.error("Request not found", extra=log_extra)
+                return "Request not found", 404
 
-        # Now we can see if we are done with the transformation and
-        # can shut down the transformers. Files remaining is None if
-        # we are still waiting for final results from the DID finder
+            # Now we can see if we are done with the transformation and
+            # can shut down the transformers. Files remaining is None if
+            # we are still waiting for final results from the DID finder
+            with session.begin():
+                files_remaining = transform_req.files_remaining
+                if files_remaining is not None and files_remaining == 0:
+                    self.transform_complete(session, current_app.logger, transform_req, self.transformer_manager)
 
-        if files_remaining is not None and files_remaining == 0:
-            self.transform_complete(session, current_app.logger, transform_req, self.transformer_manager)
-
-        current_app.logger.info("FileComplete. Request state.", extra={
-            'requestId': request_id,
-            'files_remaining': transform_req.files_remaining,
-            'files_completed': transform_req.files_completed,
-            'files_failed': transform_req.files_failed,
-            'report_processed_time': (time.time() - start_time)
-        })
-        return "Ok"
+            current_app.logger.info("FileComplete. Request state.", extra={
+                **log_extra,
+                'files_remaining': transform_req.files_remaining,
+                'files_completed': transform_req.files_completed,
+                'files_failed': transform_req.files_failed,
+                'report_processed_time': (time.time() - start_time)
+            })
+            return "Ok", 200
+        except Exception as e:
+            logger.exception("Error processing file complete",
+                             extra=log_extra, exc_info=e)
+            return "Error processing file complete", 500
 
     @staticmethod
     @file_complete_ops_retry
     def record_file_complete(session: Session, logger: Logger, request_id: str,
-                             info: dict[str, str]) -> TransformRequest | None:
+                             info: dict[str, str], log_extra: dict[str, str]) -> TransformRequest | None:
 
         with session.begin():
             # Lock the row for update
@@ -126,7 +149,7 @@ class TransformerFileComplete(ServiceXResource):
 
             if transform_req is None:
                 msg = f"Request not found with id: '{request_id}'"
-                logger.error(msg, extra={'requestId': request_id})
+                logger.error(msg, extra=log_extra)
                 return None
 
             if info['status'] == 'success':
@@ -134,17 +157,15 @@ class TransformerFileComplete(ServiceXResource):
             else:
                 transform_req.files_failed += 1
 
-        session.flush()  # Flush the changes to the database
-
         return transform_req
 
     @staticmethod
     @file_complete_ops_retry
-    def save_transform_result(transform_req: TransformRequest, info: dict[str, str], session: Session):
+    def save_transform_result(request_id: str, info: dict[str, str], session: Session):
         with session.begin():
             rec = TransformationResult(
                 file_id=info['file-id'],
-                request_id=transform_req.request_id,
+                request_id=request_id,
                 file_path=info['file-path'],
                 transform_status=info['status'],
                 transform_time=info['total-time'],
@@ -153,16 +174,14 @@ class TransformerFileComplete(ServiceXResource):
                 avg_rate=info['avg-rate']
             )
             session.add(rec)
-            return transform_req.files_remaining
 
     @staticmethod
     @file_complete_ops_retry
     def transform_complete(session: Session, logger: Logger, transform_req: TransformRequest,
                            transformer_manager: TransformerManager):
-        with session.begin():
-            transform_req.status = TransformStatus.complete
-            transform_req.finish_time = datetime.now(tz=timezone.utc)
-            session.add(transform_req)
+        transform_req.status = TransformStatus.complete
+        transform_req.finish_time = datetime.now(tz=timezone.utc)
+        session.add(transform_req)
 
         logger.info("Request completed. Shutting down transformers",
                     extra={'requestId': transform_req.request_id})

--- a/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
@@ -25,17 +25,17 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from unittest.mock import patch, PropertyMock
 
 import psycopg2
 import pytest
 
-from servicex_app.models import DatasetFile, TransformationResult, TransformRequest
+from servicex_app.models import TransformationResult, TransformRequest, TransformStatus
 from servicex_app.transformer_manager import TransformerManager
 from servicex_app_test.resource_test_base import ResourceTestBase
 
 
 class TestTransformFileComplete(ResourceTestBase):
+    module = "servicex_app.resources.internal.transformer_file_complete"
 
     @pytest.fixture
     def mock_transformer_manager(self, mocker):
@@ -44,33 +44,24 @@ class TestTransformFileComplete(ResourceTestBase):
         return manager
 
     @pytest.fixture
+    def db_session(self, mocker):
+        db = mocker.patch(f"{self.module}.db")
+        db.session = mocker.Mock()
+        db.session.begin = mocker.MagicMock()
+        return db.session
+
+    @pytest.fixture
     def fake_transform_request(self):
-        return self._generate_transform_request()
+        fake_request = self._generate_transform_request()
+        fake_request.request_id = '1234'
+        fake_request.status = TransformStatus.running
+        fake_request.files = 10
+        return fake_request
 
     @pytest.fixture
-    def mock_transform_request_lookup(self, mocker, fake_transform_request):
-        with patch('servicex_app.models.TransformRequest.lookup') as mock:
-            mock.return_value = fake_transform_request
-            yield mock
-
-    @pytest.fixture
-    def mock_files_remaining(self, mocker):
-        with patch('servicex_app.models.TransformRequest.files_remaining',
-                   new_callable=PropertyMock) as mock_remaining:
-            mock_remaining.return_value = 1
-            yield mock_remaining
-
-    @pytest.fixture
-    def mock_file_transformed_successfully(self, mocker):
-        return mocker.patch.object(
-            TransformRequest,
-            "file_transformed_successfully")
-
-    @pytest.fixture
-    def mock_file_transformed_unsuccessfully(self, mocker):
-        return mocker.patch.object(
-            TransformRequest,
-            "file_transformed_unsuccessfully")
+    def mock_transform_request_lookup(self, mocker, db_session, fake_transform_request):
+        db_session.query.return_value.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = fake_transform_request
+        return db_session.query.return_value.filter_by.return_value.with_for_update.return_value.one_or_none
 
     @pytest.fixture
     def test_client(self, mock_transformer_manager):
@@ -91,85 +82,93 @@ class TestTransformFileComplete(ResourceTestBase):
 
     def test_put_transform_file_complete_files_remaining(self,
                                                          mock_transformer_manager,
-                                                         mock_files_remaining,
-                                                         mock_file_transformed_successfully,
+                                                         db_session,
                                                          mock_transform_request_lookup,
                                                          fake_transform_request,
                                                          file_complete_response,
                                                          test_client):
+        fake_transform_request.files_completed = 0
+        fake_transform_request.files_failed = 2
         response = test_client.put('/servicex/internal/transformation/1234/file-complete',
                                    json=file_complete_response)
         assert response.status_code == 200
         assert fake_transform_request.finish_time is None
-        mock_transform_request_lookup.assert_called_with('1234')
-        mock_file_transformed_successfully.assert_called_with("1234")
-        mock_files_remaining.assert_called()
+        db_session.query.return_value.filter_by.assert_called_with(request_id='1234')
+        assert fake_transform_request.files_completed == 1
+        assert fake_transform_request.files_failed == 2
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
+        db_session.add.assert_called_once()
+        assert db_session.add.call_args[0][0].file_id == 42
 
     def test_put_transform_file_complete_unknown_files_remaining(self,
                                                                  mock_transformer_manager,
-                                                                 mock_files_remaining,
-                                                                 mock_file_transformed_successfully,
+                                                                 db_session,
                                                                  mock_transform_request_lookup,
                                                                  fake_transform_request,
                                                                  file_complete_response,
                                                                  test_client):
-        mock_files_remaining.return_value = None
+        fake_transform_request.files = None
+        fake_transform_request.files_completed = 0
+        fake_transform_request.files_failed = 2
 
         response = test_client.put('/servicex/internal/transformation/1234/file-complete',
                                    json=file_complete_response)
         assert response.status_code == 200
         assert fake_transform_request.finish_time is None
-        mock_transform_request_lookup.assert_called_with('1234')
-        mock_file_transformed_successfully.assert_called_with("1234")
-        mock_files_remaining.assert_called()
-
+        db_session.query.return_value.filter_by.assert_called_with(request_id='1234')
+        assert fake_transform_request.files_completed == 1
+        assert fake_transform_request.files_failed == 2
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
+        db_session.add.assert_called_once()
+        assert db_session.add.call_args[0][0].file_id == 42
 
-    def test_put_transform_file_complete_no_files_remaining(self, mocker,
+    def test_put_transform_file_complete_no_files_remaining(self,
                                                             mock_transformer_manager,
-                                                            mock_files_remaining,
-                                                            mock_file_transformed_successfully,
+                                                            db_session,
                                                             mock_transform_request_lookup,
                                                             fake_transform_request,
                                                             file_complete_response,
                                                             test_client):
+        fake_transform_request.files_completed = 7
+        fake_transform_request.files_failed = 2
 
-        mock_files_remaining.return_value = 0
-
-        mocker.patch.object(DatasetFile, "get_by_id")
-        mocker.patch.object(TransformationResult, "save_to_db")
-        mocker.patch.object(TransformRequest, "save_to_db")
-
-        response = test_client.put('/servicex/internal/transformation/BR549/file-complete',
+        response = test_client.put('/servicex/internal/transformation/1234/file-complete',
                                    json=file_complete_response)
 
         assert response.status_code == 200
-        assert fake_transform_request.finish_time is not None
-        mock_transform_request_lookup.assert_called_with('BR549')
-        mock_file_transformed_successfully.assert_called_with("BR549")
-        mock_files_remaining.assert_called()
-        mock_transformer_manager.shutdown_transformer_job.assert_called_with('BR549',
+        db_session.query.return_value.filter_by.assert_called_with(request_id='1234')
+        assert fake_transform_request.files_completed == 8
+        assert fake_transform_request.files_failed == 2
+
+        assert db_session.add.call_count == 2
+        assert isinstance(db_session.add.mock_calls[0][1][0], TransformationResult)
+        assert db_session.add.mock_calls[0][1][0].file_id == 42
+
+        updated_transform = db_session.add.mock_calls[1][1][0]
+        assert isinstance(updated_transform, TransformRequest)
+        assert updated_transform.status == TransformStatus.complete
+        assert updated_transform.finish_time is not None
+        mock_transformer_manager.shutdown_transformer_job.assert_called_with('1234',
                                                                              'my-ws')
 
     def test_put_transform_file_complete_unknown_request_id(self,
                                                             mock_transformer_manager,
+                                                            db_session,
                                                             mock_transform_request_lookup,
                                                             fake_transform_request,
                                                             file_complete_response,
                                                             test_client):
         mock_transform_request_lookup.return_value = None
-        response = test_client.put('/servicex/internal/transformation/BR549/file-complete',
+        response = test_client.put('/servicex/internal/transformation/1234/file-complete',
                                    json=file_complete_response)
 
         assert response.status_code == 404
-        mock_transform_request_lookup.assert_called_with('BR549')
+        db_session.query.return_value.filter_by.assert_called_with(request_id='1234')
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
 
     def test_database_error_request_read(self, mocker,
                                          mock_transformer_manager,
-                                         mock_files_remaining,
-                                         mock_file_transformed_successfully,
+                                         db_session,
                                          mock_transform_request_lookup,
                                          fake_transform_request,
                                          file_complete_response,
@@ -179,30 +178,29 @@ class TestTransformFileComplete(ResourceTestBase):
             fake_transform_request
         ]
 
-        response = test_client.put('/servicex/internal/transformation/BR549/file-complete',
+        response = test_client.put('/servicex/internal/transformation/1234/file-complete',
                                    json=file_complete_response)
         assert response.status_code == 200
         assert fake_transform_request.finish_time is None
 
         # Verify that we retried after the database error
         assert mock_transform_request_lookup.call_count == 2
-        mock_transform_request_lookup.assert_called_with('BR549')
+        db_session.query.return_value.filter_by.assert_called_with(request_id='1234')
 
-        mock_files_remaining.assert_called()
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
 
     def test_database_error_request_update(self,
                                            mock_transformer_manager,
-                                           mock_files_remaining,
-                                           mock_file_transformed_successfully,
+                                           db_session,
                                            mock_transform_request_lookup,
                                            fake_transform_request,
                                            file_complete_response,
                                            test_client):
 
-        mock_file_transformed_successfully.side_effect = [
-                                    psycopg2.OperationalError('server closed the connection unexpectedly'),
-                                    None]
+        db_session.flush.side_effect = [
+            psycopg2.OperationalError('server closed the connection unexpectedly'),
+            fake_transform_request
+        ]
 
         response = test_client.put('/servicex/internal/transformation/1234/file-complete',
                                    json=file_complete_response)
@@ -210,48 +208,48 @@ class TestTransformFileComplete(ResourceTestBase):
         assert fake_transform_request.finish_time is None
 
         # Verify that we retried after the database error
-        assert mock_transform_request_lookup.call_count == 2
-        mock_transform_request_lookup.assert_called_with('1234')
+        assert db_session.flush.call_count == 2
+        db_session.query.return_value.filter_by.assert_called_with(request_id='1234')
 
-        mock_files_remaining.assert_called()
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
 
-    def test_database_error_transform_result_save(self, mocker,
+    def test_database_error_transform_result_save(self,
                                                   mock_transformer_manager,
-                                                  mock_files_remaining,
-                                                  mock_file_transformed_successfully,
+                                                  db_session,
                                                   mock_transform_request_lookup,
                                                   fake_transform_request,
                                                   file_complete_response,
                                                   test_client):
 
-        mock_save_db = mocker.patch.object(TransformationResult, "save_to_db",
-                                           side_effect=[
-                                               psycopg2.OperationalError('server closed the connection unexpectedly'),
-                                               None
-                                           ])
+        db_session.add.side_effect = [
+            psycopg2.OperationalError('server closed the connection unexpectedly'),
+            fake_transform_request
+        ]
+
         response = test_client.put('/servicex/internal/transformation/1234/file-complete',
                                    json=file_complete_response)
         assert response.status_code == 200
-        assert mock_save_db.call_count == 2
 
-    def test_database_error_transform_complete(self, mocker,
+    def test_database_error_transform_complete(self,
                                                mock_transformer_manager,
-                                               mock_files_remaining,
-                                               mock_file_transformed_successfully,
+                                               db_session,
                                                mock_transform_request_lookup,
                                                fake_transform_request,
                                                file_complete_response,
                                                test_client):
 
         # Trigger the fileset complete by setting the files_remaining to 0
-        mock_files_remaining.return_value = 0
+        fake_transform_request.files_completed = 9
 
-        fake_transform_request.save_to_db = mocker.Mock(side_effect=[
-                                               psycopg2.OperationalError('server closed the connection unexpectedly'),
-                                               None
-                                           ])
+        db_session.add.side_effect = [
+            fake_transform_request,
+            psycopg2.OperationalError('server closed the connection unexpectedly'),
+            fake_transform_request
+        ]
+
         response = test_client.put('/servicex/internal/transformation/1234/file-complete',
                                    json=file_complete_response)
         assert response.status_code == 200
-        assert fake_transform_request.save_to_db.call_count == 2
+        # add called once for the transform result and then once for the updated transform request
+        # once with a failure and once successfully
+        assert db_session.add.call_count == 3

--- a/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
@@ -28,6 +28,7 @@
 
 import psycopg2
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from servicex_app.models import TransformationResult, TransformRequest, TransformStatus
 from servicex_app.transformer_manager import TransformerManager
@@ -151,6 +152,45 @@ class TestTransformFileComplete(ResourceTestBase):
         mock_transformer_manager.shutdown_transformer_job.assert_called_with('1234',
                                                                              'my-ws')
 
+    def test_put_transform_file_complete_duplicate_report(self,
+                                                          mocker,
+                                                          mock_transformer_manager,
+                                                          db_session,
+                                                          mock_transform_request_lookup,
+                                                          fake_transform_request,
+                                                          file_complete_response,
+                                                          test_client):
+        fake_transform_request.files_completed = 6
+        fake_transform_request.files_failed = 2
+        db_session.add.side_effect = [
+            None,
+            IntegrityError('duplicate key value violates unique constraint',
+                           params=['request_id'], orig=Exception())
+        ]
+
+        response1 = test_client.put(
+            '/servicex/internal/transformation/1234/file-complete',
+            json=file_complete_response)
+
+        response2 = test_client.put(
+            '/servicex/internal/transformation/1234/file-complete',
+            json=file_complete_response)
+
+        assert response1.status_code == 200
+        assert response2.status_code == 200
+
+        db_session.query.return_value.filter_by.assert_called_with(request_id='1234')
+        assert fake_transform_request.files_completed == 7
+        assert fake_transform_request.files_failed == 2
+
+        assert db_session.add.call_count == 2
+        assert isinstance(db_session.add.mock_calls[0][1][0], TransformationResult)
+        assert db_session.add.mock_calls[0][1][0].file_id == 42
+
+        assert db_session.add.call_count == 2
+        assert db_session.add.mock_calls[0][1][0].file_id == 42
+        assert db_session.add.mock_calls[1][1][0].file_id == 42
+
     def test_put_transform_file_complete_unknown_request_id(self,
                                                             mock_transformer_manager,
                                                             db_session,
@@ -208,7 +248,6 @@ class TestTransformFileComplete(ResourceTestBase):
         assert fake_transform_request.finish_time is None
 
         # Verify that we retried after the database error
-        assert db_session.flush.call_count == 2
         db_session.query.return_value.filter_by.assert_called_with(request_id='1234')
 
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -74,6 +74,7 @@ MAX_PATH_LEN = 255
 PLACE = {
     "host_name": os.getenv("HOST_NAME", "unknown"),
     "site": os.getenv("site", "unknown"),
+    "pod": os.getenv("POD_NAME", "unknown"),
 }
 
 

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -30,6 +30,7 @@ import json
 import os
 import shutil
 import sys
+import time
 import timeit
 from argparse import Namespace
 from hashlib import sha1, sha256
@@ -39,20 +40,20 @@ from typing import NamedTuple, Optional, Union
 
 import kombu
 import psutil as psutil
-import time
 from celery import Celery, shared_task
 from celery.signals import after_setup_logger
 
+from transformer_sidecar.object_store_manager import ObjectStoreError, ObjectStoreManager
 from transformer_sidecar.science_container_command import ScienceContainerCommand, \
     ScienceContainerException
+from transformer_sidecar.servicex_adapter import FileCompleteRecord, ServiceXAdapter
+from transformer_sidecar.transformer_argument_parser import TransformerArgumentParser
 from transformer_sidecar.transformer_logging import initialize_logging
 from transformer_sidecar.transformer_stats import TransformerStats
 from transformer_sidecar.transformer_stats.aod_stats import AODStats  # NOQA: 401
+from transformer_sidecar.transformer_stats.raw_uproot_stats import \
+    RawUprootStats  # NOQA: 401
 from transformer_sidecar.transformer_stats.uproot_stats import UprootStats  # NOQA: 401
-from transformer_sidecar.transformer_stats.raw_uproot_stats import RawUprootStats  # NOQA: 401
-from transformer_sidecar.object_store_manager import ObjectStoreManager, ObjectStoreError
-from transformer_sidecar.servicex_adapter import ServiceXAdapter, FileCompleteRecord
-from transformer_sidecar.transformer_argument_parser import TransformerArgumentParser
 
 # Module globals
 shared_dir: Optional[str] = None
@@ -80,7 +81,9 @@ start_time = timeit.default_timer()
 logger = initialize_logging()
 
 
-@shared_task(acks_late=True)
+@shared_task(
+    acks_late=True,
+)
 def transform_file(
         request_id,
         file_id,
@@ -107,6 +110,12 @@ def transform_file(
 
     global shared_dir
 
+    log_extra = {
+        "requestId": request_id,
+        "file-id": file_id,
+        "place": PLACE
+    }
+
     transform_request = {
         "file-id": file_id,
         "request-id": request_id,
@@ -128,13 +137,11 @@ def transform_file(
     logger.info(
         "got transform request.",
         extra={
-            "requestId": request_id,
+            **log_extra,
             "paths": _file_paths,
-            "file-id": file_id,
             "result-destination": result_destination,
             "result-format": result_format,
             "service-endpoint": service_endpoint,
-            "place": PLACE,
         },
     )
     servicex = ServiceXAdapter(service_endpoint)
@@ -158,10 +165,8 @@ def transform_file(
             logger.info(
                 "trying to transform file",
                 extra={
-                    "requestId": request_id,
-                    "file-id": file_id,
+                    **log_extra,
                     "file-path": _file_path,
-                    "place": PLACE,
                 },
             )
 
@@ -193,6 +198,10 @@ def transform_file(
             science_container_response = science_container.await_response()
 
             transform_request["status"] = science_container_response
+            logger.info(
+                "Science container completed with status %s" % science_container_response,
+                extra=log_extra
+            )
 
             # Grab the logs
             transformer_stats = fill_stats_parser(
@@ -220,11 +229,9 @@ def transform_file(
 
                 transform_success = True
                 ts = {
-                    "requestId": request_id,
-                    "file-id": file_id,
+                    **log_extra,
                     "file-size": transformer_stats.file_size,
                     "total-events": transformer_stats.total_events,
-                    "place": PLACE,
                 }
                 logger.info("Transformer stats.", extra=ts)
                 science_container.confirm()
@@ -236,10 +243,8 @@ def transform_file(
         # a hard failure with this file.
         if not transform_success:
             hf = {
-                "requestId": request_id,
+                **log_extra,
                 "file-path": _file_paths[0],
-                "file-id": file_id,
-                "place": PLACE,
                 "log_body": transformer_stats.log_body,
             }
             logger.error(f"Hard Failure: {transformer_stats.error_info}", extra=hf)
@@ -266,20 +271,21 @@ def transform_file(
         logger.info(
             "File processed.",
             extra={
-                "requestId": request_id,
-                "file-id": file_id,
+                **log_extra,
                 "user": elapsed_times.user,
                 "sys": elapsed_times.system,
                 "iowait": elapsed_times.iowait,
-                "place": PLACE,
             },
         )
 
-    except ScienceContainerException:
-        logger.exception("Science container not responding. Shutting down this transformer.")
-        sys.exit(0)
+    except ScienceContainerException as e:
+        logger.exception("Science container not responding. Shutting down this transformer.",
+                         extra=log_extra, exc_info=e)
+        sys.exit(-1)
+
     except Exception as error:
-        logger.exception(f"Received exception doing transform: {error}")
+        logger.exception("Received exception doing transform",
+                         extra=log_extra, exc_info=error)
         rec = FileCompleteRecord(
             request_id=request_id,
             file_path=_file_paths[0],
@@ -456,7 +462,7 @@ def init(args: Union[Namespace, SimpleNamespace], app: Celery) -> None:
             "--without-mingle",
             "--without-gossip",
             "--without-heartbeat",
-            "--loglevel=warning",
+            "--loglevel=info",
             "-Q", f"transformer-{args.request_id}",
             "-n",
             f"transformer-{args.request_id}@%h",

--- a/transformer_sidecar/tests/test_transformer.py
+++ b/transformer_sidecar/tests/test_transformer.py
@@ -131,7 +131,7 @@ def test_transformer_init(args, mock_celery, transformer_capabilities,
                 '--without-mingle',
                 '--without-gossip',
                 '--without-heartbeat',
-                "--loglevel=warning",
+                "--loglevel=info",
                 '-Q', 'transformer-1234',
                 "-n", "transformer-1234@%h",
             ]

--- a/transformer_sidecar/tests/test_transformer.py
+++ b/transformer_sidecar/tests/test_transformer.py
@@ -128,7 +128,7 @@ def test_transformer_init(args, mock_celery, transformer_capabilities,
             argv=[
                 "worker",
                 "--concurrency=1",
-                '--without-mingle',
+                "--without-mingle",
                 '--without-gossip',
                 '--without-heartbeat',
                 "--loglevel=info",


### PR DESCRIPTION
# Problem
The TransformerFileComplete resource handler is the most critical code in the entire stack. It responds to each file in the dataset being transformed, and is responsible for updating the total number of files processed (either successfully, or failure) - these two counters are how we determine if the transform is complete. The endpoint will be hit repeatedly by all of the running transformers. Consequently, database transaction handing is very important to avoid missing files.

The current implementation uses implicit transactions and doesn't manage locks and flushing to the DB. It's possible that this allows for files to be lost during big transform requests.

# Approach
1.  Us the DB session to explicitly manage transactions
2. Update the `record_file_complete` to read the request with `with_for_update` flag set which will lock the record in the db
3. The increments to files are handled in the same transaction
4. To make the file more readable, the `retry` call arguments are captured in a single, new decorator.`file_complete_ops_retry` - 

With this decorator, I ran into a problem with unit tests. Importing the module caused the `current_app.logger` expression to be evaluated. This would throw `RuntimeError: Working outside of application context.` in the unit tests. Worked around this in the decorator to only access that logger if we are inside the flask app

