### PR TITLE
add graceful exits to token refresh

### DIFF
--- a/servicex_app/servicex_app/__init__.py
+++ b/servicex_app/servicex_app/__init__.py
@@ -196,8 +196,8 @@ def create_app(
     Bootstrap5(app)
     CORS(app)
 
+    app.config["JWT_DECODE_ALGORITHMS"] = ["HS256", "RS256"]
     JWTManager(app)
-
     # setup logging
 
     logstash_host = os.environ.get("LOGSTASH_HOST")

--- a/servicex_app/servicex_app/resources/users/token_refresh.py
+++ b/servicex_app/servicex_app/resources/users/token_refresh.py
@@ -26,15 +26,22 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from flask import current_app
 from flask_jwt_extended import create_access_token, decode_token, get_jwt, jwt_required
 from flask_restful import Resource
 from servicex_app.models import UserModel
 
 
 class TokenRefresh(Resource):
-    @jwt_required(refresh=True)
+    @jwt_required(refresh=True, optional=True)
     def post(self):
+        if not current_app.config.get("ENABLE_AUTH"):
+            return {"message": "Authentication is disabled on this instance"}, 200
+
         claims = get_jwt()
+        if not claims:
+            return {"message": "Missing refresh token"}, 401
+
         user = UserModel.find_by_email(claims["sub"])
         decoded = decode_token(user.refresh_token)
         if not claims["jti"] == decoded["jti"]:

--- a/servicex_app/servicex_app/resources/users/token_refresh.py
+++ b/servicex_app/servicex_app/resources/users/token_refresh.py
@@ -52,4 +52,7 @@ class TokenRefresh(Resource):
             return {"message": "Invalid or outdated refresh token"}, 401
         current_user = user.email
         access_token = create_access_token(identity=current_user)
-        return {"access_token": access_token}, 200
+        return {
+            "access_token": access_token,
+            "auth_disabled": False
+        }, 200

--- a/servicex_app/servicex_app/resources/users/token_refresh.py
+++ b/servicex_app/servicex_app/resources/users/token_refresh.py
@@ -39,7 +39,7 @@ class TokenRefresh(Resource):
             return {
                 "message": "Authentication is disabled on this instance",
                 "access_token": "authentication_disabled",
-                "auth_disabled": True
+                "auth_disabled": True,
             }, 200
 
         claims = get_jwt()

--- a/servicex_app/servicex_app/resources/users/token_refresh.py
+++ b/servicex_app/servicex_app/resources/users/token_refresh.py
@@ -52,7 +52,4 @@ class TokenRefresh(Resource):
             return {"message": "Invalid or outdated refresh token"}, 401
         current_user = user.email
         access_token = create_access_token(identity=current_user)
-        return {
-            "access_token": access_token,
-            "auth_disabled": False
-        }, 200
+        return {"access_token": access_token, "auth_disabled": False}, 200

--- a/servicex_app/servicex_app/resources/users/token_refresh.py
+++ b/servicex_app/servicex_app/resources/users/token_refresh.py
@@ -36,7 +36,11 @@ class TokenRefresh(Resource):
     @jwt_required(refresh=True, optional=True)
     def post(self):
         if not current_app.config.get("ENABLE_AUTH"):
-            return {"message": "Authentication is disabled on this instance"}, 200
+            return {
+                "message": "Authentication is disabled on this instance",
+                "access_token": "authentication_disabled",
+                "auth_disabled": True
+            }, 200
 
         claims = get_jwt()
         if not claims:
@@ -48,4 +52,4 @@ class TokenRefresh(Resource):
             return {"message": "Invalid or outdated refresh token"}, 401
         current_user = user.email
         access_token = create_access_token(identity=current_user)
-        return {"access_token": access_token}
+        return {"access_token": access_token}, 200

--- a/servicex_app/servicex_app_test/resources/users/test_token_refresh.py
+++ b/servicex_app/servicex_app_test/resources/users/test_token_refresh.py
@@ -21,9 +21,10 @@ class TestTokenRefresh(ResourceTestBase):
         response: Response = client.post("/token/refresh")
 
         assert response.status_code == 200
-        assert response.json == {
-            "message": "Authentication is disabled on this instance"
-        }
+        assert "access_token" in response.json
+        assert response.json["access_token"] == "authentication_disabled"
+        assert "auth_disabled" in response.json
+        assert response.json["auth_disabled"] is True
 
     def test_token_refresh_with_auth_enabled_requires_token(self):
         """Test that token refresh requires a valid token when auth is enabled."""
@@ -57,6 +58,9 @@ class TestTokenRefresh(ResourceTestBase):
 
             assert response.status_code == 200
             assert "access_token" in response.json
+            assert response.json["access_token"] != "authentication_disabled"
+            assert "auth_disabled" in response.json
+            assert response.json["auth_disabled"] is False
 
     def test_token_refresh_with_mismatched_jti(self, mocker):
         """Test that token refresh fails when JTI doesn't match stored token."""

--- a/servicex_app/servicex_app_test/resources/users/test_token_refresh.py
+++ b/servicex_app/servicex_app_test/resources/users/test_token_refresh.py
@@ -1,5 +1,3 @@
-import jwt
-from datetime import datetime, timedelta
 from flask.wrappers import Response
 from flask_jwt_extended import create_refresh_token
 

--- a/servicex_app/servicex_app_test/resources/users/test_token_refresh.py
+++ b/servicex_app/servicex_app_test/resources/users/test_token_refresh.py
@@ -1,0 +1,88 @@
+import jwt
+from datetime import datetime, timedelta
+from flask.wrappers import Response
+from flask_jwt_extended import create_refresh_token
+
+from servicex_app_test.resource_test_base import ResourceTestBase
+from servicex_app.models import UserModel
+
+
+class TestTokenRefresh(ResourceTestBase):
+    """Test suite for token refresh endpoint and JWT configuration."""
+
+    def test_jwt_decode_algorithms_configured(self, client):
+        """Test that JWT_DECODE_ALGORITHMS is properly configured with HS256 and RS256."""
+        assert "JWT_DECODE_ALGORITHMS" in client.application.config
+        algorithms = client.application.config["JWT_DECODE_ALGORITHMS"]
+
+        assert "HS256" in algorithms, "HS256 algorithm should be configured"
+        assert "RS256" in algorithms, "RS256 algorithm should be configured"
+
+    def test_token_refresh_with_auth_disabled(self, client):
+        """Test that token refresh endpoint returns graceful message when auth is disabled."""
+        response: Response = client.post("/token/refresh")
+
+        assert response.status_code == 200
+        assert response.json == {
+            "message": "Authentication is disabled on this instance"
+        }
+
+    def test_token_refresh_with_auth_enabled_requires_token(self):
+        """Test that token refresh requires a valid token when auth is enabled."""
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+
+        with client.application.app_context():
+            response: Response = client.post("/token/refresh")
+            assert response.status_code == 401
+
+    def test_token_refresh_with_auth_enabled_and_valid_token(self, mocker):
+        """Test token refresh works with valid refresh token when auth is enabled."""
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+
+        with client.application.app_context():
+            test_user = UserModel()
+            test_user.email = "testuser@example.com"
+            test_user.sub = "test-sub-123"
+            test_user.name = "Test User"
+            test_user.institution = "Test Institution"
+
+            refresh_token = create_refresh_token(identity=test_user.email)
+            test_user.refresh_token = refresh_token
+
+            mocker.patch(
+                "servicex_app.resources.users.token_refresh.UserModel.find_by_email",
+                return_value=test_user
+            )
+
+            headers = {"Authorization": f"Bearer {refresh_token}"}
+            response: Response = client.post("/token/refresh", headers=headers)
+
+            assert response.status_code == 200
+            assert "access_token" in response.json
+
+    def test_token_refresh_with_mismatched_jti(self, mocker):
+        """Test that token refresh fails when JTI doesn't match stored token."""
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+
+        with client.application.app_context():
+            test_user = UserModel()
+            test_user.email = "testuser@example.com"
+            test_user.sub = "test-sub-123"
+            test_user.name = "Test User"
+            test_user.institution = "Test Institution"
+
+            old_refresh_token = create_refresh_token(identity=test_user.email)
+            new_refresh_token = create_refresh_token(identity=test_user.email)
+
+            test_user.refresh_token = new_refresh_token
+
+            mocker.patch(
+                "servicex_app.resources.users.token_refresh.UserModel.find_by_email",
+                return_value=test_user
+            )
+
+            headers = {"Authorization": f"Bearer {old_refresh_token}"}
+            response: Response = client.post("/token/refresh", headers=headers)
+
+            assert response.status_code == 401
+            assert "Invalid or outdated refresh token" in response.json.get("message", "")

--- a/servicex_app/servicex_app_test/resources/users/test_token_refresh.py
+++ b/servicex_app/servicex_app_test/resources/users/test_token_refresh.py
@@ -51,7 +51,7 @@ class TestTokenRefresh(ResourceTestBase):
 
             mocker.patch(
                 "servicex_app.resources.users.token_refresh.UserModel.find_by_email",
-                return_value=test_user
+                return_value=test_user,
             )
 
             headers = {"Authorization": f"Bearer {refresh_token}"}
@@ -78,11 +78,13 @@ class TestTokenRefresh(ResourceTestBase):
 
             mocker.patch(
                 "servicex_app.resources.users.token_refresh.UserModel.find_by_email",
-                return_value=test_user
+                return_value=test_user,
             )
 
             headers = {"Authorization": f"Bearer {old_refresh_token}"}
             response: Response = client.post("/token/refresh", headers=headers)
 
             assert response.status_code == 401
-            assert "Invalid or outdated refresh token" in response.json.get("message", "")
+            assert "Invalid or outdated refresh token" in response.json.get(
+                "message", ""
+            )


### PR DESCRIPTION
Adds graceful exits (prevents 500 errors) when accessing the refresh token route when:
1. ENABLE_AUTH is set to false: return 200
2. ENABLE_AUTH is set to true and user doesn't have a valid JWT: return 401

Also adds basic testing for token refreshes.