### PR TITLE
Enable reading ATLAS Opendata via Rucio

### DIFF
--- a/did_finder_rucio/src/rucio_did_finder/rucio_adapter.py
+++ b/did_finder_rucio/src/rucio_did_finder/rucio_adapter.py
@@ -170,13 +170,15 @@ class RucioAdapter:
             return
         no_replica_files = 0
         for ds in datasets:
+            nfiles = 0
             try:
+                nfiles = len(list(self.did_client.list_files(ds[0], ds[1])))
                 reps = self.replica_client.list_replicas(
                     [{"scope": ds[0], "name": ds[1]}],
                     schemes=["root", "http", "https"],
                     metalink=True,
                     sort="geoip",
-                    rse_expression="istape=False\\type=SPECIAL",
+                    rse_expression="istape=False",
                     ignore_availability=False,
                     client_location=self.client_location(),
                 )
@@ -197,7 +199,6 @@ class RucioAdapter:
                     # Path is either a list of replicas or a single logical name
                     if "url" not in f:
                         self.logger.error(f"File {f['identity']} has no replicas.")
-                        no_replica_files += 1
                         continue
                     path = (
                         self.get_paths(f["url"])
@@ -213,6 +214,7 @@ class RucioAdapter:
                             "paths": path,
                         }
                     )
+            no_replica_files += (nfiles - len(g_files))
             yield g_files
 
         if no_replica_files > 0:

--- a/did_finder_rucio/src/rucio_did_finder/rucio_adapter.py
+++ b/did_finder_rucio/src/rucio_did_finder/rucio_adapter.py
@@ -214,7 +214,7 @@ class RucioAdapter:
                             "paths": path,
                         }
                     )
-            no_replica_files += (nfiles - len(g_files))
+            no_replica_files += nfiles - len(g_files)
             yield g_files
 
         if no_replica_files > 0:

--- a/did_finder_rucio/src/rucio_did_finder/rucio_adapter.py
+++ b/did_finder_rucio/src/rucio_did_finder/rucio_adapter.py
@@ -178,7 +178,7 @@ class RucioAdapter:
                     schemes=["root", "http", "https"],
                     metalink=True,
                     sort="geoip",
-                    rse_expression="istape=False",
+                    rse_expression=r"istape=False&(*\type=SPECIAL|cloud=CERN)",
                     ignore_availability=False,
                     client_location=self.client_location(),
                 )

--- a/did_finder_rucio/tests/did_finder/test_lookup_request.py
+++ b/did_finder_rucio/tests/did_finder/test_lookup_request.py
@@ -86,6 +86,7 @@ class TestLookupRequest:
             "rucio_did_finder.rucio_adapter.RucioAdapter.list_datasets_for_did",
             return_value=["abc:def"],
         )
+        mock_did_client.list_files.return_value = ["ghi"]
         mock_replica_client.list_replicas.return_value = """<?xml version="1.0" encoding="UTF-8"?>
 <metalink xmlns="urn:ietf:params:xml:ns:metalink">
  <file name="ghi">


### PR DESCRIPTION
ATLAS Opendata on Rucio was blocked because the endpoint was marked as `type=SPECIAL`. This actually blocks a number of endpoints with unique datasets (mostly at CERN). Remove that restriction for now, since the `rucio` command line would be able to download them. Also improve the logic to catch when replicas are unavailable.