### PR TITLE
Enable rdataframe codegen

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -57,6 +57,14 @@ codeGen:
     defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
     defaultScienceContainerTag: 5.6.1
 
+  rdataframe:
+    enabled: true
+    image: sslhep/servicex_code_gen_python
+    pullPolicy: Always
+    tag: develop
+    defaultScienceContainerImage: sslhep/servicex_science_image_root
+    defaultScienceContainerTag: 6.32.04
+
   atlasr21:
     enabled: true
     image: sslhep/servicex_code_gen_atlas_xaod


### PR DESCRIPTION
Switches on a "rdataframe" codegen, which uses the Python codegen but runs in a C++ ROOT-based science image