### PR TITLE
Upgrade TopCP codegen library dependencies

### DIFF
--- a/code_generator_TopCPToolkit/poetry.lock
+++ b/code_generator_TopCPToolkit/poetry.lock
@@ -740,14 +740,14 @@ files = [
 
 [[package]]
 name = "servicex-code-gen-lib"
-version = "1.1.7"
+version = "1.2"
 description = "Library for creating ServiceX Code Generators"
 optional = false
-python-versions = ">=3.10,<4.0"
+python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "servicex_code_gen_lib-1.1.7-py3-none-any.whl", hash = "sha256:020a701fc31aefc753abab7886fe839e9f45d1b821a51b5e498e4da20ec33481"},
-    {file = "servicex_code_gen_lib-1.1.7.tar.gz", hash = "sha256:f97d28fe3e619d700b759f41d82a10abd5672d66dfd73168cfd81c762dd66f74"},
+    {file = "servicex_code_gen_lib-1.2-py3-none-any.whl", hash = "sha256:126abf1df475021836c9d1cc6c450efdcf39b6c24b6f24101d461d3288dc9415"},
+    {file = "servicex_code_gen_lib-1.2.tar.gz", hash = "sha256:fce65c44e894e4f5f46e971cb8e6ea15f0a53451846b894532feaa93bd3f1fcc"},
 ]
 
 [package.dependencies]
@@ -757,8 +757,8 @@ Flask-WTF = ">=1.0.1,<2.0.0"
 itsdangerous = ">=2.1.2,<3.0.0"
 Jinja2 = ">=3.1.2,<4.0.0"
 requests-toolbelt = ">=0.10.1,<0.11.0"
-urllib3 = "1.26.18"
-Werkzeug = ">=2.3.8,<3.0.0"
+urllib3 = ">=1.26.19,<2.0.0"
+Werkzeug = ">=3.0.4,<4.0.0"
 
 [[package]]
 name = "six"
@@ -798,14 +798,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.18"
+version = "1.26.20"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 groups = ["main"]
 files = [
-    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
-    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
+    {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
+    {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
 ]
 
 [package.extras]
@@ -815,14 +815,14 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "werkzeug"
-version = "2.3.8"
+version = "3.1.3"
 description = "The comprehensive WSGI web application library."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "test"]
 files = [
-    {file = "werkzeug-2.3.8-py3-none-any.whl", hash = "sha256:bba1f19f8ec89d4d607a3bd62f1904bd2e609472d93cd85e9d4e178f472c3748"},
-    {file = "werkzeug-2.3.8.tar.gz", hash = "sha256:554b257c74bbeb7a0d254160a4f8ffe185243f52a52035060b761ca62d977f03"},
+    {file = "werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e"},
+    {file = "werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"},
 ]
 
 [package.dependencies]
@@ -852,4 +852,4 @@ email = ["email-validator"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.10"
-content-hash = "a47b626104fc3637a5b69da168f8557d4fb627f3e42743c2c8969d081f0c3820"
+content-hash = "87d619455116661fae0ca90e4779286b68c6d8ca1207890901880e19207db685"

--- a/code_generator_TopCPToolkit/pyproject.toml
+++ b/code_generator_TopCPToolkit/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "code_generator_funcadl_uproot_raw"}]
 
 [tool.poetry.dependencies]
 python = "~3.10"
-servicex-code-gen-lib = "^1.1.7"
+servicex-code-gen-lib = "^1.2"
 ruamel-yaml = "^0.18.6"
 
 [tool.poetry.group.test]


### PR DESCRIPTION
Bump codegen library version to 1.2, enables science image tag choice and resolves security alerts