### PR TITLE
Store transform events and size in DB

### DIFF
--- a/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
+++ b/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
@@ -155,7 +155,10 @@ class TransformerFileComplete(ServiceXResource):
             if info['status'] == 'success':
                 transform_req.files_completed += 1
                 transform_req.total_bytes += info['total-bytes']
-                transform_req.total_events += info['total-events']
+                if transform_req.total_events is None:
+                    transform_req.total_events = info['total-events']
+                else:
+                    transform_req.total_events += info['total-events']
             else:
                 transform_req.files_failed += 1
 

--- a/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
+++ b/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
@@ -154,11 +154,12 @@ class TransformerFileComplete(ServiceXResource):
 
             if info['status'] == 'success':
                 transform_req.files_completed += 1
-                transform_req.total_bytes += info['total-bytes']
                 if transform_req.total_events is None:
                     transform_req.total_events = info['total-events']
+                    transform_req.total_bytes = info['total-bytes']
                 else:
                     transform_req.total_events += info['total-events']
+                    transform_req.total_bytes += info['total-bytes']
             else:
                 transform_req.files_failed += 1
 

--- a/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
+++ b/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
@@ -154,6 +154,8 @@ class TransformerFileComplete(ServiceXResource):
 
             if info['status'] == 'success':
                 transform_req.files_completed += 1
+                transform_req.total_bytes += info['total-bytes']
+                transform_req.total_events += info['total-events']
             else:
                 transform_req.files_failed += 1
 


### PR DESCRIPTION
Store the `total_events` and `total_bytes` fields in the database.

Right now the information will be updated on the completion of each file. I don't know if this is necessarily useful or if we should wait until transform completion, although updating as we go makes more sense from a user display point of view (if we update only at the end of the job we should probably hide the relevant fields from the user-facing page until the transform is done).