### PR TITLE
Fix logout on OIDC

### DIFF
--- a/servicex_app/servicex_app/web/auth_callback.py
+++ b/servicex_app/servicex_app/web/auth_callback.py
@@ -26,7 +26,8 @@ def auth_callback():
     tokens = oauth.oauth.authorize_access_token()
     id_token = tokens["userinfo"]
 
-    session_tokens = {"access_token": tokens["access_token"]}
+    session_tokens = {"access_token": tokens["access_token"],
+                      "id_token": tokens["id_token"]}
 
     session.update(
         tokens=session_tokens,

--- a/servicex_app/servicex_app/web/auth_callback.py
+++ b/servicex_app/servicex_app/web/auth_callback.py
@@ -26,8 +26,10 @@ def auth_callback():
     tokens = oauth.oauth.authorize_access_token()
     id_token = tokens["userinfo"]
 
-    session_tokens = {"access_token": tokens["access_token"],
-                      "id_token": tokens["id_token"]}
+    session_tokens = {
+        "access_token": tokens["access_token"],
+        "id_token": tokens["id_token"],
+    }
 
     session.update(
         tokens=session_tokens,

--- a/servicex_app/servicex_app/web/sign_out.py
+++ b/servicex_app/servicex_app/web/sign_out.py
@@ -18,7 +18,7 @@ def sign_out():
     oauth.oauth.load_server_metadata()
     id_token = session["tokens"].get("id_token")
     for ty in ("access_token",):
-        if ty in session["tokens"]:
+        if ty in session["tokens"]:  # pragma: no branch
             client.revoke_token(
                 oauth.oauth.server_metadata["revocation_endpoint"],
                 token=session["tokens"][ty],

--- a/servicex_app/servicex_app/web/sign_out.py
+++ b/servicex_app/servicex_app/web/sign_out.py
@@ -16,7 +16,8 @@ def sign_out():
         scope=oauth.oauth.client_kwargs["scope"],
     )
     oauth.oauth.load_server_metadata()
-    for ty in ("access_token", "refresh_token"):
+    id_token = session["tokens"].get("id_token")
+    for ty in ("access_token",):
         if ty in session["tokens"]:
             client.revoke_token(
                 oauth.oauth.server_metadata["revocation_endpoint"],
@@ -30,9 +31,9 @@ def sign_out():
         ga_logout_url = "".join(
             [
                 oauth.oauth.server_metadata["end_session_endpoint"],
-                f"?client={current_app.config['OAUTH_CLIENT_ID']}",
-                f"&redirect_uri={redirect_uri}",
-                "&redirect_name=ServiceX Portal",
+                f"?client_id={current_app.config['OAUTH_CLIENT_ID']}",
+                f"&id_token_hint={id_token}" if id_token else "",
+                f"&post_logout_redirect_uri={redirect_uri}",
             ]
         )
         return redirect(ga_logout_url)

--- a/servicex_app/servicex_app_test/web/test_sign_out.py
+++ b/servicex_app/servicex_app_test/web/test_sign_out.py
@@ -14,7 +14,7 @@ class TestSignOut(WebTestBase):
         relevant_tokens = [
             _[1]
             for _ in oauth_tokens.items()
-            if _[0] in ("access_token", "refresh_token")
+            if _[0] in ("access_token",)
         ]
         calls = [
             mocker.call(
@@ -28,9 +28,9 @@ class TestSignOut(WebTestBase):
         ga_logout_url = "".join(
             [
                 "https://auth.globus.org/v2/web/logout",
-                f"?client={client.application.config['OAUTH_CLIENT_ID']}",
-                f"&redirect_uri={url_for('home', _external=True)}",
-                f"&redirect_name={quote('ServiceX Portal')}",
+                f"?client_id={client.application.config['OAUTH_CLIENT_ID']}",
+                "&id_token_hint=opaque"
+                f"&post_logout_redirect_uri={url_for('home', _external=True)}",
             ]
         )
         assert response.status_code == 302

--- a/servicex_app/servicex_app_test/web/test_sign_out.py
+++ b/servicex_app/servicex_app_test/web/test_sign_out.py
@@ -12,9 +12,7 @@ class TestSignOut(WebTestBase):
             sess["tokens"] = oauth_tokens
         response: Response = client.get(url_for("sign_out"))
         relevant_tokens = [
-            _[1]
-            for _ in oauth_tokens.items()
-            if _[0] in ("access_token",)
+            _[1] for _ in oauth_tokens.items() if _[0] in ("access_token",)
         ]
         calls = [
             mocker.call(

--- a/servicex_app/servicex_app_test/web/test_sign_out.py
+++ b/servicex_app/servicex_app_test/web/test_sign_out.py
@@ -1,5 +1,3 @@
-from urllib.parse import quote
-
 from flask import Response, url_for, session
 
 from .web_test_base import WebTestBase

--- a/servicex_app/servicex_app_test/web/web_test_base.py
+++ b/servicex_app/servicex_app_test/web/web_test_base.py
@@ -122,10 +122,7 @@ class WebTestBase:
 
     @staticmethod
     def _oauth_tokens():
-        return {
-            "access_token": "opaque",
-            "id_token": "opaque"
-        }
+        return {"access_token": "opaque", "id_token": "opaque"}
 
     @staticmethod
     def _globus_metadata():

--- a/servicex_app/servicex_app_test/web/web_test_base.py
+++ b/servicex_app/servicex_app_test/web/web_test_base.py
@@ -123,11 +123,8 @@ class WebTestBase:
     @staticmethod
     def _oauth_tokens():
         return {
-            "access_token": "globus-auth-access-token",
-            "expires_at_seconds": 1596734412,
-            "resource_server": "auth.globus.org",
-            "scope": "email profile openid",
-            "token_type": "Bearer",
+            "access_token": "opaque",
+            "id_token": "opaque"
         }
 
     @staticmethod


### PR DESCRIPTION
This is a mostly cosmetic update: Globus auth doesn't use the correct OIDC logout parameters so Keycloak etc. would complain about a bad redirection URI. This is now fixed.