### PR TITLE
Restore OKD-needed permissions for home directories

### DIFF
--- a/code_generator_TopCPToolkit/Dockerfile
+++ b/code_generator_TopCPToolkit/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10
 
-RUN useradd -ms /bin/bash servicex
+RUN useradd -ms /bin/bash -g 0 servicex && chmod 0750 /home/servicex
 RUN apt-get update && apt-get install -y netcat-traditional && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/servicex

--- a/code_generator_funcadl_uproot/Dockerfile
+++ b/code_generator_funcadl_uproot/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10
 
-RUN useradd -ms /bin/bash servicex
+RUN useradd -ms /bin/bash -g 0 servicex && chmod 0750 /home/servicex
 
 WORKDIR /home/servicex
 RUN mkdir ./uproot_code_generator

--- a/code_generator_funcadl_xAOD/Dockerfile
+++ b/code_generator_funcadl_xAOD/Dockerfile
@@ -5,7 +5,7 @@ ARG APP_CONFIG_FILE="app.atlas.xaod.conf"
 ENV  POETRY_VERSION=2.1.1
 RUN pip install poetry==$POETRY_VERSION
 
-RUN useradd -ms /bin/bash servicex
+RUN useradd -ms /bin/bash -g 0 servicex && chmod 0750 /home/servicex
 
 WORKDIR /home/servicex
 RUN mkdir ./xaod_code_generator

--- a/code_generator_python/Dockerfile
+++ b/code_generator_python/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10
 
-RUN useradd -ms /bin/bash servicex
+RUN useradd -ms /bin/bash -g 0 servicex && chmod 0750 /home/servicex
 
 WORKDIR /home/servicex
 RUN mkdir ./python_code_generator

--- a/code_generator_raw_uproot/Dockerfile
+++ b/code_generator_raw_uproot/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10
 
-RUN useradd -ms /bin/bash servicex
+RUN useradd -ms /bin/bash -g 0 servicex && chmod 0750 /home/servicex
 RUN apt-get update && apt-get install -y netcat-traditional && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/servicex

--- a/servicex_app/Dockerfile
+++ b/servicex_app/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10
 
-RUN useradd -ms /bin/bash servicex
+RUN useradd -ms /bin/bash -g 0 servicex && chmod 0750 /home/servicex
 
 WORKDIR /home/servicex
 RUN mkdir ./servicex


### PR DESCRIPTION
The switch from the base image from bookworm to trixie changed the default umask from 022 to 077. This restores the previous behavior needed for OKD, which runs the container as an ephemeral user with GID 0.