### PR TITLE
set RABBIT_MQ_URL value in helm

### DIFF
--- a/helm/servicex/templates/app/deployment.yaml
+++ b/helm/servicex/templates/app/deployment.yaml
@@ -53,6 +53,8 @@ spec:
           value: "{{ .Values.app.logLevel | upper }}"
         - name: RABBIT_MQ_URL
           value: 'amqp://user:{{ .Values.rabbitmq.auth.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F'
+        - name: TRANSFORMER_RABBIT_MQ_URL
+          value: "amqp://user:{{ .Values.rabbitmq.auth.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F?heartbeat=9000"
         {{- if .Values.logging.logstash.enabled }}
         - name: LOGSTASH_HOST
           value: "{{ .Values.logging.logstash.host }}"
@@ -107,8 +109,6 @@ spec:
             secretKeyRef:
               name: {{ .Values.secrets }}
               key: rabbitmq-password
-        - name: TRANSFORMER_RABBIT_MQ_URL
-          value: "amqp://user:$(RMQ_PASS)@{{ .Release.Name }}-rabbitmq:5672/%2F?heartbeat=9000"
         - name: PG_PASS
           valueFrom:
             secretKeyRef:

--- a/helm/servicex/templates/app/deployment.yaml
+++ b/helm/servicex/templates/app/deployment.yaml
@@ -51,6 +51,8 @@ spec:
           value: "{{ .Release.Name }}"
         - name: LOG_LEVEL
           value: "{{ .Values.app.logLevel | upper }}"
+        - name: RABBIT_MQ_URL
+          value: 'amqp://user:{{ .Values.rabbitmq.auth.password }}@{{ .Release.Name }}-rabbitmq:5672/%2F'
         {{- if .Values.logging.logstash.enabled }}
         - name: LOGSTASH_HOST
           value: "{{ .Values.logging.logstash.host }}"
@@ -105,8 +107,6 @@ spec:
             secretKeyRef:
               name: {{ .Values.secrets }}
               key: rabbitmq-password
-        - name: RABBIT_MQ_URL
-          value: "amqp://user:$(RMQ_PASS)@{{ .Release.Name }}-rabbitmq:5672/%2F"
         - name: TRANSFORMER_RABBIT_MQ_URL
           value: "amqp://user:$(RMQ_PASS)@{{ .Release.Name }}-rabbitmq:5672/%2F?heartbeat=9000"
         - name: PG_PASS

--- a/servicex_app/boot.sh
+++ b/servicex_app/boot.sh
@@ -12,7 +12,7 @@ do
     fi
 done
 
-mkdir -p instance
+mkdir instance
 # SQLite doesn't handle migrations, so rely on SQLAlchmy table creation
 if grep "sqlite://" $APP_CONFIG_FILE; then
   echo "SQLLite DB, so skipping db migrations";
@@ -20,9 +20,6 @@ else
   FLASK_APP=servicex_app/app.py flask db upgrade;
 fi
 [ -d "/default_users" ] && python3 servicex/cli/create_default_users.py
-
-# Python snippet to load the config Python file directly and find the RABBIT_MQ_URL value
-RABBIT_MQ_URL=$(python3 -c "ns={}; exec(open('$APP_CONFIG_FILE').read(),{},ns); print(ns.get('RABBIT_MQ_URL','') or '')")
 
 celery --broker="$RABBIT_MQ_URL" -A servicex_app.celery.server_tasks worker \
                   --loglevel=info \

--- a/servicex_app/boot.sh
+++ b/servicex_app/boot.sh
@@ -12,7 +12,7 @@ do
     fi
 done
 
-mkdir instance
+mkdir -p instance
 # SQLite doesn't handle migrations, so rely on SQLAlchmy table creation
 if grep "sqlite://" $APP_CONFIG_FILE; then
   echo "SQLLite DB, so skipping db migrations";
@@ -20,6 +20,9 @@ else
   FLASK_APP=servicex_app/app.py flask db upgrade;
 fi
 [ -d "/default_users" ] && python3 servicex/cli/create_default_users.py
+
+# Python snippet to load the config Python file directly and find the RABBIT_MQ_URL value
+RABBIT_MQ_URL=$(python3 -c "ns={}; exec(open('$APP_CONFIG_FILE').read(),{},ns); print(ns.get('RABBIT_MQ_URL','') or '')")
 
 celery --broker="$RABBIT_MQ_URL" -A servicex_app.celery.server_tasks worker \
                   --loglevel=info \


### PR DESCRIPTION
My transformers were hanging due to issues establishing a connection to RabbitMQ. It came from the recent changes to the boot.sh script where `$RABBIT_MQ_URL` is assumed to exist and contain the RabbitMQ connection string. However, this value is only present when secrets are configured.

The change here sets a RABBIT_MQ_URL value in the servicex app deployment even if secrets aren't available.