### PR TITLE
Ignore missing trees in uproot-raw transformer by default

### DIFF
--- a/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
+++ b/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
@@ -134,7 +134,11 @@ def run_single_query(file_path, query):
                 trees = {{_:_ for _ in trees}}
             for treename, outtreename in trees.items():
                 # exception will be propagated up if tree does not exist
-                t = fl[treename]
+                try:
+                    t = fl[treename]
+                except uproot.KeyInFileError:
+                    if query.get('fail_on_missing_trees', False):
+                        raise
                 arr = None
                 for subarr in t.iterate(language=lang, **sanitized_args):
                     if arr is None:

--- a/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
+++ b/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
@@ -139,6 +139,8 @@ def run_single_query(file_path, query):
                 except uproot.KeyInFileError:
                     if query.get('fail_on_missing_trees', False):
                         raise
+                    else:
+                        continue
                 arr = None
                 for subarr in t.iterate(language=lang, **sanitized_args):
                     if arr is None:

--- a/code_generator_raw_uproot/tests/test_src.py
+++ b/code_generator_raw_uproot/tests/test_src.py
@@ -50,7 +50,7 @@ def test_generate_code():
                              'filter_name': ['lbn']},
                             {'copy_histograms': 'CutBookkeeper*'}
                             ])
-        expected_hash = "0c68ae9155b901289b888c94aa0dbda2"
+        expected_hash = "79ea5f4a52deb547331393cf091f6cf6"
         result = translator.generate_code(query, tmpdirname)
 
         # is the generated code at least syntactically valid Python?

--- a/code_generator_raw_uproot/tests/test_src.py
+++ b/code_generator_raw_uproot/tests/test_src.py
@@ -50,7 +50,7 @@ def test_generate_code():
                              'filter_name': ['lbn']},
                             {'copy_histograms': 'CutBookkeeper*'}
                             ])
-        expected_hash = "79ea5f4a52deb547331393cf091f6cf6"
+        expected_hash = "6f8ac79962ef753d3e7fd6161cba6fe8"
         result = translator.generate_code(query, tmpdirname)
 
         # is the generated code at least syntactically valid Python?


### PR DESCRIPTION
By default, now, if a requested source tree for a query is missing in an input file, the uproot-raw transformer will ignore it instead of raising an exception. This improves compatibility with ATLAS TopCPToolkit output. The old behavior can be restored by adding `fail_on_missing_trees: true` to the query JSON.