### PR TITLE
Slight cleanup in profile creation workflow

### DIFF
--- a/servicex_app/servicex_app/cli/user_commands.py
+++ b/servicex_app/servicex_app/cli/user_commands.py
@@ -1,4 +1,5 @@
 from flask import current_app
+from flask_jwt_extended import create_refresh_token
 from servicex_app.models import UserModel
 
 
@@ -7,20 +8,21 @@ def check_user_exists(sub):
 
 
 def add_user(sub, email, name, institution, refresh_token):
+    if not refresh_token:
+        refresh_token = create_refresh_token(identity=email)
+
     new_user = UserModel(
         sub=sub,
         email=email,
         name=name,
         institution=institution,
         refresh_token=refresh_token,
+        pending=False,
     )
 
     if new_user.email == current_app.config.get("JWT_ADMIN"):
         new_user.admin = True
-    if refresh_token:
-        new_user.pending = False
-    else:
-        new_user.pending = True
+
     try:
         if not check_user_exists(new_user.sub):
             new_user.save_to_db()

--- a/servicex_app/servicex_app/web/auth_callback.py
+++ b/servicex_app/servicex_app/web/auth_callback.py
@@ -50,5 +50,6 @@ def auth_callback():
         if user:
             session["user_id"] = user.id
             session["admin"] = user.admin
+            session["email"] = identity
             return redirect(url_for("user-dashboard"))
     return redirect(url_for("create_profile"))

--- a/servicex_app/servicex_app/web/create_profile.py
+++ b/servicex_app/servicex_app/web/create_profile.py
@@ -47,21 +47,12 @@ def create_profile():
             if new_user.email == current_app.config.get("JWT_ADMIN"):
                 new_user.admin = True
                 new_user.pending = False
+            new_user.save_to_db()
+            session["user_id"] = new_user.id
+            session["admin"] = new_user.admin
+            webhook_url = current_app.config.get("SIGNUP_WEBHOOK_URL")
+            msg_segments = ["Profile created!"]
             try:
-                check_user_email = UserModel.find_by_email(form.email.data)
-                if check_user_email and not check_user_email.refresh_token:
-                    UserModel.update_refresh_token_by_email(
-                        check_user_email.email,
-                        create_refresh_token(identity=sub),
-                        False,
-                    )
-                    new_user.pending = False
-                else:
-                    new_user.save_to_db()
-                session["user_id"] = new_user.id
-                session["admin"] = new_user.admin
-                webhook_url = current_app.config.get("SIGNUP_WEBHOOK_URL")
-                msg_segments = ["Profile created!"]
                 if webhook_url and new_user.pending:
                     res = post_signup(webhook_url, signup(new_user.email))
                     res.raise_for_status()


### PR DESCRIPTION
* Make sure that for Globus we make a consistent choice of session and profile email given as there could be multiple emails for a given account
* do not initialize refresh token for CLI-created users in the middle of the profile creation, do it in a sensible place