### PR TITLE
Configure Uproot compression algorithm and level in Helm chart

### DIFF
--- a/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
+++ b/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
@@ -53,6 +53,10 @@ class RawUprootTranslator(CodeGenerator):
                                             f"specified for query {subquery}")
 
         generated_code = f'''
+import os
+os.environ['COMPRESSION_ALGORITHM'] = '{os.environ['COMPRESSION_ALGORITHM']}'
+os.environ['COMPRESSION_LEVEL'] = '{os.environ['COMPRESSION_LEVEL']}'
+
 def run_query(file_path):
     jquery = {jquery}
 

--- a/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
+++ b/code_generator_raw_uproot/servicex/raw_uproot_code_generator/request_translator.py
@@ -52,11 +52,9 @@ class RawUprootTranslator(CodeGenerator):
                 raise GenerateCodeException("At least one tree or histogram must be "
                                             f"specified for query {subquery}")
 
+        print("COMPRESSION_ALGORITHM:", os.environ['COMPRESSION_ALGORITHM'])
+        print("COMPRESSION_LEVEL:", os.environ['COMPRESSION_LEVEL'])
         generated_code = f'''
-import os
-os.environ['COMPRESSION_ALGORITHM'] = '{os.environ['COMPRESSION_ALGORITHM']}'
-os.environ['COMPRESSION_LEVEL'] = '{os.environ['COMPRESSION_LEVEL']}'
-
 def run_query(file_path):
     jquery = {jquery}
 

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -34,8 +34,16 @@ from generated_transformer import run_query  # noqa
 import awkward as ak
 import pyarrow.parquet as pq
 import functools
-instance = os.environ.get('INSTANCE_NAME', 'Unknown')
+import logging
 
+logger = logging.getLogger(__name__)
+
+instance = os.environ.get('INSTANCE_NAME', 'Unknown')
+compression_algorithm = os.environ.get('COMPRESSION_ALGORITHM', 'ZSTD')
+compression_level = int(os.environ.get('COMPRESSION_LEVEL', 5))
+
+ALLOWED_COMPRESSION_ALGORITHMS = ['ZSTD', 'ZLIB', 'LZMA', 'ZSTD']
+ALLOWED_COMPRESSION_LEVELS = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 def get_generator_timing(f):
     from time import perf_counter
@@ -90,10 +98,23 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
 
         if output_format in ('root-file', 'root-rntuple'):
             import uproot
+
+            if compression_algorithm not in ALLOWED_COMPRESSION_ALGORITHMS:
+                logger.warning(
+                    f"Invalid compression algorithm '{compression_algorithm}'. "
+                    f"Using default 'ZSTD' instead."
+                )
+                compression_algorithm = 'ZSTD'
+            
+            if compression_level not in ALLOWED_COMPRESSION_LEVELS:
+                logger.warning(
+                    f"Invalid compression level '{compression_level}'. "
+                    f"Using default '5' instead."
+                )
+                compression_level = 5
+
             # opening the file with open() is a workaround for a bug handling multiple colons
             # in the filename in uproot
-            compression_algorithm = os.environ.get('COMPRESSION_ALGORITHM', 'ZSTD')
-            compression_level = int(os.environ.get('COMPRESSION_LEVEL', 5))
             with open(output_path, 'b+w') as wfile:
                 compression_obj = getattr(uproot, compression_algorithm)(compression_level)
                 with uproot.recreate(wfile, compression=compression_obj) as writer:

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -34,9 +34,6 @@ from generated_transformer import run_query  # noqa
 import awkward as ak
 import pyarrow.parquet as pq
 import functools
-import logging
-
-logger = logging.getLogger(__name__)
 
 instance = os.environ.get('INSTANCE_NAME', 'Unknown')
 compression_algorithm = os.environ.get('COMPRESSION_ALGORITHM', 'ZSTD')
@@ -100,15 +97,15 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
             import uproot
 
             if compression_algorithm not in ALLOWED_COMPRESSION_ALGORITHMS:
