### PR TITLE
Set uproot science image to 5.5.1

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -45,7 +45,7 @@ codeGen:
     enabled: true
     image: sslhep/servicex_code_gen_func_adl_uproot
     pullPolicy: Always
-    tag: develop
+    tag: 5.5.1
     defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
     defaultScienceContainerTag: uproot5
 


### PR DESCRIPTION
Give a specific version for the uproot science image so deployments don't pick up every change to the uproot5 branch in an uncontrolled way