### PR TITLE
More general python codegen

### DIFF
--- a/code_generator_python/python_code_generator/templates/transform_single_file.py
+++ b/code_generator_python/python_code_generator/templates/transform_single_file.py
@@ -2,8 +2,10 @@ import os
 import sys
 import time
 from pathlib import Path
+import inspect
 import generated_transformer
-instance = os.environ.get('INSTANCE_NAME', 'Unknown')
+
+instance = os.environ.get("INSTANCE_NAME", "Unknown")
 default_tree_name = "servicex"
 default_branch_name = "branch"
 
@@ -18,18 +20,23 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
     try:
         stime = time.time()
 
-        # We first see if the function has the signature to directly write output
+        # We first see if the function takes two parameters; if so we assume the second
+        # will be interpreted as the file name for the output.
         # If it doesn't, then we assume it's giving us back awkward array results
-        try:
+
+        provided_signature = inspect.signature(generated_transformer.run_query)
+        if len(provided_signature.parameters) == 2:
             generated_transformer.run_query(file_path, str(output_path))
             if not output_path.exists():
-                raise RuntimeError("Transformation did not produce expected output file "
-                                   f"{output_path}")
+                raise RuntimeError(
+                    "Transformation did not produce expected output file "
+                    f"{output_path}"
+                )
             ttime = time.time()
             etime = time.time()
             wtime = time.time()
             total_events = 0
-        except AttributeError:
+        else:
             import awkward as ak
             import uproot
             import pyarrow.parquet as pq
@@ -38,22 +45,26 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
             output = generated_transformer.run_query(file_path)
 
             ttime = time.time()
-            if output_format == 'root-file':
+            if output_format == "root-file":
                 etime = time.time()
                 if isinstance(output, ak.Array):
                     awkward_arrays = {default_tree_name: output}
                 elif isinstance(output, dict):
                     awkward_arrays = output
-                with open(output_path, 'b+w') as wfile:
+                with open(output_path, "b+w") as wfile:
                     with uproot.recreate(wfile) as writer:
                         for key in awkward_arrays.keys():
                             total_events = awkward_arrays[key].__len__()
                             if awkward_arrays[key].fields and total_events:
-                                o_dict = {field: awkward_arrays[key][field]
-                                          for field in awkward_arrays[key].fields}
+                                o_dict = {
+                                    field: awkward_arrays[key][field]
+                                    for field in awkward_arrays[key].fields
+                                }
                             elif awkward_arrays[key].fields and not total_events:
-                                o_dict = {field: np.array([])
-                                          for field in awkward_arrays[key].fields}
+                                o_dict = {
+                                    field: np.array([])
+                                    for field in awkward_arrays[key].fields
+                                }
                             elif not awkward_arrays[key].fields and total_events:
                                 o_dict = {default_branch_name: awkward_arrays[key]}
                             else:
@@ -61,7 +72,7 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
                             writer[key] = o_dict
 
                 wtime = time.time()
-            elif output_format == 'raw-file':
+            elif output_format == "raw-file":
                 etime = time.time()
                 total_events = 0
                 output_path = output
@@ -70,9 +81,11 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
                 if isinstance(output, dict):
                     tree_name = list(output.keys())[0]
                     awkward_array = output[tree_name]
-                    print(f'Returned type from your Python function is a dictionary - '
-                          f'Only the first key {tree_name} will be written as parquet files. '
-                          f'Please use root-file output to write all trees.')
+                    print(
+                        f"Returned type from your Python function is a dictionary - "
+                        f"Only the first key {tree_name} will be written as parquet files. "
+                        f"Please use root-file output to write all trees."
+                    )
                 else:
                     awkward_array = output
 
@@ -88,11 +101,15 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
                 wtime = time.time()
 
         output_size = os.stat(output_path).st_size
-        print(f'Detailed transformer times. query_time:{round(ttime - stime, 3)} '
-              f'serialization: {round(etime - ttime, 3)} '
-              f'writing: {round(wtime - etime, 3)}')
+        print(
+            f"Detailed transformer times. query_time:{round(ttime - stime, 3)} "
+            f"serialization: {round(etime - ttime, 3)} "
+            f"writing: {round(wtime - etime, 3)}"
+        )
 
-        print(f"Transform stats: Total Events: {total_events}, resulting file size {output_size}")
+        print(
+            f"Transform stats: Total Events: {total_events}, resulting file size {output_size}"
+        )
     except Exception as error:
         mesg = f"Failed to transform input file {file_path}: {error}"
         print(mesg)

--- a/code_generator_python/python_code_generator/templates/transform_single_file.py
+++ b/code_generator_python/python_code_generator/templates/transform_single_file.py
@@ -21,7 +21,7 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
         # We first see if the function has the signature to directly write output
         # If it doesn't, then we assume it's giving us back awkward array results
         try:
-            generated_transformer.run_query(file_path, output_path)
+            generated_transformer.run_query(file_path, str(output_path))
             if not output_path.exists():
                 raise RuntimeError("Transformation did not produce expected output file "
                                    f"{output_path}")

--- a/code_generator_python/python_code_generator/templates/transform_single_file.py
+++ b/code_generator_python/python_code_generator/templates/transform_single_file.py
@@ -3,10 +3,6 @@ import sys
 import time
 from pathlib import Path
 import generated_transformer
