### PR TITLE
Improved fix for x509 proxy retrieval

### DIFF
--- a/x509_secrets/Dockerfile
+++ b/x509_secrets/Dockerfile
@@ -26,8 +26,6 @@ COPY . .
 # build
 RUN echo "Timestamp:" `date --utc` | tee /image-build-info.txt
 
-ENV X509_USER_PROXY /tmp/x509up
-# overrides deprecated auth servers. Remove when upstream fixes this
-ENV VOMS_USERCONF /usr/src/app/vomses
+ENV X509_USER_PROXY=/tmp/x509up
 
-CMD sh -c "python3 x509_updater.py --voms $VOMS"
+CMD ["sh", "-c", "python3", "x509_updater.py", "--voms", "$VOMS"]

--- a/x509_secrets/vomses/vomses
+++ b/x509_secrets/vomses/vomses
@@ -1,2 +1,0 @@
-"atlas" "voms-atlas-auth.cern.ch" "443" "/DC=ch/DC=cern/OU=computers/CN=atlas-auth.cern.ch" "atlas"
-"cms" "voms-cms-auth.cern.ch" "443" "/DC=ch/DC=cern/OU=computers/CN=cms-auth.cern.ch" "cms"

--- a/x509_secrets/x509_updater.py
+++ b/x509_secrets/x509_updater.py
@@ -62,8 +62,8 @@ else:
 
 
 myCmd = """
- voms-proxy-init --pwstdin -key /etc/grid-certs/userkey.pem \
-                  -cert /etc/grid-certs/usercert.pem \
+ voms-proxy-init3 --pwstdin --key /etc/grid-certs/userkey.pem \
+                  --cert /etc/grid-certs/usercert.pem \
                   --voms=%s \
                   <  /etc/grid-certs-ro/passphrase
                   """


### PR DESCRIPTION
Move to latest `rucio-client` image: new voms command, remove overrides. Should match @ivukotic 's fixes from a while ago.