### PR TITLE
Fix #1009 (documentation links)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ ServiceX is an on-demand service that delivers data straight from the grid to hi
 
 ## Getting Started
 
-Check out our [quick start guide](https://servicex-frontend.readthedocs.io/en/stable/)) 
-for instructions on how to obtain credentials, 
+Check out our [quick start guide](https://servicex-frontend.readthedocs.io/en/stable/) 
+for instructions on how to obtain credentials,
 install the [ServiceX Python library](https://pypi.org/project/servicex/),
 and make your first ServiceX transformation request.
 
-[![Documentation Status](https://readthedocs.org/projects/servicex-frontend/badge/?version=stable)](https://servicex-frontend.readthedocs.io/en/stable/?badge=stable)
+[![Documentation Status](https://readthedocs.org/projects/servicex-frontend/badge/?version=stable)](https://servicex-frontend.readthedocs.io/en/stable/)
 
 ## Self-Hosting
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,12 @@ ServiceX is an on-demand service that delivers data straight from the grid to hi
 
 ## Getting Started
 
-Check out our [quick start guide](https://servicex.readthedocs.io/en/latest/user/getting-started/) 
+Check out our [quick start guide](https://servicex-frontend.readthedocs.io/en/stable/)) 
 for instructions on how to obtain credentials, 
 install the [ServiceX Python library](https://pypi.org/project/servicex/),
 and make your first ServiceX transformation request.
 
-## Documentation
-
-[![Documentation Status](https://readthedocs.org/projects/servicex/badge/?version=latest)](https://servicex.readthedocs.io/en/latest/?badge=latest)
-
-The [ServiceX documentation](https://servicex.readthedocs.io/en/latest/) is hosted on Read the Docs.
+[![Documentation Status](https://readthedocs.org/projects/servicex-frontend/badge/?version=stable)](https://servicex-frontend.readthedocs.io/en/stable/?badge=stable)
 
 ## Self-Hosting
 

--- a/servicex_app/app.conf.template
+++ b/servicex_app/app.conf.template
@@ -5,7 +5,7 @@
 SECRET_KEY = 'abc123!'
 
 # Base URL of documentation
-DOCS_BASE_URL = 'https://servicex.readthedocs.io/en/latest/'
+DOCS_BASE_URL = 'https://servicex-frontend.readthedocs.io/en/stable/'
 
 # Enable JWT auth on public endpoints
 ENABLE_AUTH=False

--- a/servicex_app/servicex_app/templates/emails/welcome.html
+++ b/servicex_app/servicex_app/templates/emails/welcome.html
@@ -4,7 +4,7 @@
 </p>
 <div>
   Check out the ServiceX
-  <a href="{{ config['DOCS_BASE_URL'] }}/user/getting-started/">docs</a>
+  <a href="{{ config['DOCS_BASE_URL'] }}">docs</a>
   to get started!
 </div>
 </html>

--- a/servicex_app/servicex_app/templates/get_started.html
+++ b/servicex_app/servicex_app/templates/get_started.html
@@ -7,7 +7,7 @@
     Recent requests will show up here.
   </p>
   <div class="row justify-content-center">
-    <a class="btn btn-outline-primary" href="{{ config['DOCS_BASE_URL']}}/user/getting-started" role="button">
+    <a class="btn btn-outline-primary" href="{{ config['DOCS_BASE_URL']}}" role="button">
       Go to Docs
     </a>
   </div>


### PR DESCRIPTION
Clean up documentation links. Do not assume we know the internal structure of the documentation site.