### PR TITLE
894 objectstore errors

### DIFF
--- a/transformer_sidecar/src/transformer_sidecar/object_store_manager.py
+++ b/transformer_sidecar/src/transformer_sidecar/object_store_manager.py
@@ -27,7 +27,13 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import os
 import logging
+import traceback
+
 from minio.error import MinioException, S3Error
+
+
+class ObjectStoreError(Exception):
+    pass
 
 
 class ObjectStoreManager:
@@ -58,12 +64,16 @@ class ObjectStoreManager:
                                                    file_path=path)
             self.logger.info("OSM > created object.", extra={
                              "requestId": bucket, "object": result.object_name})
-        except S3Error:
+        except S3Error as e:
             self.logger.error("S3Error", exc_info=True)
-        except MinioException:
+            traceback.print_exc()
+            raise ObjectStoreError(f"Error uploading file to object store: {path}") from e
+        except MinioException as e:
             self.logger.error("Minio error", exc_info=True)
+            traceback.print_exc()
+            raise ObjectStoreError(f"Error uploading file to object store: {path}") from e
 
         try:
             os.remove(path)
         except FileNotFoundError:
-            pass
+            pass  # Should never happen, but is not fatal if it occurs

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -33,7 +33,6 @@ import sys
 import timeit
 from argparse import Namespace
 from hashlib import sha1, sha256
-from multiprocessing import Queue
 from pathlib import Path
 from types import SimpleNamespace
 from typing import NamedTuple, Optional, Union
@@ -61,8 +60,6 @@ object_store = None
 posix_path: str = ""
 startup_time = None
 convert_root_to_parquet: bool = False
-
-upload_queue: Optional[Queue] = None
 
 science_container: Optional[ScienceContainerCommand] = None
 transformer_capabilities: dict = {}
