### PR TITLE
Fix silly bug in min workers in hpa request

### DIFF
--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -329,7 +329,7 @@ class TransformerManager:
         spec = client.V1HorizontalPodAutoscalerSpec(
             scale_target_ref=target,
             target_cpu_utilization_percentage=cfg["TRANSFORMER_CPU_SCALE_THRESHOLD"],
-            min_replicas=cfg["TRANSFORMER_MIN_REPLICAS"],
+            min_replicas=min(max_workers, cfg["TRANSFORMER_MIN_REPLICAS"]),
             max_replicas=min(max_workers, cfg["TRANSFORMER_MAX_REPLICAS"])
         )
         hpa = client.V1HorizontalPodAutoscaler(


### PR DESCRIPTION
Don't allow min workers to exceed max workers requested for very small datasets