-import awkward as ak
-import uproot
-import pyarrow.parquet as pq
-import numpy as np
 instance = os.environ.get('INSTANCE_NAME', 'Unknown')
 default_tree_name = "servicex"
 default_branch_name = "branch"
@@ -34,6 +30,11 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
             wtime = time.time()
             total_events = 0
         except AttributeError:
+            import awkward as ak
+            import uproot
+            import pyarrow.parquet as pq
+            import numpy as np
+
             output = generated_transformer.run_query(file_path)
 
             ttime = time.time()

--- a/code_generator_python/python_code_generator/templates/transform_single_file.py
+++ b/code_generator_python/python_code_generator/templates/transform_single_file.py
@@ -22,58 +22,69 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
     try:
         stime = time.time()
 
-        output = generated_transformer.run_query(file_path)
-
-        ttime = time.time()
-
-        if output_format == 'root-file':
+        # We first see if the function has the signature to directly write output
+        # If it doesn't, then we assume it's giving us back awkward array results
+        try:
+            generated_transformer.run_query(file_path, output_path)
+            if not output_path.exists():
+                raise RuntimeError("Transformation did not produce expected output file "
+                                   f"{output_path}")
+            ttime = time.time()
             etime = time.time()
-            if isinstance(output, ak.Array):
-                awkward_arrays = {default_tree_name: output}
-            elif isinstance(output, dict):
-                awkward_arrays = output
-            with open(output_path, 'b+w') as wfile:
-                with uproot.recreate(wfile) as writer:
-                    for key in awkward_arrays.keys():
-                        total_events = awkward_arrays[key].__len__()
-                        if awkward_arrays[key].fields and total_events:
-                            o_dict = {field: awkward_arrays[key][field]
-                                      for field in awkward_arrays[key].fields}
-                        elif awkward_arrays[key].fields and not total_events:
-                            o_dict = {field: np.array([])
-                                      for field in awkward_arrays[key].fields}
-                        elif not awkward_arrays[key].fields and total_events:
-                            o_dict = {default_branch_name: awkward_arrays[key]}
-                        else:
-                            o_dict = {default_branch_name: np.array([])}
-                        writer[key] = o_dict
-
             wtime = time.time()
-        elif output_format == 'raw-file':
-            etime = time.time()
             total_events = 0
-            output_path = output
-            wtime = time.time()
-        else:
-            if isinstance(output, dict):
-                tree_name = list(output.keys())[0]
-                awkward_array = output[tree_name]
-                print(f'Returned type from your Python function is a dictionary - '
-                      f'Only the first key {tree_name} will be written as parquet files. '
-                      f'Please use root-file output to write all trees.')
+        except AttributeError:
+            output = generated_transformer.run_query(file_path)
+
+            ttime = time.time()
+            if output_format == 'root-file':
+                etime = time.time()
+                if isinstance(output, ak.Array):
+                    awkward_arrays = {default_tree_name: output}
+                elif isinstance(output, dict):
+                    awkward_arrays = output
+                with open(output_path, 'b+w') as wfile:
+                    with uproot.recreate(wfile) as writer:
+                        for key in awkward_arrays.keys():
+                            total_events = awkward_arrays[key].__len__()
+                            if awkward_arrays[key].fields and total_events:
+                                o_dict = {field: awkward_arrays[key][field]
+                                          for field in awkward_arrays[key].fields}
+                            elif awkward_arrays[key].fields and not total_events:
+                                o_dict = {field: np.array([])
+                                          for field in awkward_arrays[key].fields}
+                            elif not awkward_arrays[key].fields and total_events:
+                                o_dict = {default_branch_name: awkward_arrays[key]}
+                            else:
+                                o_dict = {default_branch_name: np.array([])}
+                            writer[key] = o_dict
+
+                wtime = time.time()
+            elif output_format == 'raw-file':
+                etime = time.time()
+                total_events = 0
+                output_path = output
+                wtime = time.time()
             else:
-                awkward_array = output
+                if isinstance(output, dict):
+                    tree_name = list(output.keys())[0]
+                    awkward_array = output[tree_name]
+                    print(f'Returned type from your Python function is a dictionary - '
+                          f'Only the first key {tree_name} will be written as parquet files. '
+                          f'Please use root-file output to write all trees.')
+                else:
+                    awkward_array = output
 
-            total_events = ak.num(awkward_array, axis=0)
-            arrow = ak.to_arrow_table(awkward_array)
+                total_events = ak.num(awkward_array, axis=0)
+                arrow = ak.to_arrow_table(awkward_array)
 
-            etime = time.time()
+                etime = time.time()
 
-            writer = pq.ParquetWriter(output_path, arrow.schema)
-            writer.write_table(table=arrow)
-            writer.close()
+                writer = pq.ParquetWriter(output_path, arrow.schema)
+                writer.write_table(table=arrow)
+                writer.close()
 
-            wtime = time.time()
+                wtime = time.time()
 
         output_size = os.stat(output_path).st_size
         print(f'Detailed transformer times. query_time:{round(ttime - stime, 3)} '


### PR DESCRIPTION
Allow the function signature
```
run_query(file_path, output_path: Path)
```
in addition to
```
run_query(file_path)
```
so Python transformers can create arbitrary ROOT file output.