### PR TITLE
Add R25 science image and codegen

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -83,6 +83,7 @@ codeGen:
   atlasr25:
     enabled: true
     image: sslhep/servicex_code_gen_atlas_xaod
+    pullPolicy: Always
     tag: develop
     defaultScienceContainerImage: sslhep/servicex_func_adl_xaod_transformer
     defaultScienceContainerTag: 25.2.41

--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -80,6 +80,13 @@ codeGen:
     defaultScienceContainerImage: sslhep/servicex_func_adl_xaod_transformer
     defaultScienceContainerTag: 22.2.107
 
+  atlasr25:
+    enabled: true
+    image: sslhep/servicex_code_gen_atlas_xaod
+    tag: develop
+    defaultScienceContainerImage: sslhep/servicex_func_adl_xaod_transformer
+    defaultScienceContainerTag: 25.2.41
+
   cmssw-5-3-32:
     enabled: true
     image: sslhep/servicex_code_gen_cms_aod


### PR DESCRIPTION
Introduce support for the R25 science image and update code generation configurations accordingly by updating `values.yaml`