### PR TITLE
Do not login or push to dockerhub if secrets not available in job

### DIFF
--- a/.github/workflows/ci_servicex.yaml
+++ b/.github/workflows/ci_servicex.yaml
@@ -105,6 +105,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
       - name: Login to Docker Hub
         uses: docker/login-action@v3.3.0
+        if: ${{ github.secret_source == 'Actions' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -112,7 +113,7 @@ jobs:
         uses: docker/build-push-action@v6.15.0
         with:
           context: ${{ matrix.app.dir_name }}
-          push: true
+          push: ${{ github.secret_source == 'Actions' }}
           tags: ${{ steps.extract_tag_name.outputs.imagetag }}
           cache-from: type=${{ format('registry,ref={0}',steps.extract_cache_name.outputs.cachetag) }}
           cache-to: type=${{ format('registry,ref={0}',steps.extract_cache_name.outputs.cachetag) }},mode=max


### PR DESCRIPTION
It's important that dependabot be able to build docker images to test that the updated `poetry.lock` files actually work in the container build process. The current setup requires that the Docker Hub secrets be present in the CI job or else things will fail, and dependabot does not have access to these. Use a conditional to avoid pushing the images, and just check we can build them.