### PR TITLE
Fix servicex.yaml download

### DIFF
--- a/servicex_app/servicex_app/web/servicex_file.py
+++ b/servicex_app/servicex_app/web/servicex_file.py
@@ -14,11 +14,13 @@ def servicex_file():
     sub = session.get('sub')
     user = UserModel.find_by_sub(sub)
     endpoint_url = get_correct_url(request)
+    endpoint_name = urlparse(endpoint_url).hostname
 
     body = "api_endpoints:\n"
-    body += f"  - name: {backend_type}\n"
+    body += f"  - name: {endpoint_name}\n"
     body += f"    endpoint: {endpoint_url}\n"
     body += f"    token: {user.refresh_token}\n"
+    body += f"default_endpoint: {endpoint_name}\n"
     return send_file(BytesIO(dedent(body).encode()), mimetype="text/plain",
                      as_attachment=True, download_name="servicex.yaml")
 

--- a/servicex_app/servicex_app/web/servicex_file.py
+++ b/servicex_app/servicex_app/web/servicex_file.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 from urllib.parse import urlparse
 
 import flask
-from flask import (current_app, request, send_file, session)
+from flask import (request, send_file, session)
 from servicex_app.decorators import oauth_required
 from servicex_app.models import UserModel
 
@@ -11,18 +11,14 @@ from servicex_app.models import UserModel
 @oauth_required
 def servicex_file():
     """Generate a servicex.yaml config file prepopulated with this endpoint."""
-    code_gen_types = current_app.config.get('CODE_GEN_IMAGES', '').keys()
     sub = session.get('sub')
     user = UserModel.find_by_sub(sub)
     endpoint_url = get_correct_url(request)
 
     body = "api_endpoints:\n"
-    for backend_type in code_gen_types:
-        body += f"  - name: {backend_type}\n"
-        body += f"    endpoint: {endpoint_url}\n"
-        body += f"    token: {user.refresh_token}\n"
-        body += f"    codegen: {backend_type}\n"
-        body += "    return_data: root-file\n"
+    body += f"  - name: {backend_type}\n"
+    body += f"    endpoint: {endpoint_url}\n"
+    body += f"    token: {user.refresh_token}\n"
     return send_file(BytesIO(dedent(body).encode()), mimetype="text/plain",
                      as_attachment=True, download_name="servicex.yaml")
 

--- a/servicex_app/servicex_app_test/web/test_servicex_file.py
+++ b/servicex_app/servicex_app_test/web/test_servicex_file.py
@@ -16,16 +16,10 @@ class TestServiceXFile(WebTestBase):
         response: Response = client.get(url_for('servicex-file'))
         expected = """\
         api_endpoints:
-          - name: xaod
+          - name: localhost
             endpoint: http://localhost/
             token: abcdef
-            codegen: xaod
-            return_data: root-file
-          - name: uproot
-            endpoint: http://localhost/
-            token: abcdef
-            codegen: uproot
-            return_data: root-file
+        default_endpoint: localhost
         """
         assert response.data.decode() == dedent(expected)
         assert response.headers['Content-Disposition'] == 'attachment; filename=servicex.yaml'


### PR DESCRIPTION
Only give one endpoint for the instance; drop obsolete `codegen` and `return_data` fields. Add `default_endpoint`. Resolves #926 