### PR TITLE
Migrate bitnami helm charts to legacy images

### DIFF
--- a/helm/servicex/requirements.lock
+++ b/helm/servicex/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami/
-  version: 11.4.0
+  version: 11.16.2
 - name: minio
   repository: https://charts.bitnami.com/bitnami/
   version: 11.10.26
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami/
-  version: 11.6.26
-digest: sha256:1538e3fd27ac2dcfe5df320de851a8c501f8b5cc4056b13b208a92d5e70340c5
-generated: "2023-01-25T16:29:05.999958-06:00"
+  version: 11.9.13
+digest: sha256:89088cda84e9c968cd177a4ec4a986969db95dff2293a3efc51dcf24bbb2b7f8
+generated: "2025-08-22T10:22:33.266158-05:00"

--- a/helm/servicex/requirements.yaml
+++ b/helm/servicex/requirements.yaml
@@ -1,12 +1,12 @@
 dependencies:
   - name: rabbitmq
-    version: 11.4.*
+    version: 11.16.2
     repository: https://charts.bitnami.com/bitnami/
   - name: minio
-    version: 11.10.*
+    version: 11.10.26
     repository: https://charts.bitnami.com/bitnami/
     condition: objectStore.internal, objectStore.enabled
   - name: postgresql
-    version: 11.6.*
+    version: 11.9.13
     repository: https://charts.bitnami.com/bitnami/
     condition: postgres.enabled

--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -148,7 +148,8 @@ minio:
     repository: bitnamilegacy/minio
   volumePermissions:
     image:
-      repository: bitnamilegacy/bitnami-shell-archived
+      repository: bitnamilegacy/os-shell
+      tag: 12-debian-12-r51
   auth:
     rootPassword: leftfoot1
     rootUser: miniouser
@@ -172,7 +173,9 @@ postgresql:
     repository: bitnamilegacy/postgresql
   volumePermissions:
     image:
-      repository: bitnamilegacy/bitnami-shell-archived
+      repository: bitnamilegacy/os-shell
+      tag: 12-debian-12-r51
+
   global:
     postgresql:
       auth:
@@ -195,7 +198,9 @@ rabbitmq:
   volumePermissions:
     enabled: true
     image:
-      repository: bitnamilegacy/bitnami-shell-archived
+      repository: bitnamilegacy/os-shell
+      tag: 12-debian-12-r51
+
   extraConfiguration: |-
     consumer_timeout = 3600000
 

--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -144,9 +144,11 @@ logging:
     monitor: "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards?auth_provider_hint=anonymous1#/view/c2cc1f30-4a5b-11ed-afcf-d91dad577662?embed=true&_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-24h%2Fh%2Cto%3Anow))&show-time-filter=true"
     logs: "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards?auth_provider_hint=anonymous1#/view/bb682100-5558-11ed-afcf-d91dad577662?embed=true&_g=(filters%3A!(('%24state'%3A(store%3AglobalState)%2Cmeta%3A(alias%3A!n%2Cdisabled%3A!f%2Cindex%3A'923eaa00-45b9-11ed-afcf-d91dad577662'%2Ckey%3Ainstance%2Cnegate%3A!f%2Cparams%3A(query%3Aservicex)%2Ctype%3Aphrase)%2Cquery%3A(term%3A(instance%3A{{ .Release.Name }}))))%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-24h%2Fh%2Cto%3Anow))&show-query-input=true&show-time-filter=true&hide-filter-bar=true"
 minio:
+  image:
+    repository: bitnamilegacy/minio
   volumePermissions:
     image:
-      repository: bitnami/bitnami-shell-archived
+      repository: bitnamilegacy/bitnami-shell-archived
   auth:
     rootPassword: leftfoot1
     rootUser: miniouser
@@ -166,9 +168,11 @@ objectStore:
 postgres:
   enabled: false
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
   volumePermissions:
     image:
-      repository: bitnami/bitnami-shell-archived
+      repository: bitnamilegacy/bitnami-shell-archived
   global:
     postgresql:
       auth:
@@ -182,6 +186,8 @@ postgresql:
     persistence:
       enabled: false
 rabbitmq:
+  image:
+    repository: bitnamilegacy/rabbitmq
   auth:
     password: leftfoot1
   persistence:
@@ -189,7 +195,7 @@ rabbitmq:
   volumePermissions:
     enabled: true
     image:
-      repository: bitnami/bitnami-shell-archived
+      repository: bitnamilegacy/bitnami-shell-archived
   extraConfiguration: |-
     consumer_timeout = 3600000
 


### PR DESCRIPTION
On August 28, 2025, Bitnami announced they are archiving their free images to a new organization, bitnamilegacy. Our charts will be able to continue working by pulling their images from the archived org, bitnamilegacy.
See: https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon

It seemed wise to pin the charts to the last known working minor release in case their are any 
future shenanigans