### PR TITLE
Fix internal ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### 1.7.5
+November 17, 2025
+
+### Fixed
+- Configuration of internal routes
+
+### 1.7.4
+October 28, 2025
+
+### Fixed
+- Ordering in RabbitMQ Password
+
 ### 1.7.3
 October, 27, 2025
 

--- a/helm/servicex/templates/app/ingress.yaml
+++ b/helm/servicex/templates/app/ingress.yaml
@@ -22,6 +22,13 @@ spec:
   - host: {{ .Release.Name }}.{{ .Values.app.ingress.host }}
     http:
       paths:
+      - path: /servicex/internal
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Values.app.ingress.defaultBackend }}
+            port:
+              number: 8000
       - path: /
         pathType: Prefix
         backend:


### PR DESCRIPTION
During a previous release the protection of internal routes was deleted from the ingress. This restores the external redirect to the default backend