### PR TITLE
Configurable compression algorithm and level for Uproot transformers

### DIFF
--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -75,11 +75,14 @@ def root_write_table_data(output_format, writer, outtreename, data):
             writer.mkrntuple(outtreename, data)
 
 
-def transform_single_file(file_path: str, output_path: Path, output_format: str):
+def transform_single_file(file_path: str, output_path: Path, output_format: str, compression_algorithm: str = 'ZSTD', compression_level: int = 5):
     """
     Transform a single file and return some information about output
     :param file_path: path for file to process
     :param output_path: path to file
+    :param output_format: format of output file
+    :param compression_algorithm: compression algorithm to use (default ZSTD)
+    :param compression_level: compression level to use (default 5)
     :return: Tuple with (total_events: Int, output_size: Int)
     """
     try:
@@ -93,7 +96,8 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
             # opening the file with open() is a workaround for a bug handling multiple colons
             # in the filename in uproot
             with open(output_path, 'b+w') as wfile:
-                with uproot.recreate(wfile, compression=uproot.ZSTD(5)) as writer:
+                compression = getattr(uproot, compression_algorithm)(compression_level)
+                with uproot.recreate(wfile, compression=compression) as writer:
                     for dt, item in get_generator_timing(run_query)(file_path):
                         ttimedt += dt
                         match item:

--- a/servicex_app/servicex_app/lookup_result_processor.py
+++ b/servicex_app/servicex_app/lookup_result_processor.py
@@ -57,7 +57,9 @@ class LookupResultProcessor:
                                         + "servicex/internal/transformation/"
                                         + request.request_id,
                                         "result_destination": request.result_destination,
-                                        "result_format": request.result_format
+                                        "result_format": request.result_format,
+                                        "result_compression_algorithm": request.result_compression_algorithm,
+                                        "result_compression_level": request.result_compression_level
                                     })
 
             current_app.logger.info("Added file to processing queue", extra={

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -178,6 +178,8 @@ class TransformRequest(db.Model):
     workers = db.Column(db.Integer, nullable=True)
     result_destination = db.Column(db.String(32), nullable=False)
     result_format = db.Column(db.String(32), nullable=False)
+    result_compression_algorithm = db.Column(db.String(32), nullable=False)
+    result_compression_level = db.Column(db.Integer, nullable=False)
     submitted_by = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=True)
 
     files = db.Column(db.Integer, default=0, nullable=False)
@@ -214,6 +216,8 @@ class TransformRequest(db.Model):
             'workers': self.workers,
             'result-destination': self.result_destination,
             'result-format': self.result_format,
+            'result-compression-algorithm': self.result_compression_algorithm,
+            'result-compression-level': self.result_compression_level,
             'generated-code-cm': self.generated_code_cm,
             'status': self.status.string_name,
             'failure-info': self.failure_description,

--- a/servicex_app/servicex_app/resources/servicex_resource.py
+++ b/servicex_app/servicex_app/resources/servicex_resource.py
@@ -102,6 +102,8 @@ class ServiceXResource(Resource):
             generated_code_cm=generated_code_cm,
             result_destination=request_rec.result_destination,
             result_format=request_rec.result_format,
+            result_compression_algorithm=request_rec.result_compression_algorithm,
+            result_compression_level=request_rec.result_compression_level,
             transformer_language=request_rec.transformer_language,
             transformer_command=request_rec.transformer_command
         )

--- a/servicex_app/servicex_app/resources/transformation/submit.py
+++ b/servicex_app/servicex_app/resources/transformation/submit.py
@@ -79,6 +79,12 @@ class SubmitTransformationRequest(ServiceXResource):
             'result-format', choices=['parquet', 'root-file',
                                       'root-rntuple'], default='parquet'
         )
