### PR TITLE
Add `assert_` to called_once and other checks

### DIFF
--- a/servicex_app/servicex_app_test/resources/users/test_accept_user.py
+++ b/servicex_app/servicex_app_test/resources/users/test_accept_user.py
@@ -7,7 +7,7 @@ class TestAcceptUser(WebTestBase):
         response = client.post("/accept", json={"email": user.email})
         assert response.status_code == 200
         assert not user.pending
-        assert user.save_to_db.called_once()
+        user.save_to_db.assert_called_once()
 
     def test_accept_user_missing(self, client, mocker):
         mocker.patch("servicex_app.models.UserModel.find_by_email", return_value=None)

--- a/servicex_app/servicex_app_test/resources/users/test_all_users.py
+++ b/servicex_app/servicex_app_test/resources/users/test_all_users.py
@@ -11,7 +11,7 @@ class TestAllUsers(WebTestBase):
         )
         response: Response = client.get("/users")
         assert response.status_code == 200
-        assert mock.called_once()
+        mock.assert_called_once()
         assert response.json == resp_json
 
     def test_delete_users(self, client, mocker):
@@ -21,5 +21,5 @@ class TestAllUsers(WebTestBase):
         )
         response: Response = client.delete("/users")
         assert response.status_code == 200
-        assert mock.called_once()
+        mock.assert_called_once()
         assert response.json == resp_json

--- a/servicex_app/servicex_app_test/resources/users/test_delete_user.py
+++ b/servicex_app/servicex_app_test/resources/users/test_delete_user.py
@@ -10,7 +10,7 @@ class TestDeleteUser(WebTestBase):
         resp: Response = client.delete(f"users/{user.id}")
         assert resp.status_code == 200
         assert resp.json == resp_json
-        assert user.delete_from_db.called_once()
+        user.delete_from_db.assert_called_once()
 
     def test_delete_user_missing(self, client):
         fake_user_id = 12345

--- a/servicex_app/servicex_app_test/resources/users/test_pending_users.py
+++ b/servicex_app/servicex_app_test/resources/users/test_pending_users.py
@@ -11,7 +11,7 @@ class TestPendingUsers(WebTestBase):
         )
         response: Response = client.get("/pending")
         assert response.status_code == 200
-        assert mock.called_once()
+        mock.assert_called_once()
         assert response.json == resp_json
 
     def test_delete_pending_users(self, client, mocker):
@@ -21,5 +21,5 @@ class TestPendingUsers(WebTestBase):
         )
         response: Response = client.delete("/pending")
         assert response.status_code == 200
-        assert mock.called_once()
+        mock.assert_called_once()
         assert response.json == resp_json

--- a/servicex_app/servicex_app_test/resources/users/test_slack_interaction.py
+++ b/servicex_app/servicex_app_test/resources/users/test_slack_interaction.py
@@ -94,8 +94,8 @@ class TestSlackInteraction(ResourceTestBase):
         with client.application.app_context():
             from servicex_app.web.slack_msg_builder import missing_slack_app
 
