### PR TITLE
endpoint name is the instance name if it's defined

### DIFF
--- a/servicex_app/servicex_app/web/servicex_file.py
+++ b/servicex_app/servicex_app/web/servicex_file.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 from urllib.parse import urlparse
 
 import flask
-from flask import (request, send_file, session)
+from flask import (request, send_file, session, current_app)
 from servicex_app.decorators import oauth_required
 from servicex_app.models import UserModel
 
@@ -14,7 +14,7 @@ def servicex_file():
     email = session.get('email')
     user = UserModel.find_by_email(email)
     endpoint_url = get_correct_url(request)
-    endpoint_name = urlparse(endpoint_url).hostname
+    endpoint_name = current_app.config.get("INSTANCE_NAME", urlparse(endpoint_url).hostname)
 
     body = "api_endpoints:\n"
     body += f"  - name: {endpoint_name}\n"

--- a/servicex_app/servicex_app_test/web/test_servicex_file.py
+++ b/servicex_app/servicex_app_test/web/test_servicex_file.py
@@ -24,6 +24,19 @@ class TestServiceXFile(WebTestBase):
         assert response.data.decode() == dedent(expected)
         assert response.headers['Content-Disposition'] == 'attachment; filename=servicex.yaml'
 
+        cfg = {'INSTANCE_NAME': 'important-instance'}
+        client.application.config.update(cfg)
+        response: Response = client.get(url_for('servicex-file'))
+        expected = """\
+        api_endpoints:
+          - name: important-instance
+            endpoint: http://localhost/
+            token: abcdef
+        default_endpoint: important-instance
+        """
+        assert response.data.decode() == dedent(expected)
+        assert response.headers['Content-Disposition'] == 'attachment; filename=servicex.yaml'
+
     def test_correct_url(self, client):
         """
         Test that http endpoints are replaced with https addresses with the


### PR DESCRIPTION
Make the names in the `servicex.yaml` downloads a little nicer.