+        cls.parser.add_argument(
+            'result-compression-algorithm', choices=['ZSTD', 'LZ4', 'ZLIB', 'LZMA'], default='ZSTD'
+        )
+        cls.parser.add_argument(
+            'result-compression-level', type=int, default=5, choices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        )
         return cls
 
     def _initialize_dataset_manager(self, did: Optional[str],
@@ -183,6 +189,8 @@ class SubmitTransformationRequest(ServiceXResource):
                 tree_name=args['tree-name'],
                 result_destination=args['result-destination'],
                 result_format=args['result-format'],
+                result_compression_algorithm=args['result-compression-algorithm'],
+                result_compression_level=args['result-compression-level'],
                 workers=args['workers'],
                 status=TransformStatus.submitted,
                 app_version=self._get_app_version(),

--- a/servicex_app/servicex_app/templates/transformation_request.html
+++ b/servicex_app/servicex_app/templates/transformation_request.html
@@ -38,6 +38,12 @@
     <dt class="col-sm-3">Result Format</dt>
     <dd class="col-sm-9">{{ req.result_format }}</dd>
 
+    <dt class="col-sm-3">Result Compression Algorithm</dt>
+    <dd class="col-sm-9">{{ req.result_compression_algorithm }}</dd>
+
+    <dt class="col-sm-3">Result Compression Level</dt>
+    <dd class="col-sm-9">{{ req.result_compression_level }}</dd>
+
     <dt class="col-sm-3">Files</dt>
     <dd class="col-sm-9">{{ humanize.intcomma(req.files) }}</dd>
 

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -84,14 +84,17 @@ class TransformerManager:
             generated_code_cm=generated_code_cm,
             result_destination=request_rec.result_destination,
             result_format=request_rec.result_format,
+            result_compression_algorithm=request_rec.result_compression_algorithm,
+            result_compression_level=request_rec.result_compression_level,
             transformer_language=request_rec.transformer_language,
             transformer_command=request_rec.transformer_command
         )
 
     @staticmethod
     def create_job_object(request_id, image, rabbitmq_uri, workers,
-                          result_destination, result_format, x509_secret,
-                          generated_code_cm, transformer_language, transformer_command):
+                          result_destination, result_format, result_compression_algorithm,
+                          result_compression_level, x509_secret, generated_code_cm,
+                          transformer_language, transformer_command):
         volume_mounts = []
         volumes = []
 
@@ -200,7 +203,9 @@ class TransformerManager:
             " --request-id " + request_id + \
             " --rabbit-uri " + rabbitmq_uri + \
             " --result-destination " + result_destination + \
-            " --result-format " + result_format
+            " --result-format " + result_format + \
+            " --result-compression-algorithm " + result_compression_algorithm + \
+            " --result-compression-level " + str(result_compression_level)
 
         watch_path = os.path.join(current_app.config['TRANSFORMER_SIDECAR_VOLUME_PATH'],
                                   request_id)
@@ -362,12 +367,14 @@ class TransformerManager:
 
     def launch_transformer_jobs(self, image, request_id, workers, max_workers,
                                 rabbitmq_uri, namespace, x509_secret, generated_code_cm,
-                                result_destination, result_format, transformer_language,
+                                result_destination, result_format, result_compression_algorithm,
+                                result_compression_level, transformer_language,
                                 transformer_command
                                 ):
         api_v1 = client.AppsV1Api()
         job = self.create_job_object(request_id, image, rabbitmq_uri, workers,
                                      result_destination, result_format,
+                                     result_compression_algorithm, result_compression_level,
                                      x509_secret, generated_code_cm,
                                      transformer_language, transformer_command)
 

--- a/transformer_sidecar/scripts/watch.sh
+++ b/transformer_sidecar/scripts/watch.sh
@@ -51,9 +51,11 @@ while [[ $nc_PID ]] ; do
     download_path=$(echo $line | jq -r '.downloadPath')
     output_file=$(echo $line | jq -r '.safeOutputFileName')
     output_format=$(echo $line | jq -r '."result-format"')
+    output_compression_algorithm=$(echo $line | jq -r '."result-compression-algorithm"')
+    output_compression_level=$(echo $line | jq -r '."result-compression-level"')
 
     echo "Attempting $download_path -> $output_file with $output_format format"
