### PR TITLE
Add retry on S3 SlowDown exceptions

### DIFF
--- a/transformer_sidecar/src/transformer_sidecar/object_store_manager.py
+++ b/transformer_sidecar/src/transformer_sidecar/object_store_manager.py
@@ -25,12 +25,13 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import os
 import logging
+import os
 import traceback
 
 from minio.error import MinioException, S3Error
-from retry import retry
+from tenacity import RetryError, before_log, retry, retry_if_result, stop_after_attempt, \
+    wait_exponential, wait_random
 
 
 class ObjectStoreError(Exception):
@@ -58,26 +59,57 @@ class ObjectStoreManager:
             'MINIO_SECRET_KEY'],
             secure=secure_connection)
 
-    @retry(tries=3, delay=3,
-           backoff=4,
-           jitter=(1, 3), logger=logging.getLogger(__name__))
-    def upload_file(self, bucket, object_name, path):
+    @retry(
+        stop=stop_after_attempt(3),
+        retry=retry_if_result(lambda e:
+                              isinstance(e, S3Error)
+                              and hasattr(e, 'code')
+                              and e.code in ['SlowDown', 'ServiceUnavailable', 'Throttling']),
+        wait=wait_exponential(multiplier=3, exp_base=4) + wait_random(min=1, max=3),
+        before=before_log(logging.getLogger(__name__), logging.INFO)
+    )
+    def _upload_file_with_retry(self, bucket, object_name, path):
+        """
+        Upload a file to the object store with retry logic for certain S3 errors.
+        To take advantage of tenacity's retry logic based on specific errors, this
+        function needs to return the exception rather than raise it.
+        """
         try:
             result = self.minio_client.fput_object(bucket_name=bucket,
                                                    object_name=object_name,
                                                    file_path=path)
+        except Exception as e:
+            # retry_if_result needs the exception to be returned and not raised
+            return e
+        return result
+
+    def upload_file(self, bucket, object_name, path):
+        try:
+            result = self._upload_file_with_retry(bucket, object_name, path)
+
+            # The retry logic will return the exception rather than raise it
+            if isinstance(result, Exception):
+                raise result
+
             self.logger.info("OSM > created object.", extra={
                              "requestId": bucket, "object": result.object_name})
-        except S3Error as e:
+
+        except (RetryError, S3Error) as e:
+            # If a non-retryable S3Error is raised it will come here. If we
+            # ran out of retries it will also come here, but the exception will
+            # wrapped by tenacity
             self.logger.error("S3Error", exc_info=True)
             traceback.print_exc()
             raise ObjectStoreError(f"Error uploading file to object store: {path}") from e
+
         except MinioException as e:
             self.logger.error("Minio error", exc_info=True)
             traceback.print_exc()
             raise ObjectStoreError(f"Error uploading file to object store: {path}") from e
 
-        try:
-            os.remove(path)
-        except FileNotFoundError:
-            pass  # Should never happen, but is not fatal if it occurs
+        finally:
+            # Delete the file regardless of success or failure
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass  # Should never happen, but is not fatal if it occurs

--- a/transformer_sidecar/src/transformer_sidecar/object_store_manager.py
+++ b/transformer_sidecar/src/transformer_sidecar/object_store_manager.py
@@ -30,6 +30,7 @@ import logging
 import traceback
 
 from minio.error import MinioException, S3Error
+from retry import retry
 
 
 class ObjectStoreError(Exception):
@@ -57,6 +58,9 @@ class ObjectStoreManager:
             'MINIO_SECRET_KEY'],
             secure=secure_connection)
 
+    @retry(tries=3, delay=3,
+           backoff=4,
+           jitter=(1, 3), logger=logging.getLogger(__name__))
     def upload_file(self, bucket, object_name, path):
         try:
             result = self.minio_client.fput_object(bucket_name=bucket,

--- a/transformer_sidecar/tests/test_object_store_manager.py
+++ b/transformer_sidecar/tests/test_object_store_manager.py
@@ -81,21 +81,50 @@ class TestObjectStoreManager:
 
     def test_upload_file_exception(self, mocker):
         import minio
+
+        def s3_error(code):
+            """
+            Construct an S3Error with a specific code.
+            """
+            return minio.error.S3Error(
+                response=mocker.Mock(),
+                code=code,
+                message='Mocked S3 Error',
+                resource='test-resource',
+                request_id='test-request-id',
+                host_id='test-host-id'
+            )
+
         mock_minio = mocker.MagicMock(minio.api.Minio)
         mock_minio.fput_object = mocker.Mock()
-        mock_minio.fput_object.side_effect = minio.error.S3Error(
-            response=mocker.Mock(),
-            code='TestError',
-            message='Mocked S3 Error',
-            resource='test-resource',
-            request_id='test-request-id',
-            host_id='test-host-id'
-        )
+
+        # Throw three retryable errors
+        mock_minio.fput_object.side_effect = [
+            s3_error('SlowDown'),
+            s3_error('ServiceUnavailable'),
+            s3_error('Throttling')
+        ]
+
         mocker.patch('minio.Minio', return_value=mock_minio)
         result = ObjectStoreManager('localhost:9999', 'foo', 'bar')
         with pytest.raises(ObjectStoreError):
             result.upload_file("my-bucket", "foo.txt", "/tmp/foo.txt")
+        assert mock_minio.fput_object.call_count == 3
 
+        # Now throw one retryable exception and one non-retryable which should
+        # cause the upload to fail after the first retry
+        mock_minio.fput_object.reset_mock()
+        mock_minio.fput_object.side_effect = [
+            s3_error('SlowDown'),
+            s3_error('ItsDeadJim')
+        ]
+        with pytest.raises(ObjectStoreError):
+            result.upload_file("my-bucket", "foo.txt", "/tmp/foo.txt")
+        assert mock_minio.fput_object.call_count == 2
+
+        # Now test out the MinioExceptions which are all non-retryable
+        mock_minio.fput_object.reset_mock()
         mock_minio.fput_object.side_effect = minio.error.MinioException()
         with pytest.raises(ObjectStoreError):
             result.upload_file("my-bucket", "foo.txt", "/tmp/foo.txt")
+        assert mock_minio.fput_object.call_count == 1


### PR DESCRIPTION
# Problem
When the Ceph object store is overwhelmed it throws SlowDown exceptions:
```
Traceback (most recent call last):
  File "/servicex/transformer_sidecar/object_store_manager.py", line 62, in upload_file
    result = self.minio_client.fput_object(bucket_name=bucket,
  File "/usr/local/lib/python3.10/site-packages/minio/api.py", line 1051, in fput_object
    return self.put_object(
  File "/usr/local/lib/python3.10/site-packages/minio/api.py", line 1996, in put_object
    raise exc
  File "/usr/local/lib/python3.10/site-packages/minio/api.py", line 1947, in put_object
    upload_id = self._create_multipart_upload(
  File "/usr/local/lib/python3.10/site-packages/minio/api.py", line 1762, in _create_multipart_upload
    response = self._execute(
  File "/usr/local/lib/python3.10/site-packages/minio/api.py", line 441, in _execute
    return self._url_open(
  File "/usr/local/lib/python3.10/site-packages/minio/api.py", line 424, in _url_open
    raise response_error
minio.error.S3Error: S3 operation failed; code: SlowDown, message: None, resource: None, request_id: tx0000032ac6ddfe2121a06-0067943977-aeca260-af-object-store, host_id: aeca260-af-object-store-af-object-store
```

We should retry when this happens. It can often impact several transformers and so it's essential that we use the exponential retry along with jitter.