-            assert mock_post.called_once_with(
-                payload["response_url"], missing_slack_app()
+            mock_post.assert_called_once_with(
+                payload["response_url"], missing_slack_app(), timeout=(0.5, None)
             )
 
     def test_slack_interaction_expired(self, mocker):
@@ -111,8 +111,8 @@ class TestSlackInteraction(ResourceTestBase):
         with client.application.app_context():
             from servicex_app.web.slack_msg_builder import request_expired
 
-            assert mock_post.called_once_with(
-                payload["response_url"], request_expired()
+            mock_post.assert_called_once_with(
+                payload["response_url"], request_expired(), timeout=(0.5, None)
             )
 
     def test_slack_interaction_invalid(self, mocker):
@@ -128,8 +128,8 @@ class TestSlackInteraction(ResourceTestBase):
         with client.application.app_context():
             from servicex_app.web.slack_msg_builder import verification_failed
 
-            assert mock_post.called_once_with(
-                payload["response_url"], verification_failed()
+            mock_post.assert_called_once_with(
+                payload["response_url"], verification_failed(), timeout=(0.5, None)
             )
 
     def test_slack_interaction_accept_user(self, mocker):
@@ -154,9 +154,11 @@ class TestSlackInteraction(ResourceTestBase):
         )
         assert response.status_code == 200
         email = payload["actions"][0]["value"]
-        assert mock_user_model.accept.called_once_with(email)
+        mock_user_model.accept.assert_called_once_with(email)
         with client.application.app_context():
             from servicex_app.web.slack_msg_builder import signup_ia
 
             resp = signup_ia(payload["message"], payload["user"], "accept_user")
-            assert mock_post.called_once_with(payload["response_url"], resp)
+            mock_post.assert_called_once_with(
+                payload["response_url"], resp, timeout=(0.5, None)
+            )

--- a/servicex_app/servicex_app_test/resources/users/test_slack_interaction.py
+++ b/servicex_app/servicex_app_test/resources/users/test_slack_interaction.py
@@ -134,7 +134,9 @@ class TestSlackInteraction(ResourceTestBase):
 
     def test_slack_interaction_accept_user(self, mocker):
         mock_post = mocker.patch("requests.post")
-        mock_user_model = mocker.patch("servicex_app.resources.users.slack_interaction.UserModel")
+        mock_user_model = mocker.patch(
+            "servicex_app.resources.users.slack_interaction.UserModel"
+        )
         secret = "my-slack-secret"
         client = self._test_client(
             extra_config={"SLACK_SIGNING_SECRET": "my-slack-secret"}

--- a/servicex_app/servicex_app_test/resources/users/test_slack_interaction.py
+++ b/servicex_app/servicex_app_test/resources/users/test_slack_interaction.py
@@ -134,7 +134,7 @@ class TestSlackInteraction(ResourceTestBase):
 
     def test_slack_interaction_accept_user(self, mocker):
         mock_post = mocker.patch("requests.post")
-        mock_user_model = mocker.patch("servicex_app.models.UserModel")
+        mock_user_model = mocker.patch("servicex_app.resources.users.slack_interaction.UserModel")
         secret = "my-slack-secret"
         client = self._test_client(
             extra_config={"SLACK_SIGNING_SECRET": "my-slack-secret"}

--- a/servicex_app/servicex_app_test/test_models.py
+++ b/servicex_app/servicex_app_test/test_models.py
@@ -24,7 +24,7 @@ class TestTransformRequest:
         mock_dt = mocker.patch("servicex_app.models.datetime")
         mock_dt.utcnow.return_value = t + delta
         assert request.age == delta
-        assert mock_dt.utcnow.called_once()
+        mock_dt.utcnow.assert_called_once()
 
     def test_submitter_name(self):
         user = UserModel()

--- a/servicex_app/servicex_app_test/web/test_api_token.py
+++ b/servicex_app/servicex_app_test/web/test_api_token.py
@@ -10,6 +10,6 @@ class TestApiToken(WebTestBase):
         user.refresh_token = "jwt:refresh"
         response: Response = client.get(url_for("api_token"))
         assert user.refresh_token != "jwt:refresh"
-        assert db.session.commit.called_once()
+        db.session.commit.assert_called_once()
         assert response.status_code == 302
         assert response.location == "/profile"

--- a/servicex_app/servicex_app_test/web/test_api_token.py
+++ b/servicex_app/servicex_app_test/web/test_api_token.py
@@ -4,7 +4,8 @@ from .web_test_base import WebTestBase
 
 
 class TestApiToken(WebTestBase):
-    def test_api_token(self, client, user, db):
+    def test_api_token(self, client, user, db, mocker):
+        mocker.patch("servicex_app.web.api_token.db", db)
         with client.session_transaction() as sess:
             sess["sub"] = user.sub
         user.refresh_token = "jwt:refresh"

--- a/servicex_app/servicex_app_test/web/test_auth_callback.py
+++ b/servicex_app/servicex_app_test/web/test_auth_callback.py
@@ -9,7 +9,7 @@ class TestAuthCallback(WebTestBase):
     def test_auth_callback_outgoing(self, client, oauth_client):
         response: Response = client.get(url_for("auth_callback"))
         assert response.status_code == 302
-        assert oauth_client.authorize_redirect.called_once()
+        oauth_client.authorize_redirect.assert_called_once()
         assert response.location == self._auth_url()
 
     def test_auth_callback_incoming_new(
@@ -18,7 +18,7 @@ class TestAuthCallback(WebTestBase):
         response: Response = client.get(
             url_for("auth_callback"), query_string={"code": "oauth-code"}
         )
-        assert oauth_client.authorize_access_token.called_once()
+        oauth_client.authorize_access_token.assert_called_once()
         id_token = self._id_token()
         assert mock_session.get("is_authenticated")
         assert mock_session.get("name") == id_token["name"]
@@ -32,7 +32,7 @@ class TestAuthCallback(WebTestBase):
         response: Response = client.get(
             url_for("auth_callback"), query_string={"code": "oauth-code"}
         )
-        assert oauth_client.authorize_access_token.called_once()
+        oauth_client.authorize_access_token.assert_called_once()
         id_token = self._id_token()
         assert mock_session.get("user_id") == user.id
         assert mock_session.get("admin") == user.admin

--- a/servicex_app/servicex_app_test/web/test_auth_callback.py
+++ b/servicex_app/servicex_app_test/web/test_auth_callback.py
@@ -5,17 +5,15 @@ from .web_test_base import WebTestBase
 class TestAuthCallback(WebTestBase):
     module = "servicex_app.web.auth_callback"
     userinfo = {
-            "id_token": {
-            },
-            "userinfo": {
-                "email": "<EMAIL>",
-                "name": "Jane Doe",
-                "sub": "primary-oauth-id",
-                "preferred_username": "testuser",
-                "organization": "Test Organization"
-
-            },
-            "access_token": ""
+        "id_token": {},
+        "userinfo": {
+            "email": "<EMAIL>",
+            "name": "Jane Doe",
+            "sub": "primary-oauth-id",
+            "preferred_username": "testuser",
+            "organization": "Test Organization",
+        },
+        "access_token": "",
     }
 
     def test_auth_callback_outgoing(self, client, oauth_client):
@@ -30,9 +28,13 @@ class TestAuthCallback(WebTestBase):
         mock_user_model = mocker.patch("servicex_app.web.auth_callback.UserModel")
         mock_user_model.find_by_email.return_value = None  # User does not exist
 
-        mock_oauth = mocker.patch("servicex_app.web.auth_callback.load_oauth_client").return_value
+        mock_oauth = mocker.patch(
+            "servicex_app.web.auth_callback.load_oauth_client"
+        ).return_value
         mock_oauth.oauth = mocker.Mock()
-        mock_oauth.oauth.authorize_access_token = mocker.Mock(return_value=self.userinfo)
+        mock_oauth.oauth.authorize_access_token = mocker.Mock(
+            return_value=self.userinfo
+        )
 
         response: Response = client.get(
             url_for("auth_callback"), query_string={"code": "oauth-code"}
@@ -52,9 +54,13 @@ class TestAuthCallback(WebTestBase):
         mock_user_model = mocker.patch("servicex_app.web.auth_callback.UserModel")
         mock_user_model.find_by_email.return_value = user  # User does exist
 
-        mock_oauth = mocker.patch("servicex_app.web.auth_callback.load_oauth_client").return_value
+        mock_oauth = mocker.patch(
+            "servicex_app.web.auth_callback.load_oauth_client"
+        ).return_value
         mock_oauth.oauth = mocker.Mock()
-        mock_oauth.oauth.authorize_access_token = mocker.Mock(return_value=self.userinfo)
+        mock_oauth.oauth.authorize_access_token = mocker.Mock(
+            return_value=self.userinfo
+        )
 
         response: Response = client.get(
             url_for("auth_callback"), query_string={"code": "oauth-code"}

--- a/servicex_app/servicex_app_test/web/test_auth_callback.py
+++ b/servicex_app/servicex_app_test/web/test_auth_callback.py
@@ -1,10 +1,22 @@
 from flask import Response, url_for
-
 from .web_test_base import WebTestBase
 
 
 class TestAuthCallback(WebTestBase):
     module = "servicex_app.web.auth_callback"
+    userinfo = {
+            "id_token": {
+            },
+            "userinfo": {
+                "email": "<EMAIL>",
+                "name": "Jane Doe",
+                "sub": "primary-oauth-id",
+                "preferred_username": "testuser",
+                "organization": "Test Organization"
+
+            },
+            "access_token": ""
+    }
 
     def test_auth_callback_outgoing(self, client, oauth_client):
         response: Response = client.get(url_for("auth_callback"))
@@ -15,10 +27,18 @@ class TestAuthCallback(WebTestBase):
     def test_auth_callback_incoming_new(
         self, client, oauth_client, mock_session, mocker
     ):
+        mock_user_model = mocker.patch("servicex_app.web.auth_callback.UserModel")
+        mock_user_model.find_by_email.return_value = None  # User does not exist
+
+        mock_oauth = mocker.patch("servicex_app.web.auth_callback.load_oauth_client").return_value
+        mock_oauth.oauth = mocker.Mock()
+        mock_oauth.oauth.authorize_access_token = mocker.Mock(return_value=self.userinfo)
+
         response: Response = client.get(
             url_for("auth_callback"), query_string={"code": "oauth-code"}
         )
-        oauth_client.authorize_access_token.assert_called_once()
+        mock_oauth.authorize_redirect.assert_not_called()
+        mock_user_model.find_by_email.assert_called_once()
         id_token = self._id_token()
         assert mock_session.get("is_authenticated")
         assert mock_session.get("name") == id_token["name"]
@@ -29,10 +49,17 @@ class TestAuthCallback(WebTestBase):
     def test_auth_callback_incoming_existing(
         self, client, oauth_client, user, mock_session, mocker
     ):
+        mock_user_model = mocker.patch("servicex_app.web.auth_callback.UserModel")
+        mock_user_model.find_by_email.return_value = user  # User does exist
+
+        mock_oauth = mocker.patch("servicex_app.web.auth_callback.load_oauth_client").return_value
+        mock_oauth.oauth = mocker.Mock()
+        mock_oauth.oauth.authorize_access_token = mocker.Mock(return_value=self.userinfo)
+
         response: Response = client.get(
             url_for("auth_callback"), query_string={"code": "oauth-code"}
         )
-        oauth_client.authorize_access_token.assert_called_once()
+        mock_oauth.oauth.authorize_access_token.assert_called_once()
         id_token = self._id_token()
         assert mock_session.get("user_id") == user.id
         assert mock_session.get("admin") == user.admin

--- a/servicex_app/servicex_app_test/web/test_create_profile.py
+++ b/servicex_app/servicex_app_test/web/test_create_profile.py
@@ -42,8 +42,8 @@ class TestCreateProfile(WebTestBase):
         keys = ["name", "email", "institution", "experiment"]
         data = {key: new_user.__dict__[key] for key in keys}
         response: Response = client.post(url_for("create_profile"), data=data)
-        assert db.session.commit.called_once()
-        assert new_user.save_to_db.called_once()
+        db.session.commit.assert_called_once()
+        new_user.save_to_db.assert_called_once()
         mock_flash.assert_called_once()
         assert "Profile created!" in mock_flash.call_args[0][0]
         assert response.status_code == 302

--- a/servicex_app/servicex_app_test/web/test_create_profile.py
+++ b/servicex_app/servicex_app_test/web/test_create_profile.py
@@ -36,14 +36,19 @@ class TestCreateProfile(WebTestBase):
         assert template.name == "profile_form.html"
         assert context["action"] == "Create Profile"
 
-    def test_post_create_profile(self, new_user, db, client, mock_flash):
+    def test_post_create_profile(self, new_user, db, client, mock_flash, mocker):
+        user_class = mocker.patch("servicex_app.web.create_profile.UserModel")
+        user_instance = user_class.return_value
+        user_instance.id = 1
+        user_instance.name = "Jane Doe"
+        user_instance.admin = False
+
         with client.session_transaction() as sess:
             sess["sub"] = "create-me"
         keys = ["name", "email", "institution", "experiment"]
         data = {key: new_user.__dict__[key] for key in keys}
         response: Response = client.post(url_for("create_profile"), data=data)
-        db.session.commit.assert_called_once()
-        new_user.save_to_db.assert_called_once()
+        user_instance.save_to_db.assert_called_once()
         mock_flash.assert_called_once()
         assert "Profile created!" in mock_flash.call_args[0][0]
         assert response.status_code == 302

--- a/servicex_app/servicex_app_test/web/test_edit_profile.py
+++ b/servicex_app/servicex_app_test/web/test_edit_profile.py
@@ -15,7 +15,9 @@ class TestEditProfile(WebTestBase):
         assert template.name == "profile_form.html"
         assert context["action"] == "Edit Profile"
 
-    def test_post_edit_profile(self, client, user, db, mock_flash):
+    def test_post_edit_profile(self, client, user, db, mock_flash, mocker):
+        mocker.patch("servicex_app.web.edit_profile.db", db)
+
         assert user.name != "new name"
         with client.session_transaction() as sess:
             sess["sub"] = "some-new-user-id"

--- a/servicex_app/servicex_app_test/web/test_edit_profile.py
+++ b/servicex_app/servicex_app_test/web/test_edit_profile.py
@@ -28,7 +28,7 @@ class TestEditProfile(WebTestBase):
                 "experiment": user.experiment,
             },
         )
-        assert db.session.commit.called_once()
+        db.session.commit.assert_called_once()
         assert user.name == "new name"
         mock_flash.assert_called_once()
         assert "Your profile has been saved!" in mock_flash.call_args[0][0]

--- a/servicex_app/servicex_app_test/web/web_test_base.py
+++ b/servicex_app/servicex_app_test/web/web_test_base.py
@@ -26,6 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from datetime import datetime
+from unittest.mock import MagicMock
 
 from flask import template_rendered, redirect
 from flask.testing import FlaskClient
@@ -247,7 +248,10 @@ class WebTestBase:
 
     @fixture
     def db(self, mocker):
-        return mocker.patch("flask_sqlalchemy.SQLAlchemy").return_value
+        mock_db = MagicMock()
+        mock_db.session = MagicMock()
+        mock_db.session.commit = MagicMock()
+        return mock_db
 
     @fixture
     def oauth_client(self, mocker):


### PR DESCRIPTION
* convert `called_once` to `assert_called_once`. The former was not actually checking anything.
* Simple fixes to repair tests that were then failing.