### PR TITLE
Bump uproot science image to 5.6.0

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -45,7 +45,7 @@ codeGen:
     enabled: true
     image: sslhep/servicex_code_gen_func_adl_uproot
     pullPolicy: Always
-    tag: 5.5.1
+    tag: 5.6.0
     defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
     defaultScienceContainerTag: uproot5
 


### PR DESCRIPTION
Better version to invoke (in particular we can get the ARM build)