### PR TITLE
Use main tag for checks image

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -4,7 +4,7 @@ app:
   adminEmail: admin@example.com
   auth: false
   authExpires: 21600
-  checksImage: ncsa/checks:latest
+  checksImage: ncsa/checks:main
   defaultDIDFinderScheme: null
   oauthMetadataURL: null
   oauthClientID: null


### PR DESCRIPTION
The use of the `latest` tag is fraught and [prone to misunderstanding](https://mifergo.medium.com/why-you-should-stop-using-the-latest-tag-in-docker-167c641e6da2). 

Switch the default tag to `main` which is always going to be based on the main branch of the checks repo.