### PR TITLE
Enable `davs` replicas in the Rucio DID finder

### DIFF
--- a/did_finder_rucio/src/rucio_did_finder/rucio_adapter.py
+++ b/did_finder_rucio/src/rucio_did_finder/rucio_adapter.py
@@ -173,7 +173,7 @@ class RucioAdapter:
             try:
                 reps = self.replica_client.list_replicas(
                     [{"scope": ds[0], "name": ds[1]}],
-                    schemes=["root", "http", "https"],
+                    schemes=["davs", "root", "http", "https"],
                     metalink=True,
                     sort="geoip",
                     rse_expression="istape=False\\type=SPECIAL",

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -136,7 +136,7 @@ def transform_file(
     _file_paths = prioritize_replicas(paths)
 
     # Change davs to https
-    _file_paths = change_davs_to_https(paths)
+    _file_paths = change_davs_to_https(_file_paths)
 
     # adding cache prefix
     _file_paths = prepend_xcache(_file_paths)

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -32,6 +32,7 @@ import shutil
 import sys
 import time
 import timeit
+import re
 from argparse import Namespace
 from hashlib import sha1, sha256
 from pathlib import Path
@@ -133,6 +134,9 @@ def transform_file(
 
     # Prioritize the replicas
     _file_paths = prioritize_replicas(paths)
+
+    # Change davs to https
+    _file_paths = change_davs_to_https(paths)
 
     # adding cache prefix
     _file_paths = prepend_xcache(_file_paths)
@@ -514,6 +518,10 @@ def prioritize_replicas(replicas: list[str]) -> list[str]:
     http_replicas = [replica for replica in replicas if replica.startswith("http")]
     root_replicas = [replica for replica in replicas if not replica.startswith("http")]
     return root_replicas + http_replicas
+
+
+def change_davs_to_https(replicas: list[str]) -> list[str]:
+    return [re.sub("^davs", "https", _) for _ in replicas]
 
 
 def get_process_info():

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -132,11 +132,11 @@ def transform_file(
     if convert_root_to_parquet:
         result_format = "root"
 
-    # Prioritize the replicas
-    _file_paths = prioritize_replicas(paths)
-
     # Change davs to https
-    _file_paths = change_davs_to_https(_file_paths)
+    _file_paths = change_davs_to_https(paths)
+
+    # Prioritize the replicas
+    _file_paths = prioritize_replicas(_file_paths)
 
     # adding cache prefix
     _file_paths = prepend_xcache(_file_paths)
@@ -522,13 +522,15 @@ def prioritize_replicas(replicas: list[str]) -> list[str]:
 
 def change_davs_to_https(replicas: list[str]) -> list[str]:
     """
-    Converts all replica URLs in the provided list that start with "davs" to use "https" instead.
+    Converts all replica URLs in the provided list that start with "davs" to use
+    "https" instead.
 
     Args:
         replicas (list[str]): A list of replica URLs or paths.
 
     Returns:
-        list[str]: A list of replica URLs with "davs" replaced by "https" at the start of each string.
+        list[str]: A list of replica URLs with "davs" replaced by "https" at the
+        start of each string.
     """
     return [re.sub("^davs", "https", _) for _ in replicas]
 

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -521,6 +521,15 @@ def prioritize_replicas(replicas: list[str]) -> list[str]:
 
 
 def change_davs_to_https(replicas: list[str]) -> list[str]:
+    """
+    Converts all replica URLs in the provided list that start with "davs" to use "https" instead.
+
+    Args:
+        replicas (list[str]): A list of replica URLs or paths.
+
+    Returns:
+        list[str]: A list of replica URLs with "davs" replaced by "https" at the start of each string.
+    """
     return [re.sub("^davs", "https", _) for _ in replicas]
 
 


### PR DESCRIPTION
Accept `davs` replicas and prioritize these first. (To be discussed if we want to keep this order, but it's inspired by discussions at the 2025 retreat.)