### PR TITLE
Change axis default on a number of functions in uproot-raw codegen

### DIFF
--- a/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
+++ b/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
@@ -28,8 +28,11 @@
 import os
 import shutil
 
-from servicex_codegen.code_generator import CodeGenerator, GeneratedFileResult, \
-    GenerateCodeException
+from servicex_codegen.code_generator import (
+    CodeGenerator,
+    GeneratedFileResult,
+    GenerateCodeException,
+)
 
 
 class RawUprootTranslator(CodeGenerator):
@@ -41,18 +44,22 @@ class RawUprootTranslator(CodeGenerator):
             raise GenerateCodeException("Requested codegen for an empty string.")
 
         import json
+
         jquery = json.loads(query)
 
         if not isinstance(jquery, list):
             raise GenerateCodeException("Provided query is not a list")
 
         for subquery in jquery:
-            if (('treename' not in subquery or not subquery['treename'])
-                    and ('copy_histograms' not in subquery or not subquery['copy_histograms'])):
-                raise GenerateCodeException("At least one tree or histogram must be "
-                                            f"specified for query {subquery}")
+            if ("treename" not in subquery or not subquery["treename"]) and (
+                "copy_histograms" not in subquery or not subquery["copy_histograms"]
+            ):
+                raise GenerateCodeException(
+                    "At least one tree or histogram must be "
+                    f"specified for query {subquery}"
+                )
 
