### PR TITLE
Have sideband tasks in app container attempt indefinite reconnection to RabbitMQ

### DIFF
--- a/servicex_app/boot.sh
+++ b/servicex_app/boot.sh
@@ -21,10 +21,12 @@ else
 fi
 [ -d "/default_users" ] && python3 servicex/cli/create_default_users.py
 
-celery --config servicex_app.celery.celeryconfig \
-       --broker="$RABBIT_MQ_URL" -A servicex_app.celery.server_tasks worker \
-       --loglevel=info \
-       --concurrency=5 &
+while true; do
+  celery --config servicex_app.celery.celeryconfig \
+         --broker="$RABBIT_MQ_URL" -A servicex_app.celery.server_tasks worker \
+         --loglevel=info \
+         --concurrency=5 ;
+done &
 
 exec gunicorn -b [::]:5000 $RELOAD --workers=5 --threads=1 --timeout 120 --log-level=warning --access-logfile /tmp/gunicorn.log --error-logfile - "servicex_app:create_app()"
 # to log requests to stdout  --access-logfile -

--- a/servicex_app/boot.sh
+++ b/servicex_app/boot.sh
@@ -21,9 +21,10 @@ else
 fi
 [ -d "/default_users" ] && python3 servicex/cli/create_default_users.py
 
-celery --broker="$RABBIT_MQ_URL" -A servicex_app.celery.server_tasks worker \
-                  --loglevel=info \
-                  --concurrency=5 &
+celery --config servicex_app.celery.celeryconfig \
+       --broker="$RABBIT_MQ_URL" -A servicex_app.celery.server_tasks worker \
+       --loglevel=info \
+       --concurrency=5 &
 
 exec gunicorn -b [::]:5000 $RELOAD --workers=5 --threads=1 --timeout 120 --log-level=warning --access-logfile /tmp/gunicorn.log --error-logfile - "servicex_app:create_app()"
 # to log requests to stdout  --access-logfile -

--- a/servicex_app/servicex_app/celery/celeryconfig.py
+++ b/servicex_app/servicex_app/celery/celeryconfig.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2025, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# configuration options for server task celery workers
+
+# retry RabbitMQ connections forever
+broker_connection_max_retries = None


### PR DESCRIPTION
If the RabbitMQ container dies for some reason, by default celery will retry connections 100 times then stop. This means a sufficiently long outage will leave the `app` in a state where jobs can be submitted, but the file list never gets dispatched to the transformers because that worker has exited. 

The update here is only for the worker spun up in the `app` container. The DID finders in principle have the same problem but since the Celery workers are the primary tasks in those containers, when they exit k8s will restart them so we don't see the issue there. I guess something similar happens with the transformer sidecars although that is certainly going to be ugly.