### PR TITLE
Pick up the result file size directly from the file before uploading

### DIFF
--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -200,6 +200,7 @@ def transform_file(
                 Path(os.path.join(request_path, "abc.log")),
             )
             if science_container_response == "success.":
+                output_path = Path(transform_request["safeOutputFileName"])
                 rec = FileCompleteRecord(
                     request_id=request_id,
                     file_path=_file_path,
@@ -207,7 +208,7 @@ def transform_file(
                     status="success",
                     total_time=time.time() - total_time,
                     total_events=transformer_stats.total_events,
-                    total_bytes=transformer_stats.file_size,
+                    total_bytes=os.path.getsize(output_path),
                 )
 
                 if object_store:

--- a/transformer_sidecar/tests/test_transformer.py
+++ b/transformer_sidecar/tests/test_transformer.py
@@ -193,13 +193,18 @@ def test_transformer_output_dir(args, mock_celery, transformer_capabilities,
                                 mock_science_container, mocker):
     with (tempfile.TemporaryDirectory() as temp_dir):
         args.result_destination = 'volume'
-        args.output_dir = "/local/results"
+        args.output_dir = os.path.join(temp_dir, "local", "results")
+        os.makedirs(args.output_dir, exist_ok=True)
 
         init_test(args, mock_celery, transformer_capabilities, temp_dir,
                   ['root', 'parquet'], 'parquet')
 
         mock_science_container.return_value.await_response.side_effect = ["failure",
                                                                           "success."]
+
+        result_file_path = os.path.join(temp_dir, "local", "results", "site2:file.root.parquet")
+        with open(result_file_path, 'w') as f:
+            f.write("test")
 
         # Call the task
         transform_file(
@@ -212,10 +217,12 @@ def test_transformer_output_dir(args, mock_celery, transformer_capabilities,
         )
 
         science_request = mock_science_container.return_value.send.call_args[0][0]
-        assert science_request["safeOutputFileName"] == '/local/results/site2:file.root.parquet'
+        assert science_request["safeOutputFileName"] == result_file_path
         mock_servicex_adapter.return_value.put_file_complete.assert_called_once()
         assert mock_servicex_adapter.return_value. \
             put_file_complete.call_args[0][0].status == 'success'
+        assert mock_servicex_adapter.return_value. \
+            put_file_complete.call_args[0][0].total_bytes == 4
 
 
 def test_transformer_long_filename(args, mock_celery, transformer_capabilities,


### PR DESCRIPTION
# Problem 
File size reported to file complete endpoint is often zero

Resolves #943 

# Approach
Before uploading the result file from the object store, directly observe the file size using Path.getsize call.