### PR TITLE
Add capabilities reporting feature

### DIFF
--- a/servicex_app/servicex_app/resources/info.py
+++ b/servicex_app/servicex_app/resources/info.py
@@ -33,5 +33,6 @@ class Info(ServiceXResource):
     def get(self):
         return {
             "app-version": self._get_app_version(),
-            "code-gen-image": current_app.config['CODE_GEN_IMAGES']
+            "code-gen-image": current_app.config['CODE_GEN_IMAGES'],
+            "capabilities": []
         }

--- a/servicex_app/servicex_app_test/resources/test_servicex_info.py
+++ b/servicex_app/servicex_app_test/resources/test_servicex_info.py
@@ -40,5 +40,6 @@ class TestServicexInfo(ResourceTestBase):
                                     'cms': 'sslhep/servicex_code_gen_cms_aod:develop',
                                     'python': 'sslhep/servicex_code_gen_python:develop',
                                     'uproot': 'sslhep/servicex_code_gen_func_adl_uproot:develop'
-                                    }
+                                    },
+                                 'capabilities': []
                                 }  # noqa: E501


### PR DESCRIPTION
Extend the "Info" (/servicex) endpoint return value to include a static list of capabilities that the client can test against. For now keep it blank, but this can be updated as features are added.