### PR TITLE
Eliminate possibility of running arbitrary user-specified science images

### DIFF
--- a/servicex_app/servicex_app/resources/transformation/submit.py
+++ b/servicex_app/servicex_app/resources/transformation/submit.py
@@ -68,7 +68,6 @@ class SubmitTransformationRequest(ServiceXResource):
             help='Static list of Root Files. Provide this or Dataset Identifier.'
         )
         cls.parser.add_argument('selection', help='Query string')
-        cls.parser.add_argument('image')
         cls.parser.add_argument('codegen')
         cls.parser.add_argument('tree-name')
         cls.parser.add_argument('workers', type=int, default=1)
@@ -144,7 +143,6 @@ class SubmitTransformationRequest(ServiceXResource):
             config = current_app.config
             user = self.get_requesting_user()
 
-            image = args.get("image")
             did = args.get("did")
             file_list = args.get("file-list")
             user_codegen_name = args.get("codegen")
@@ -182,7 +180,6 @@ class SubmitTransformationRequest(ServiceXResource):
                 submitted_by=user.id if user is not None else None,
                 selection=args['selection'],
                 tree_name=args['tree-name'],
-                image=image,
                 result_destination=args['result-destination'],
                 result_format=args['result-format'],
                 workers=args['workers'],
@@ -201,9 +198,7 @@ class SubmitTransformationRequest(ServiceXResource):
                 self.code_gen_service.generate_code_for_selection(request_rec, namespace,
                                                                   user_codegen_name)
 
-            # If the user didn't specify an image, use the one from the codegen
-            if not request_rec.image:
-                request_rec.image = codegen_transformer_image
+            request_rec.image = codegen_transformer_image
 
             # Check to make sure the transformer docker image actually exists (if enabled)
             if config['TRANSFORMER_VALIDATE_DOCKER_IMAGE']:

--- a/servicex_app/servicex_app_test/resources/transformation/test_submit.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_submit.py
@@ -458,7 +458,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
             assert saved_obj.image == 'ssl-hep/func_adl:latest'
 
     def test_submit_transformation_provided_image_ignored(self, mocker, mock_codegen,
-                                                  mock_dataset_manager_from_did):
+                                                          mock_dataset_manager_from_did):
         client = self._test_client(code_gen_service=mock_codegen)
         with client.application.app_context():
             request = self._generate_transformation_request(**{

--- a/servicex_app/servicex_app_test/resources/transformation/test_submit.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_submit.py
@@ -153,8 +153,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
                                    celery_app=mock_celery_app)
 
         with client.application.app_context():
-            request = self._generate_transformation_request(
-                image="sslhep/servicex_func_adl_xaod_transformer:develop")
+            request = self._generate_transformation_request()
 
             response = client.post('/servicex/transformation',
                                    json=request,
@@ -168,7 +167,6 @@ class TestSubmitTransformationRequest(ResourceTestBase):
             assert saved_obj.finish_time is None
             assert saved_obj.request_id == request_id
             assert saved_obj.title is None
-            assert saved_obj.image == "sslhep/servicex_func_adl_xaod_transformer:develop"
             assert saved_obj.selection == 'test-string'
             assert saved_obj.workers == 10
             assert saved_obj.result_destination == 'object-store'
@@ -362,19 +360,6 @@ class TestSubmitTransformationRequest(ResourceTestBase):
                 start_transformers \
                 .assert_called_with(ANY, submitted_request)
 
-    def test_submit_transformation_request_bad_image(
-        self, mocker, mock_docker_repo_adapter,
-            mock_dataset_manager_from_did, mock_codegen
-    ):
-        mock_docker_repo_adapter.check_image_exists = mocker.Mock(return_value=False)
-        client = self._test_client(docker_repo_adapter=mock_docker_repo_adapter,
-                                   code_gen_service=mock_codegen)
-        request = self._generate_transformation_request()
-        request["image"] = "ssl-hep/foo:latest"
-        response = client.post('/servicex/transformation', json=request)
-        assert response.status_code == 500
-        assert response.json == {"message": "Requested transformer docker image doesn't exist: " + request["image"]}  # noqa: E501
-
     def test_submit_transformation_request_no_docker_check(
         self, mocker, mock_docker_repo_adapter, mock_dataset_manager_from_did,
             mock_codegen
@@ -472,7 +457,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
             assert saved_obj
             assert saved_obj.image == 'ssl-hep/func_adl:latest'
 
-    def test_submit_transformation_provided_image(self, mocker, mock_codegen,
+    def test_submit_transformation_provided_image_ignored(self, mocker, mock_codegen,
                                                   mock_dataset_manager_from_did):
         client = self._test_client(code_gen_service=mock_codegen)
         with client.application.app_context():
@@ -490,7 +475,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
 
             saved_obj = TransformRequest.lookup(request_id)
             assert saved_obj
-            assert saved_obj.image == 'my-image:latest'
+            assert saved_obj.image == 'ssl-hep/func_adl:latest'
 
     def test_submit_transformation_auth_enabled(
         self, mock_jwt_extended, mock_requesting_user,


### PR DESCRIPTION
Only take science image specification from codegen. Remove image argument to submission. (Since the frontend doesn't send `null` for optional arguments, this is fully compatible with all requests that didn't try to override the science image, which should be ~ all of them.)

Codegens that want to have multiple science image support should implement an option in their queries and construct the image name themselves.