### PR TITLE
Extend sample title field and add corresponding capability

### DIFF
--- a/servicex_app/migrations/versions/1.7.1.py
+++ b/servicex_app/migrations/versions/1.7.1.py
@@ -1,0 +1,35 @@
+"""
+Revision ID: v1_7_1
+Revises: v1_7_0a
+Create Date: 2025-07-04
+
+Increase title field length from 512 to 10240 characters
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "v1_7_1"
+down_revision = "v1_7_0a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "requests",
+        "title",
+        existing_type=sa.String(length=512),
+        type_=sa.String(length=10240),
+        nullable=True,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "requests",
+        "title",
+        existing_type=sa.String(length=10240),
+        type_=sa.String(length=512),
+        nullable=True,
+    )

--- a/servicex_app/servicex_app/resources/info.py
+++ b/servicex_app/servicex_app/resources/info.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, IRIS-HEP
+# Copyright (c) 2019-2025, IRIS-HEP
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -33,8 +33,9 @@ class Info(ServiceXResource):
     def get(self):
         return {
             "app-version": self._get_app_version(),
-            "code-gen-image": current_app.config['CODE_GEN_IMAGES'],
+            "code-gen-image": current_app.config["CODE_GEN_IMAGES"],
             "capabilities": [
-                "poll_local_transformation_results"
-            ]
+                "poll_local_transformation_results",
+                "long_sample_titles_10240",
+            ],
         }

--- a/servicex_app/servicex_app_test/resources/test_servicex_info.py
+++ b/servicex_app/servicex_app_test/resources/test_servicex_info.py
@@ -30,18 +30,19 @@ from servicex_app_test.resource_test_base import ResourceTestBase
 
 class TestServicexInfo(ResourceTestBase):
     def test_get_info(self, client, mock_app_version):
-        response = client.get('/servicex')
+        response = client.get("/servicex")
         assert response.status_code == 200
         print(response.json)
         assert response.json == {
-                                 'app-version': '3.14.15',
-                                 'code-gen-image': {
-                                    'atlasxaod': 'sslhep/servicex_code_gen_func_adl_xaod:develop',
-                                    'cms': 'sslhep/servicex_code_gen_cms_aod:develop',
-                                    'python': 'sslhep/servicex_code_gen_python:develop',
-                                    'uproot': 'sslhep/servicex_code_gen_func_adl_uproot:develop'
-                                    },
-                                 'capabilities': [
-                                     'poll_local_transformation_results'
-                                 ]
-                                }  # noqa: E501
+            "app-version": "3.14.15",
+            "code-gen-image": {
+                "atlasxaod": "sslhep/servicex_code_gen_func_adl_xaod:develop",
+                "cms": "sslhep/servicex_code_gen_cms_aod:develop",
+                "python": "sslhep/servicex_code_gen_python:develop",
+                "uproot": "sslhep/servicex_code_gen_func_adl_uproot:develop",
+            },
+            "capabilities": [
+                "poll_local_transformation_results",
+                "long_sample_titles_10240",
+            ],
+        }  # noqa: E501


### PR DESCRIPTION
In discussion with Gordon, it seems that we want "Rucio dataset name + metadata" in the sample title, so 512 characters is in principle not enough. In practice in my opinion the only reason to put a length in this field is to prevent malicious injection of bad data of indefinite length. I propose to raise the limit to 10240 (far more than anything reasonable but not so long as to allow compromising junk). In addition I have added a capability report so the client knows how long of a limit is supported.