### PR TITLE
Add missing quotes that broke 1.6.1-RC2

### DIFF
--- a/helm/servicex/templates/app/configmap.yaml
+++ b/helm/servicex/templates/app/configmap.yaml
@@ -92,7 +92,7 @@ data:
     {{- end }}
     TRANSFORMER_AUTOSCALE_ENABLED = {{- ternary "True" "False" .Values.transformer.autoscaler.enabled }}
     TRANSFORMER_CPU_LIMIT = {{ .Values.transformer.cpuLimit }}
-    TRANSFORMER_MEMORY_LIMIT = {{ .Values.transformer.memoryLimit }}
+    TRANSFORMER_MEMORY_LIMIT = "{{ .Values.transformer.memoryLimit }}"
     TRANSFORMER_CPU_SCALE_THRESHOLD = {{ .Values.transformer.autoscaler.cpuScaleThreshold }}
     TRANSFORMER_MIN_REPLICAS = {{ .Values.transformer.autoscaler.minReplicas }}
     TRANSFORMER_MAX_REPLICAS = {{ .Values.transformer.autoscaler.maxReplicas }}

--- a/servicex_app/app.conf.template
+++ b/servicex_app/app.conf.template
@@ -59,7 +59,7 @@ TRANSFORMER_MAX_REPLICAS = 20
 # Use one core per transformer
 TRANSFORMER_CPU_LIMIT = 1
 # Use 2GB per transformer
-TRANSFORMER_MEMORY_LIMIT = 2Gi
+TRANSFORMER_MEMORY_LIMIT = "2Gi"
 
 # CPU threshold for HPA (in percent) to spawn additional transformers
 TRANSFORMER_CPU_SCALE_THRESHOLD = 70


### PR DESCRIPTION
Needed because the memory limit is a string