### PR TITLE
Add finish times when transforms run on zero files

### DIFF
--- a/servicex_app/servicex_app/resources/internal/fileset_complete.py
+++ b/servicex_app/servicex_app/resources/internal/fileset_complete.py
@@ -31,6 +31,8 @@ from servicex_app.models import Dataset, db, TransformRequest, TransformStatus, 
 from servicex_app.dataset_manager import DatasetManager
 from servicex_app.resources.servicex_resource import ServiceXResource
 
+from datetime import datetime, timezone
+
 
 class FilesetComplete(ServiceXResource):
     @classmethod
@@ -74,6 +76,7 @@ class FilesetComplete(ServiceXResource):
             namespace = current_app.config['TRANSFORMER_NAMESPACE']
             for running_request in TransformRequest.lookup_running_by_dataset_id(int(dataset_id)):
                 running_request.status = TransformStatus.complete
+                running_request.finish_time = datetime.now(tz=timezone.utc)
                 self.transformer_manager.shutdown_transformer_job(
                     running_request.request_id, namespace
                 )
@@ -82,5 +85,6 @@ class FilesetComplete(ServiceXResource):
             # not to expect to run
             for pending_transform in TransformRequest.lookup_pending_on_dataset(int(dataset_id)):
                 pending_transform.status = TransformStatus.complete
+                pending_transform.finish_time = datetime.now(tz=timezone.utc)
 
         db.session.commit()

--- a/servicex_app/servicex_app_test/resources/internal/test_fileset_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_fileset_complete.py
@@ -126,4 +126,6 @@ class TestFilesetComplete(ResourceTestBase):
         mock_lookup_running.assert_called_once_with(12345)
         mock_transformer_manager.shutdown_transformer_job.assert_called_with("111-111", 'my-ws')
         assert running_request.status == TransformStatus.complete
+        assert running_request.finish_time is not None
         assert pending_request.status == TransformStatus.complete
+        assert pending_request.finish_time is not None


### PR DESCRIPTION
Had previously missed adding finish times for transform status when the jobs are aborted due to having no input files
Should address #961