### PR TITLE
Eliminate three unnecessary log lines per worker

### DIFF
--- a/transformer_sidecar/src/transformer_sidecar/transformer_stats/__init__.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer_stats/__init__.py
@@ -35,8 +35,7 @@ class TransformerStats:
             with open(log_path, encoding="utf8", errors='ignore') as log:
                 self.log_body = log.read()
         else:
-            print("File does not exist:", log_path)
-            self.log_body = ""
+            self.log_body = f"File does not exist: {log_path}"
         self.total_events = 0
         self.file_size = 0
         self.error_info = "Unable to determine error cause. Please consult log files"


### PR DESCRIPTION
Since we init an empty `TransformerStats` in each sidecar, we were getting three log entries from the print statement which were also quite confusing (i.e. "File does not exist:" and "None", with an empty string also). Clean this all up, backstop with a dummy message if there _is_ an issue.