-                logger.warning(
-                    f"Invalid compression algorithm '{compression_algorithm}'. "
+                print(
+                    f"WARNING: Invalid compression algorithm '{compression_algorithm}'. "
                     f"Using default 'ZSTD' instead."
                 )
                 compression_algorithm = 'ZSTD'
             
             if compression_level not in ALLOWED_COMPRESSION_LEVELS:
-                logger.warning(
-                    f"Invalid compression level '{compression_level}'. "
+                print(
+                    f"WARNING: Invalid compression level '{compression_level}'. "
                     f"Using default '5' instead."
                 )
                 compression_level = 5
@@ -157,11 +154,16 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
             wtime = time.time()
 
         output_size = os.stat(output_path).st_size
-        print(f'Detailed transformer times. query_time:{round(ttimedt, 3)} '
-              f'serialization: {round(etimedt, 3)} '
-              f'writing: {round((wtime - stime) - etimedt - ttimedt, 3)}')
+        print(
+            f"Detailed transformer times. query_time:{round(ttimedt, 3)} "
+            f"serialization: {round(etimedt, 3)} "
+            f"writing: {round((wtime - stime) - etimedt - ttimedt, 3)}"
+        )
 
-        print(f"Transform stats: Total Events: {total_events}, resulting file size {output_size}")
+        print(
+            f"Transform stats: Total Events: {total_events}, "
+            f"resulting file size {output_size}"
+        )
     except Exception as error:
         mesg = f"Failed to transform input file {file_path}: {error}"
         print(mesg)

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -92,8 +92,10 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
             import uproot
             # opening the file with open() is a workaround for a bug handling multiple colons
             # in the filename in uproot
+            compression_algorithm = os.environ.get('COMPRESSION_ALGORITHM', 'ZSTD')
+            compression_level = int(os.environ.get('COMPRESSION_LEVEL', 5))
             with open(output_path, 'b+w') as wfile:
-                with uproot.recreate(wfile, compression=uproot.ZSTD(5)) as writer:
+                with uproot.recreate(wfile, compression=getattr(uproot, compression_algorithm)(compression_level)) as writer:
                     for dt, item in get_generator_timing(run_query)(file_path):
                         ttimedt += dt
                         match item:

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -42,8 +42,8 @@ try:
 except ValueError:
     compression_level = 5
 
-ALLOWED_COMPRESSION_ALGORITHMS = ['ZSTD', 'ZLIB', 'LZMA', 'ZSTD']
-ALLOWED_COMPRESSION_LEVELS = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+ALLOWED_COMPRESSION_ALGORITHMS = {'ZLIB', 'LZMA', 'LZ4' 'ZSTD'}
+ALLOWED_COMPRESSION_LEVELS = {1, 2, 3, 4, 5, 6, 7, 8, 9}
 
 def get_generator_timing(f):
     from time import perf_counter

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -87,6 +87,11 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
     :param output_path: path to file
     :return: Tuple with (total_events: Int, output_size: Int)
     """
+    print(f"Compression algorithm: {compression_algorithm}")
+    print(f"Compression level: {compression_level}")
+    print(f"Allowed compression algorithms: {ALLOWED_COMPRESSION_ALGORITHMS}")
+    print(f"Allowed compression levels: {ALLOWED_COMPRESSION_LEVELS}")
+
     try:
         stime = time.time()
         total_events = 0

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -87,10 +87,6 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
     :param output_path: path to file
     :return: Tuple with (total_events: Int, output_size: Int)
     """
-    print(f"Compression algorithm: {compression_algorithm}")
-    print(f"Compression level: {compression_level}")
-    print(f"Allowed compression algorithms: {ALLOWED_COMPRESSION_ALGORITHMS}")
-    print(f"Allowed compression levels: {ALLOWED_COMPRESSION_LEVELS}")
 
     try:
         stime = time.time()

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -95,7 +95,8 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
             compression_algorithm = os.environ.get('COMPRESSION_ALGORITHM', 'ZSTD')
             compression_level = int(os.environ.get('COMPRESSION_LEVEL', 5))
             with open(output_path, 'b+w') as wfile:
-                with uproot.recreate(wfile, compression=getattr(uproot, compression_algorithm)(compression_level)) as writer:
+                compression_obj = getattr(uproot, compression_algorithm)(compression_level)
+                with uproot.recreate(wfile, compression=compression_obj) as writer:
                     for dt, item in get_generator_timing(run_query)(file_path):
                         ttimedt += dt
                         match item:

--- a/code_generator_raw_uproot/servicex/templates/transform_single_file.py
+++ b/code_generator_raw_uproot/servicex/templates/transform_single_file.py
@@ -37,7 +37,10 @@ import functools
 
 instance = os.environ.get('INSTANCE_NAME', 'Unknown')
 compression_algorithm = os.environ.get('COMPRESSION_ALGORITHM', 'ZSTD')
-compression_level = int(os.environ.get('COMPRESSION_LEVEL', 5))
+try:
+    compression_level = int(os.environ.get('COMPRESSION_LEVEL', 5))
+except ValueError:
+    compression_level = 5
 
 ALLOWED_COMPRESSION_ALGORITHMS = ['ZSTD', 'ZLIB', 'LZMA', 'ZSTD']
 ALLOWED_COMPRESSION_LEVELS = [1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/helm/servicex/templates/app/configmap.yaml
+++ b/helm/servicex/templates/app/configmap.yaml
@@ -118,6 +118,8 @@ data:
     TRANSFORMER_PERSISTENCE_PROVIDED_CLAIM = "{{ .Values.transformer.persistence.existingClaim }}"
     TRANSFORMER_PERSISTENCE_SUBDIR = "{{ .Values.transformer.persistence.subdir}}"
 
+    TRANSFORMER_COMPRESSION_ALGORITHM = "{{ .Values.transformer.compressionAlgorithm }}"
+    TRANSFORMER_COMPRESSION_LEVEL = "{{ .Values.transformer.compressionLevel }}"
 
     {{ if .Values.objectStore.enabled }}
     OBJECT_STORE_ENABLED = True

--- a/helm/servicex/templates/app/configmap.yaml
+++ b/helm/servicex/templates/app/configmap.yaml
@@ -118,8 +118,6 @@ data:
     TRANSFORMER_PERSISTENCE_PROVIDED_CLAIM = "{{ .Values.transformer.persistence.existingClaim }}"
     TRANSFORMER_PERSISTENCE_SUBDIR = "{{ .Values.transformer.persistence.subdir}}"
 
-    TRANSFORMER_COMPRESSION_ALGORITHM = "{{ .Values.transformer.compressionAlgorithm }}"
-    TRANSFORMER_COMPRESSION_LEVEL = "{{ .Values.transformer.compressionLevel }}"
 
     {{ if .Values.objectStore.enabled }}
     OBJECT_STORE_ENABLED = True

--- a/helm/servicex/templates/codegen/deployment.yaml
+++ b/helm/servicex/templates/codegen/deployment.yaml
@@ -24,6 +24,10 @@ spec:
           value: {{ $.Release.Name }}
         - name: TRANSFORMER_SCIENCE_IMAGE
           value: {{ .defaultScienceContainerImage }}:{{ .defaultScienceContainerTag }}
+        - name: TRANSFORMER_COMPRESSION_ALGORITHM
+          value: {{ .compressionAlgorithm }}
+        - name: TRANSFORMER_COMPRESSION_LEVEL
+          value: {{ .compressionLevel }}
         tty: true
         stdin: true
         imagePullPolicy: {{ .pullPolicy }}

--- a/helm/servicex/templates/codegen/deployment.yaml
+++ b/helm/servicex/templates/codegen/deployment.yaml
@@ -24,6 +24,12 @@ spec:
           value: {{ $.Release.Name }}
         - name: TRANSFORMER_SCIENCE_IMAGE
           value: {{ .defaultScienceContainerImage }}:{{ .defaultScienceContainerTag }}
+        {{- $compressionAlgorithm := .compressionAlgorithm | default "ZSTD" }}
+        {{- $compressionLevel := .compressionLevel | default 5 }}
+        - name: COMPRESSION_ALGORITHM
+          value: {{ $compressionAlgorithm }}
+        - name: COMPRESSION_LEVEL
+          value: "{{ $compressionLevel }}"
         tty: true
         stdin: true
         imagePullPolicy: {{ .pullPolicy }}

--- a/helm/servicex/templates/codegen/deployment.yaml
+++ b/helm/servicex/templates/codegen/deployment.yaml
@@ -24,10 +24,12 @@ spec:
           value: {{ $.Release.Name }}
         - name: TRANSFORMER_SCIENCE_IMAGE
           value: {{ .defaultScienceContainerImage }}:{{ .defaultScienceContainerTag }}
-        - name: TRANSFORMER_COMPRESSION_ALGORITHM
-          value: {{ .compressionAlgorithm }}
-        - name: TRANSFORMER_COMPRESSION_LEVEL
-          value: {{ .compressionLevel }}
+        {{- $compressionAlgorithm := .compressionAlgorithm | default "ZSTD" }}
+        {{- $compressionLevel := .compressionLevel | default 5 }}
+        - name: COMPRESSION_ALGORITHM
+          value: {{ $compressionAlgorithm }}
+        - name: COMPRESSION_LEVEL
+          value: "{{ $compressionLevel }}"
         tty: true
         stdin: true
         imagePullPolicy: {{ .pullPolicy }}

--- a/helm/servicex/templates/codegen/deployment.yaml
+++ b/helm/servicex/templates/codegen/deployment.yaml
@@ -24,12 +24,6 @@ spec:
           value: {{ $.Release.Name }}
         - name: TRANSFORMER_SCIENCE_IMAGE
           value: {{ .defaultScienceContainerImage }}:{{ .defaultScienceContainerTag }}
-        {{- $compressionAlgorithm := .compressionAlgorithm | default "ZSTD" }}
-        {{- $compressionLevel := .compressionLevel | default 5 }}
-        - name: COMPRESSION_ALGORITHM
-          value: {{ $compressionAlgorithm }}
-        - name: COMPRESSION_LEVEL
-          value: "{{ $compressionLevel }}"
         tty: true
         stdin: true
         imagePullPolicy: {{ .pullPolicy }}

--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -40,6 +40,9 @@ codeGen:
     tag: develop
     defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
     defaultScienceContainerTag: 5.6.1
+    compressionAlgorithm: ZSTD
+    compressionLevel: 5
+
 
   uproot:
     enabled: true
@@ -185,10 +188,6 @@ transformer:
     existingClaim: null
     subdir: null
   priorityClassName: null
-
-  # applied only in uproot-raw code generator
-  compressionAlgorithm: ZSTD
-  compressionLevel: 5
 
 x509Secrets:
   image: sslhep/x509-secrets

--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -40,8 +40,6 @@ codeGen:
     tag: develop
     defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
     defaultScienceContainerTag: 5.6.1
-    compressionAlgorithm: ZSTD
-    compressionLevel: 5
 
   uproot:
     enabled: true
@@ -187,6 +185,11 @@ transformer:
     existingClaim: null
     subdir: null
   priorityClassName: null
+
+  # applied only in uproot-raw code generator
+  compressionAlgorithm: ZSTD
+  compressionLevel: 5
+
 x509Secrets:
   image: sslhep/x509-secrets
   initImage: alpine:3.6

--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -40,6 +40,8 @@ codeGen:
     tag: develop
     defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
     defaultScienceContainerTag: 5.6.1
+    compressionAlgorithm: ZSTD
+    compressionLevel: 5
 
   uproot:
     enabled: true

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -221,6 +221,13 @@ class TransformerManager:
                     "memory": current_app.config['TRANSFORMER_MEMORY_LIMIT']}
         )
 
+        env += [
+            client.V1EnvVar(name='COMPRESSION_ALGORITHM',
+                            value=current_app.config['TRANSFORMER_COMPRESSION_ALGORITHM']),
+            client.V1EnvVar(name='COMPRESSION_LEVEL',
+                            value=current_app.config['TRANSFORMER_COMPRESSION_LEVEL'])
+        ]
+
         # Configure Pod template container
         science_container = client.V1Container(
             name="transformer",

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -221,6 +221,8 @@ class TransformerManager:
                     "memory": current_app.config['TRANSFORMER_MEMORY_LIMIT']}
         )
 
