### PR TITLE
Enable Pointer Returns in C++

### DIFF
--- a/code_generator_funcadl_xAOD/poetry.lock
+++ b/code_generator_funcadl_xAOD/poetry.lock
@@ -379,14 +379,14 @@ test = ["astunparse", "black", "coverage", "flake8", "hatch", "isort", "numpy", 
 
 [[package]]
 name = "func-adl-xaod"
-version = "2.2.0"
+version = "2.2.1"
 description = "Functional Analysis Description Language backend for accessing ATLAS xAOD files."
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "func_adl_xAOD-2.2.0-py3-none-any.whl", hash = "sha256:39cd6598bc957184ddd401443f6bfc0a2ce890f3577decc0fbad31c5e7a11adc"},
-    {file = "func_adl_xaod-2.2.0.tar.gz", hash = "sha256:8cad08f7a093dbcb6f832444b9c2d2ffcc3a726157dba700794d44af9b9f6ec6"},
+    {file = "func_adl_xaod-2.2.1-py3-none-any.whl", hash = "sha256:dcbc544278519f54d0f2c84c4b6ccf8b4e601626db92bf70db48019b98abae91"},
+    {file = "func_adl_xaod-2.2.1.tar.gz", hash = "sha256:a35f52286650980125c2fc9db3ef8de0b06b81c7420cd707278d8428828b20b8"},
 ]
 
 [package.dependencies]
@@ -417,14 +417,14 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "iniconfig"
-version = "2.0.0"
+version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["test"]
 files = [
-    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
-    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
 ]
 
 [[package]]
@@ -719,14 +719,14 @@ dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "pytz"
-version = "2025.1"
+version = "2025.2"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "pytz-2025.1-py2.py3-none-any.whl", hash = "sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57"},
-    {file = "pytz-2025.1.tar.gz", hash = "sha256:c2db42be2a2518b28e65f9207c4d05e6ff547d1efa4086469ef855e4ab70178e"},
+    {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
+    {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
 ]
 
 [[package]]
@@ -944,4 +944,4 @@ email = ["email-validator"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.10"
-content-hash = "fd57618e80988e23b8ca59b66111d3c502139b9c9fbba9a50e90dd95ecb24a69"
+content-hash = "462f15e06a38dc055c2e04d218a41c54f955d4175c4b9dc3195bb997d4742788"

--- a/code_generator_funcadl_xAOD/pyproject.toml
+++ b/code_generator_funcadl_xAOD/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{ include = "code_generator_funcadl_xaod" }]
 
 [tool.poetry.dependencies]
 python = "~3.10"
-func-adl-xAOD = "2.2.0"
+func-adl-xAOD = "^2.2.0"
 servicex-code-gen-lib = "^1.2"
 
 [tool.poetry.group.test]


### PR DESCRIPTION
This version of `func_adl_xAOD` enables C++ pointers to be returned from injected C++ code.

This is especially helpful when dealing with ElementLink's that have to by dynamically cast to other object types (knarly, dude).

This is suitable for inclusing in a release as soon as it has passed review and tests.