-    $lang "$cmd" "$download_path" "$output_file" "$output_format" 2>&1 | tee $path/abc.log
+    $lang "$cmd" "$download_path" "$output_file" "$output_format" "$output_compression_algorithm" "$output_compression_level" 2>&1 | tee $path/abc.log
 
     # sending status back
     if [ "${PIPESTATUS[0]}" == 0 ]; then

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -92,7 +92,9 @@ def transform_file(
         paths: list[str],
         service_endpoint,
         result_destination,
-        result_format):
+        result_format,
+        result_compression_algorithm='ZSTD',
+        result_compression_level=5):
     """
     This is the main function for the transformer. It is called whenever a new message
     is available on the rabbit queue. These messages represent a single file to be
@@ -143,6 +145,8 @@ def transform_file(
             "paths": _file_paths,
             "result-destination": result_destination,
             "result-format": result_format,
+            "result-compression-algorithm": result_compression_algorithm,
+            "result-compression-level": result_compression_level,
             "service-endpoint": service_endpoint,
         },
     )
@@ -195,6 +199,8 @@ def transform_file(
                     os.path.join(scratch_path, hashed_file_name)
 
             transform_request['result-format'] = result_format
+            transform_request['result-compression-algorithm'] = result_compression_algorithm
+            transform_request['result-compression-level'] = result_compression_level
             science_container.synch()
             science_container.send(transform_request)
             science_container_response = science_container.await_response()

--- a/transformer_sidecar/src/transformer_sidecar/transformer_argument_parser.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer_argument_parser.py
@@ -59,6 +59,14 @@ class TransformerArgumentParser(argparse.ArgumentParser):
                           default='parquet', help='parquet, root-file, root-rntuple',
                           choices=['parquet', 'root-file', 'root-rntuple'])
 
+        self.add_argument('--result-compression-algorithm', dest='result_compression_algorithm', action='store',
+                          default='ZSTD', help='Compression algorithm to use: [ZSTD, LZ4, ZLIB, LZMA]',
+                          choices=['ZSTD', 'LZ4', 'ZLIB', 'LZMA'])
+
+        self.add_argument('--result-compression-level', dest='result_compression_level', action='store',
+                          default=5, help='Compression level  (int, 0-9): 0 is uncompressed, 1 is minimally compressed, 9 is maximally compressed.',
+                          choices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
         self.add_argument('--rabbit-uri', dest="rabbit_uri", action='store',
                           default='host.docker.internal')
 

--- a/transformer_sidecar/tests/test_transformer.py
+++ b/transformer_sidecar/tests/test_transformer.py
@@ -187,6 +187,32 @@ def test_transformer_parquet(args, mock_celery, transformer_capabilities,
         science_request = mock_science_container.return_value.send.call_args[0][0]
         assert science_request["result-format"] == "parquet"
 
+def test_transformer_compression(args, mock_celery, transformer_capabilities,
+                             mock_servicex_adapter,
+                             mock_object_store_manager,
+                             mock_science_container):
+    with (tempfile.TemporaryDirectory() as temp_dir):
+        init_test(args, mock_celery, transformer_capabilities, temp_dir,
+                  ['root', 'parquet'], 'root')
+
+        mock_science_container.return_value.await_response.side_effect = ["failure",
+                                                                          "success."]
+
+        # Call the task
+        transform_file(
+            request_id=test_request_id,
+            file_id=test_file_id,
+            paths=test_paths,
+            service_endpoint=test_service_endpoint,
+            result_destination=test_result_destination,
+            result_format="root",
+            result_compression_algorithm="ZLIB",
+            result_compression_level=9
+        )
+
+        science_request = mock_science_container.return_value.send.call_args[0][0]
+        assert science_request["result-compression-algorithm"] == "ZLIB"
+        assert science_request["result-compression-level"] == 9
 
 def test_transformer_output_dir(args, mock_celery, transformer_capabilities,
                                 mock_servicex_adapter,


### PR DESCRIPTION
This PR adds parameters to control compression algorithm and level, for now only in uproot-raw transformer. 
The new parameters `result-compression-algorithm` and `result-compression-level` are propagated similarly to `result-format`.