### PR TITLE
Provide overrides for outdated VOMS servers

### DIFF
--- a/x509_secrets/Dockerfile
+++ b/x509_secrets/Dockerfile
@@ -27,5 +27,7 @@ COPY . .
 RUN echo "Timestamp:" `date --utc` | tee /image-build-info.txt
 
 ENV X509_USER_PROXY /tmp/x509up
+# overrides deprecated auth servers. Remove when upstream fixes this
+ENV VOMS_USERCONF /usr/src/app/vomses
 
 CMD sh -c "python3 x509_updater.py --voms $VOMS"

--- a/x509_secrets/vomses/vomses
+++ b/x509_secrets/vomses/vomses
@@ -1,0 +1,2 @@
+"atlas" "voms-atlas-auth.cern.ch" "443" "/DC=ch/DC=cern/OU=computers/CN=atlas-auth.cern.ch" "atlas"
+"cms" "voms-cms-auth.cern.ch" "443" "/DC=ch/DC=cern/OU=computers/CN=cms-auth.cern.ch" "cms"


### PR DESCRIPTION
Override the CMS and ATLAS VOMS servers until the upstream RPM packages catch up.