### PR TITLE
Change default dashboard sort order to start (desc)

### DIFF
--- a/servicex_app/servicex_app/web/dashboard.py
+++ b/servicex_app/servicex_app/web/dashboard.py
@@ -15,7 +15,7 @@ sort_choices = tuple(model_attributes.keys())
 parser.add_argument(
     "sort",
     choices=sort_choices,
-    default="finish",
+    default="start",
     location='args',
     help=f"Sort must be one of: {', '.join(map(repr, sort_choices))}."
 )


### PR DESCRIPTION
The sort order "Finish (desc)" on the dashboard means that requests can get reordered, when reloading the page, in strange and counterintuitive ways. Change the default so that requests are shown by default in the order of submission.