### PR TITLE
remove minio.apiIngress.enabled from values.yaml

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -143,8 +143,6 @@ minio:
   volumePermissions:
     image:
       repository: bitnami/bitnami-shell-archived
-  apiIngress:
-    enabled: false
   auth:
     rootPassword: leftfoot1
     rootUser: miniouser


### PR DESCRIPTION
Removes the `minio.apiIngress.enabled` value from the default `valules.yaml`. (It is being set to false, which is the default value in the minio chart.) This change was erroneously made to resolve a helm linting error as part of https://github.com/ssl-hep/ServiceX/pull/1101.