### PR TITLE
add archived bitnami shell image to default values.yaml

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -140,6 +140,9 @@ logging:
     monitor: "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards?auth_provider_hint=anonymous1#/view/c2cc1f30-4a5b-11ed-afcf-d91dad577662?embed=true&_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-24h%2Fh%2Cto%3Anow))&show-time-filter=true"
     logs: "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards?auth_provider_hint=anonymous1#/view/bb682100-5558-11ed-afcf-d91dad577662?embed=true&_g=(filters%3A!(('%24state'%3A(store%3AglobalState)%2Cmeta%3A(alias%3A!n%2Cdisabled%3A!f%2Cindex%3A'923eaa00-45b9-11ed-afcf-d91dad577662'%2Ckey%3Ainstance%2Cnegate%3A!f%2Cparams%3A(query%3Aservicex)%2Ctype%3Aphrase)%2Cquery%3A(term%3A(instance%3A{{ .Release.Name }}))))%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-24h%2Fh%2Cto%3Anow))&show-query-input=true&show-time-filter=true&hide-filter-bar=true"
 minio:
+  volumePermissions:
+    image:
+      repository: bitnami/bitnami-shell-archived
   apiIngress:
     enabled: false
   auth:
@@ -161,6 +164,9 @@ objectStore:
 postgres:
   enabled: false
 postgresql:
+  volumePermissions:
+    image:
+      repository: bitnami/bitnami-shell-archived
   global:
     postgresql:
       auth:
@@ -180,6 +186,8 @@ rabbitmq:
     enabled: false
   volumePermissions:
     enabled: true
+    image:
+      repository: bitnami/bitnami-shell-archived
   extraConfiguration: |-
     consumer_timeout = 3600000
 


### PR DESCRIPTION
We are currently using older versions of several bitnami images (rabbitmq, postgresql, minio) that use a deprecated image (`bitnami/bitnami-shell`) to manage volume permissions. The deprecated image can be accessed using `bitnami/bitnami-shell-archived` and a replacement image is provided by `bitnami/os-shell` (available in newer versions of the chart repositories).

This PR sets the relevant pods to use the archived version of the deprecated bitnami image. A separate issue will be made to create a repository upgrade plan which will remove the need to specify this image explicitly in our app's values.yaml.