-        generated_code = f'''
+        generated_code = f"""
 def run_query(file_path):
     jquery = {jquery}
 
@@ -61,41 +68,48 @@ def run_query(file_path):
         for obj in run_single_query(file_path, subquery):
             yield obj
 
-def run_single_query(file_path, query):
-    import uproot
-    import awkward as ak
-    from tenacity import retry, stop_after_attempt, retry_if_exception_message,\
-                         wait_exponential_jitter
+def change_axis(func, axis=1):
+    # change the axis argument
+    import functools
+    return functools.partial(func, axis=axis)
 
+def get_lang(default_axis=False):
+    import awkward as ak
+    import uproot
     lang = uproot.language.python.PythonLanguage()
-    lang.functions.update({{ 'concatenate': ak.concatenate,
+    if default_axis:
+        import functools
+        fa = functools.partial
+    else:
+        fa = change_axis
+    lang.functions.update({{ 'concatenate': fa(ak.concatenate),
                              'where': ak.where,
-                             'flatten': ak.flatten,
+                             'flatten': fa(ak.flatten, axis=2),
                              'num': ak.num,
-                             'count': ak.count,
-                             'count_nonzero': ak.count_nonzero,
-                             'sum': ak.sum,
-                             'nansum': ak.nansum,
-                             'prod': ak.prod,
-                             'nanprod': ak.nanprod,
-                             'any': ak.any,
-                             'all': ak.all,
-                             'min': ak.min,
-                             'nanmin': ak.nanmin,
-                             'max': ak.max,
-                             'nanmax': ak.nanmax,
-                             'argmin': ak.argmin,
-                             'nanargmin': ak.nanargmin,
-                             'argmax': ak.argmax,
-                             'nanargmax': ak.nanargmax,
-                             'moment': ak.moment,
-                             'mean': ak.mean,
-                             'nanmean': ak.nanmean,
-                             'var': ak.var,
-                             'nanvar': ak.nanvar,
-                             'std': ak.std,
-                             'nanstd': ak.nanstd,
-                             'softmax': ak.softmax,
+                             'count': fa(ak.count),
+                             'count_nonzero': fa(ak.count_nonzero),
+                             'sum': fa(ak.sum),
+                             'nansum': fa(ak.nansum),
+                             'prod': fa(ak.prod),
+                             'nanprod': fa(ak.nanprod),
+                             'any': fa(ak.any),
+                             'all': fa(ak.all),
+                             'min': fa(ak.min),
+                             'nanmin': fa(ak.nanmin),
+                             'max': fa(ak.max),
+                             'nanmax': fa(ak.nanmax),
+                             'argmin': fa(ak.argmin),
+                             'nanargmin': fa(ak.nanargmin),
+                             'argmax': fa(ak.argmax),
+                             'nanargmax': fa(ak.nanargmax),
+                             'moment': fa(ak.moment),
+                             'mean': fa(ak.mean),
+                             'nanmean': fa(ak.nanmean),
+                             'var': fa(ak.var),
+                             'nanvar': fa(ak.nanvar),
+                             'std': fa(ak.std),
+                             'nanstd': fa(ak.nanstd),
+                             'softmax': fa(ak.softmax),
                              'sort': ak.sort,
                              'argsort': ak.argsort,
                              'mask': ak.mask,
@@ -114,6 +128,12 @@ def run_single_query(file_path, query):
                              'isclose': ak.isclose,
                              'almost_equal': ak.almost_equal,
                            }})
+    return lang
+
+def run_single_query(file_path, query):
+    import uproot
+    from tenacity import retry, stop_after_attempt, retry_if_exception_message,\
+                         wait_exponential_jitter
 
     sanitized_args = {{'expressions': query.get('expressions'),
                        'cut': query.get('cut'),
@@ -127,6 +147,7 @@ def run_single_query(file_path, query):
     with open_func({{file_path: None}}) as fl:
         if 'treename' in query:
             trees = query['treename']
+            lang = get_lang(query.get('use_standard_awkward_axis', False))
             if isinstance(trees, str):
                 trees = [trees]
             if isinstance(trees, list):
@@ -154,7 +175,7 @@ def run_single_query(file_path, query):
             keys = fl.keys(filter_name=histograms, cycle=False)
             for key in keys:
                 yield ('obj', key, fl[key])
-'''
+"""
 
         _hash = hashlib.md5(generated_code.encode(), usedforsecurity=False).hexdigest()
         query_file_path = os.path.join(cache_path, _hash)
@@ -163,17 +184,26 @@ def run_single_query(file_path, query):
         if not os.path.exists(query_file_path):
             os.makedirs(query_file_path)
 
-        with open(os.path.join(query_file_path, 'generated_transformer.py'), 'w') as python_file:
+        with open(
+            os.path.join(query_file_path, "generated_transformer.py"), "w"
+        ) as python_file:
             python_file.write(generated_code)
 
         # Transfer the templated main python script
-        template_path = os.environ.get('TEMPLATE_PATH',
-                                       "/home/servicex/servicex/templates/transform_single_file.py")  # NOQA: 501
-        shutil.copyfile(template_path, os.path.join(query_file_path, "transform_single_file.py"))
+        template_path = os.environ.get(
+            "TEMPLATE_PATH",
+            "/home/servicex/servicex/templates/transform_single_file.py",
+        )  # NOQA: 501
+        shutil.copyfile(
+            template_path, os.path.join(query_file_path, "transform_single_file.py")
+        )
 
-        capabilities_path = os.environ.get('CAPABILITIES_PATH',
-                                           "/home/servicex/transformer_capabilities.json")
-        shutil.copyfile(capabilities_path, os.path.join(query_file_path,
-                                                        "transformer_capabilities.json"))
+        capabilities_path = os.environ.get(
+            "CAPABILITIES_PATH", "/home/servicex/transformer_capabilities.json"
+        )
+        shutil.copyfile(
+            capabilities_path,
+            os.path.join(query_file_path, "transformer_capabilities.json"),
+        )
 
         return GeneratedFileResult(_hash, query_file_path)

--- a/code_generator_raw_uproot/tests/test_src.py
+++ b/code_generator_raw_uproot/tests/test_src.py
@@ -26,8 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from servicex.raw_uproot_code_generator.request_translator import \
-    RawUprootTranslator
+from servicex.raw_uproot_code_generator.request_translator import RawUprootTranslator
 import json
 import os
 import tempfile
@@ -36,38 +35,44 @@ from servicex_codegen.code_generator import GenerateCodeException
 
 
 def test_generate_code():
-    os.environ['TEMPLATE_PATH'] = "servicex/templates/transform_single_file.py"
-    os.environ['CAPABILITIES_PATH'] = "transformer_capabilities.json"
+    os.environ["TEMPLATE_PATH"] = "servicex/templates/transform_single_file.py"
+    os.environ["CAPABILITIES_PATH"] = "transformer_capabilities.json"
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         # proper query
         translator = RawUprootTranslator()
-        query = json.dumps([{'treename': 'sumWeights', 'filter_name': ['/totalE.*/']},
-                            {'treename': ['nominal', 'JET_JER_EffectiveNP_1__1down'],
-                             'filter_name': ['/mu_.*/', 'runNumber', 'lbn'],
-                             'cut': 'met_met>150e3'},
-                            {'treename': {'nominal': 'modified'},
-                             'filter_name': ['lbn']},
-                            {'copy_histograms': 'CutBookkeeper*'}
-                            ])
-        expected_hash = "e95bbb95ff7556f2ffcc8a8c8f09919c"
+        query = json.dumps(
+            [
+                {"treename": "sumWeights", "filter_name": ["/totalE.*/"]},
+                {
+                    "treename": ["nominal", "JET_JER_EffectiveNP_1__1down"],
+                    "filter_name": ["/mu_.*/", "runNumber", "lbn"],
+                    "cut": "met_met>150e3",
+                },
+                {"treename": {"nominal": "modified"}, "filter_name": ["lbn"]},
+                {"copy_histograms": "CutBookkeeper*"},
+            ]
+        )
+        expected_hash = "a8c6631c850eb04ba9c8675cfe1d3bb0"
         result = translator.generate_code(query, tmpdirname)
 
         # is the generated code at least syntactically valid Python?
         try:
-            exec(open(os.path.join(result.output_dir, 'generated_transformer.py')).read())
+            exec(
+                open(os.path.join(result.output_dir, "generated_transformer.py")).read()
+            )
         except SyntaxError:
-            pytest.fail('Generated Python is not valid code')
+            pytest.fail("Generated Python is not valid code")
 
         assert result.hash == expected_hash
         assert result.output_dir == os.path.join(tmpdirname, expected_hash)
 
         # empty query
-        query = ''
+        query = ""
         with pytest.raises(GenerateCodeException):
             translator.generate_code(query, tmpdirname)
 
-        query = json.dumps('abc')
+        query = json.dumps("abc")
         with pytest.raises(GenerateCodeException):
             translator.generate_code(query, tmpdirname)
 
@@ -78,4 +83,5 @@ def test_generate_code():
 
 def test_app():
     import servicex.raw_uproot_code_generator
+
     servicex.raw_uproot_code_generator.create_app()


### PR DESCRIPTION
We make many `awkward` functions available when writing cuts and expressions for uproot. A lot of these default to operating on the entire array at once (`axis=0`) in ways that make no sense for an event-by-event cut mask. In general this default causes a lot of errors. We will override those defaults here (we believe the defaults are so incorrect that nobody with correct code will be affected by this). The axis can still be overridden if people want. The list of functions with changed defaults will be given in the frontend documentation.