@@ -103,8 +100,7 @@ def transform_file(
 
     This control document is sent via a socket to the science image.
     Once science image has done its job, it sends back a message over the socket.
-    The sidecar will then add the parquet/root file in the output directory to the
-    S3 upload queue.
+    The sidecar will then upload the file to object store
 
     We will examine this log file to see if the transform succeeded or failed
     """
@@ -407,7 +403,7 @@ def read_capabilities_file() -> dict[str, str]:
 
 
 def init(args: Union[Namespace, SimpleNamespace], app: Celery) -> None:
-    global convert_root_to_parquet, startup_time, upload_queue, \
+    global convert_root_to_parquet, startup_time, \
         object_store, posix_path, science_container, \
         shared_dir, transformer_capabilities, request_id, celery_app
 

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -51,7 +51,7 @@ from transformer_sidecar.transformer_stats import TransformerStats
 from transformer_sidecar.transformer_stats.aod_stats import AODStats  # NOQA: 401
 from transformer_sidecar.transformer_stats.uproot_stats import UprootStats  # NOQA: 401
 from transformer_sidecar.transformer_stats.raw_uproot_stats import RawUprootStats  # NOQA: 401
-from transformer_sidecar.object_store_manager import ObjectStoreManager
+from transformer_sidecar.object_store_manager import ObjectStoreManager, ObjectStoreError
 from transformer_sidecar.servicex_adapter import ServiceXAdapter, FileCompleteRecord
 from transformer_sidecar.transformer_argument_parser import TransformerArgumentParser
 
@@ -348,15 +348,25 @@ def upload_file(source_path: Path,
                        "place": PLACE,
                        "objectName": object_name})
     t0 = time.time()
-    object_store.upload_file(request_id, object_name, file_to_upload.as_posix())
-    logger.info("File uploaded to object store.",
-                extra={'requestId': request_id,
-                       "file-id": rec.file_id,
-                       "place": PLACE,
-                       "objectName": object_name,
-                       "elapsed": time.time()-t0})
+    try:
+        object_store.upload_file(request_id, object_name, file_to_upload.as_posix())
+        logger.info("File uploaded to object store.",
+                    extra={'requestId': request_id,
+                           "file-id": rec.file_id,
+                           "place": PLACE,
+                           "objectName": object_name,
+                           "elapsed": time.time()-t0})
 
-    servicex.put_file_complete(rec)
+        servicex.put_file_complete(rec)
+
+    except ObjectStoreError as e:
+        logger.error(f"Error uploading file to object store: {e}",
+                     extra={'requestId': request_id, "place": PLACE,
+                            "file-id": rec.file_id,
+                            "objectName": object_name}
+                     )
+        rec.status = "failure"
+        servicex.put_file_complete(rec)
 
 
 class TimeTuple(NamedTuple):

--- a/transformer_sidecar/tests/test_object_store_manager.py
+++ b/transformer_sidecar/tests/test_object_store_manager.py
@@ -27,7 +27,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import os
 
-from transformer_sidecar.object_store_manager import ObjectStoreManager
+import pytest
+
+from transformer_sidecar.object_store_manager import ObjectStoreManager, ObjectStoreError
 
 
 class TestObjectStoreManager:
@@ -76,3 +78,24 @@ class TestObjectStoreManager:
         result = ObjectStoreManager('localhost:9999', 'foo', 'bar')
         result.upload_file("my-bucket", "foo.txt", "/tmp/foo.txt")
         mock_minio.fput_object.assert_called()
+
+    def test_upload_file_exception(self, mocker):
+        import minio
+        mock_minio = mocker.MagicMock(minio.api.Minio)
+        mock_minio.fput_object = mocker.Mock()
+        mock_minio.fput_object.side_effect = minio.error.S3Error(
+            response=mocker.Mock(),
+            code='TestError',
+            message='Mocked S3 Error',
+            resource='test-resource',
+            request_id='test-request-id',
+            host_id='test-host-id'
+        )
+        mocker.patch('minio.Minio', return_value=mock_minio)
+        result = ObjectStoreManager('localhost:9999', 'foo', 'bar')
+        with pytest.raises(ObjectStoreError):
+            result.upload_file("my-bucket", "foo.txt", "/tmp/foo.txt")
+
+        mock_minio.fput_object.side_effect = minio.error.MinioException()
+        with pytest.raises(ObjectStoreError):
+            result.upload_file("my-bucket", "foo.txt", "/tmp/foo.txt")

--- a/transformer_sidecar/tests/test_transformer.py
+++ b/transformer_sidecar/tests/test_transformer.py
@@ -35,6 +35,7 @@ from types import SimpleNamespace
 
 from pytest import fixture
 
+from transformer_sidecar.object_store_manager import ObjectStoreError
 from transformer_sidecar.transformer import init, transform_file, prioritize_replicas, \
     prepend_xcache
 
@@ -341,6 +342,29 @@ def test_transform_file_exception(args, mock_celery,
         assert failure_report.file_path == test_paths[0]
         assert failure_report.file_id == test_file_id
         assert failure_report.request_id == test_request_id
+
+
+def test_transform_file_object_store_error(args, mock_celery, transformer_capabilities,
+                                           mock_servicex_adapter,
+                                           mock_object_store_manager,
+                                           mock_science_container):
+    with (tempfile.TemporaryDirectory() as temp_dir):
+        init_test(args, mock_celery, transformer_capabilities, temp_dir,
+                  ['root', 'parquet'], 'root')
+
+        mock_object_store_manager.return_value.upload_file.side_effect = ObjectStoreError("Test Exception")  # noqa E501
+        mock_science_container.return_value.await_response.side_effect = ["success."]
+
+        # Call the task
+        transform_file(
+            request_id=test_request_id,
+            file_id=test_file_id,
+            paths=test_paths,
+            service_endpoint=test_service_endpoint,
+            result_destination=test_result_destination,
+            result_format=test_result_format
+        )
+        assert mock_servicex_adapter.return_value.put_file_complete.call_args[0][0].status == 'failure'  # noqa E501
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
# Problem
The object store manager swallows exceptions from uploading the transformed file to the object store. When this happens
the file is not reported at all to the app and the transform will never complete.

Resolves #894 

# Approach
Instead of just logging the exceptions and carrying on, raise a new Exception subclass, ObjectStoreError - catch that in the transformer and post the file-complete message to the server, but with the status set to _failed_

Also took this opportunity to remove the vestigial UploadQueue from the class