### PR TITLE
Allow cancellation of all not-completed requests

### DIFF
--- a/servicex_app/servicex_app/lookup_result_processor.py
+++ b/servicex_app/servicex_app/lookup_result_processor.py
@@ -42,6 +42,11 @@ class LookupResultProcessor:
     def add_files_to_processing_queue(self, request, files=None):
         if files is None:
             files = request.all_files
+        if request.status.is_complete:
+            current_app.logger.debug("Rejecting file addition request, request is canceled",
+                                     extra={
+                                        "task_id": self.celery_task_name(request.request_id)})
+            return
         for file_record in files:
             self.celery.send_task("transformer_sidecar.transform_file",
                                   kwargs={

--- a/servicex_app/servicex_app/resources/transformation/cancel.py
+++ b/servicex_app/servicex_app/resources/transformation/cancel.py
@@ -55,7 +55,7 @@ class CancelTransform(ServiceXResource):
 
         namespace = current_app.config['TRANSFORMER_NAMESPACE']
 
-        if transform_req.status == TransformStatus.running:
+        if transform_req.status in (TransformStatus.running, TransformStatus.lookup):
             try:
                 self.transformer_manager.shutdown_transformer_job(request_id, namespace)
             except kubernetes.client.exceptions.ApiException as exc:

--- a/servicex_app/servicex_app/templates/requests_table.html
+++ b/servicex_app/servicex_app/templates/requests_table.html
@@ -63,7 +63,7 @@
       </td>
       <td id="replicas-{{ req.request_id }}">-</td>
       <td>
-        {% if req.status.string_name == 'Running' %}
+        {% if not req.status.is_complete %}
         <button id="cancel-{{ req.request_id }}"
           onclick="fetch('/servicex/transformation/{{ req.request_id }}/cancel').then((res) => location.reload())"
           type="button" class="btn btn-danger btn-sm">


### PR DESCRIPTION
Show the cancel button in the dashboard for all requests that are believed to be in progress (including in the `Lookup`, `Pending Lookup`, and `Submitted` states). 