### PR TITLE
Install OSG certificates in xrootd did finder container

### DIFF
--- a/did_finder_xrootd/Dockerfile
+++ b/did_finder_xrootd/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM debian:trixie
 
 LABEL maintainer="Peter Onyisi <ponyisi@utexas.edu>"
 
@@ -11,9 +11,8 @@ RUN useradd -g 0 -ms /bin/bash celery
 ENV  POETRY_VERSION=2.1.1
 
 RUN apt-get update && \
-    apt-get install cmake --no-install-recommends --assume-yes
+    apt-get install cmake osg-ca-certs python3-poetry python3-dev build-essential uuid-dev libssl-dev --no-install-recommends --assume-yes
 
-RUN pip install poetry==$POETRY_VERSION
 RUN mkdir -p /opt/servicex/pypoetry
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock

--- a/did_finder_xrootd/Dockerfile
+++ b/did_finder_xrootd/Dockerfile
@@ -38,6 +38,8 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/opt/servicex/src
 
 ENV BROKER_URL="amqp://guest:guest@localhost:5672//"
+ENV X509_USER_PROXY=/etc/grid-security-ro/x509up
+ENV X509_CERT_DIR=/etc/grid-security/certificates
 
 
 ENTRYPOINT [ "scripts/start_celery_worker.sh"]

--- a/did_finder_xrootd/poetry.lock
+++ b/did_finder_xrootd/poetry.lock
@@ -17,14 +17,14 @@ vine = ">=5.0.0,<6.0.0"
 
 [[package]]
 name = "billiard"
-version = "4.2.0"
+version = "4.2.1"
 description = "Python multiprocessing fork with improvements and bugfixes"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "billiard-4.2.0-py3-none-any.whl", hash = "sha256:07aa978b308f334ff8282bd4a746e681b3513db5c9a514cbdd810cbbdc19714d"},
-    {file = "billiard-4.2.0.tar.gz", hash = "sha256:9a3c3184cb275aa17a732f93f65b20c525d3d9f253722d26a82194803ade5a2c"},
+    {file = "billiard-4.2.1-py3-none-any.whl", hash = "sha256:40b59a4ac8806ba2c2369ea98d876bc6108b051c227baffd928c644d15d8f3cb"},
+    {file = "billiard-4.2.1.tar.gz", hash = "sha256:12b641b0c539073fc8d3f5b8b7be998956665c4233c7c1fcd66a7e677c4fb36f"},
 ]
 
 [[package]]

--- a/did_finder_xrootd/poetry.lock
+++ b/did_finder_xrootd/poetry.lock
@@ -702,16 +702,16 @@ files = [
 
 [[package]]
 name = "xrootd"
-version = "5.7.0"
+version = "5.8.4"
 description = "eXtended ROOT daemon"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "xrootd-5.7.0.tar.gz", hash = "sha256:453bda26b2492580f90d374974905a5446bfffa749952337ca21cd25c19ef24c"},
+    {file = "xrootd-5.8.4.tar.gz", hash = "sha256:2d1d597c2ce5200a20eb85f12012759fbbfc6912815e07956015f20904b81eb6"},
 ]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "5c58c2b226b02293fbfffe8f59ee48af4ee0e1390a171ae1f1995cf492ae7fe9"
+content-hash = "a14b1546c04cd2e8da3987aa23e94d0d837b95bffcdf5c4afc6be2905370bd81"

--- a/did_finder_xrootd/pyproject.toml
+++ b/did_finder_xrootd/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "src/servicex_did_finder_xrootd"}]
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 servicex-did-finder-lib = "^3.0.0"
-xrootd = ">=5.6.9"
+xrootd = ">=5.8.3"
 
 [tool.poetry.group.test]
 optional = true

--- a/helm/servicex/templates/did-finder-xrootd/deployment.yaml
+++ b/helm/servicex/templates/did-finder-xrootd/deployment.yaml
@@ -39,4 +39,17 @@ spec:
           - name: BROKER_URL
             value: amqp://user:{{ .Values.rabbitmq.auth.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F
         {{- end }}
+        {{ if not .Values.noCerts}}
+        volumeMounts:
+          - name: x509-secret
+            mountPath: /etc/grid-security-ro
+            readOnly: true
+        {{- end }}
+      {{ if not .Values.noCerts}}
+      volumes:
+        - name: x509-secret
+          secret:
+            defaultMode: 292
+            secretName: x509-proxy
+      {{- end }}
 {{ end }}


### PR DESCRIPTION
Somewhat drastic: use new osg certificates Debian package, which requires an update to Debian Trixie (which the standard Docker Python images do not use yet). This should be fixed in the next few months. In the meanwhile, install python into a Trixie image. The advantage here over the method in the science images is that we don't need to keep updating tarball versions. The alternative would be to switch to a redhat-based image.