+        print("COMPRESSION_ALGORITHM (current_app.config):", current_app.config['TRANSFORMER_COMPRESSION_ALGORITHM'])
+        print("COMPRESSION_LEVEL (current_app.config):", current_app.config['TRANSFORMER_COMPRESSION_LEVEL'])
         env += [
             client.V1EnvVar(name='COMPRESSION_ALGORITHM',
                             value=current_app.config['TRANSFORMER_COMPRESSION_ALGORITHM']),

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -221,12 +221,6 @@ class TransformerManager:
                     "memory": current_app.config['TRANSFORMER_MEMORY_LIMIT']}
         )
 
-        env += [
-            client.V1EnvVar(name='COMPRESSION_ALGORITHM',
-                            value=current_app.config['TRANSFORMER_COMPRESSION_ALGORITHM']),
-            client.V1EnvVar(name='COMPRESSION_LEVEL',
-                            value=current_app.config['TRANSFORMER_COMPRESSION_LEVEL'])
-        ]
 
         # Configure Pod template container
         science_container = client.V1Container(

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -221,8 +221,6 @@ class TransformerManager:
                     "memory": current_app.config['TRANSFORMER_MEMORY_LIMIT']}
         )
 
-        current_app.logger.info(f"COMPRESSION_ALGORITHM (current_app.config): {current_app.config['TRANSFORMER_COMPRESSION_ALGORITHM']}")
-        current_app.logger.info(f"COMPRESSION_LEVEL (current_app.config): {current_app.config['TRANSFORMER_COMPRESSION_LEVEL']}")
         env += [
             client.V1EnvVar(name='COMPRESSION_ALGORITHM',
                             value=current_app.config['TRANSFORMER_COMPRESSION_ALGORITHM']),

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -221,8 +221,8 @@ class TransformerManager:
                     "memory": current_app.config['TRANSFORMER_MEMORY_LIMIT']}
         )
 
-        print("COMPRESSION_ALGORITHM (current_app.config):", current_app.config['TRANSFORMER_COMPRESSION_ALGORITHM'])
-        print("COMPRESSION_LEVEL (current_app.config):", current_app.config['TRANSFORMER_COMPRESSION_LEVEL'])
+        current_app.logger.info(f"COMPRESSION_ALGORITHM (current_app.config): {current_app.config['TRANSFORMER_COMPRESSION_ALGORITHM']}")
+        current_app.logger.info(f"COMPRESSION_LEVEL (current_app.config): {current_app.config['TRANSFORMER_COMPRESSION_LEVEL']}")
         env += [
             client.V1EnvVar(name='COMPRESSION_ALGORITHM',
                             value=current_app.config['TRANSFORMER_COMPRESSION_ALGORITHM']),


### PR DESCRIPTION
Adds parameters
- `codeGen.<codeGenName>.compressionAlgorithm`
- `codeGen.<codeGenName>.compressionLevel`

which specify compression algorithm ('ZSTD', 'ZLIB', 'LZMA', 'ZSTD') and level (1-9) for uproot-raw code generator.

If values are incorrect or unspecified, default ZSTD(5) will be used. For codeGens other than uproot-raw, the parameters are ignored.

