### PR TITLE
properly quote integers in cronjobs

### DIFF
--- a/helm/servicex/templates/data-lifecycle/cronjob.yaml
+++ b/helm/servicex/templates/data-lifecycle/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
             imagePullPolicy: {{ .Values.scheduledTasks.pullPolicy }}
             env:
               - name: RETENTION_PERIOD
-                value: {{ .Values.scheduledTasks.dataLifecycle.retention }}
+                value: "{{ .Values.scheduledTasks.dataLifecycle.retention }}"
 
             command:
             - /bin/sh

--- a/helm/servicex/templates/data-lifecycle/cronjob.yaml
+++ b/helm/servicex/templates/data-lifecycle/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
             imagePullPolicy: {{ .Values.scheduledTasks.pullPolicy }}
             env:
               - name: RETENTION_PERIOD
-                value: "{{ .Values.scheduledTasks.dataLifecycle.retention }}"
+                value: {{ .Values.scheduledTasks.dataLifecycle.retention }}
 
             command:
             - /bin/sh

--- a/helm/servicex/templates/dataset-lifecycle/cronjob.yaml
+++ b/helm/servicex/templates/dataset-lifecycle/cronjob.yaml
@@ -18,7 +18,7 @@ spec:
             imagePullPolicy: {{ .Values.scheduledTasks.pullPolicy }}
             env:
               - name: LIFETIME
-                value: {{ .Values.scheduledTasks.datasetLifecycle.cacheLifetime }}
+                value: "{{ .Values.scheduledTasks.datasetLifecycle.cacheLifetime }}"
             command:
             - /usr/bin/curl
             - --request POST "http://{{ .Release.Name }}-servicex-app:8000/servicex/internal/dataset-lifecycle?age=$(LIFETIME)"

--- a/helm/servicex/templates/dataset-lifecycle/cronjob.yaml
+++ b/helm/servicex/templates/dataset-lifecycle/cronjob.yaml
@@ -18,7 +18,7 @@ spec:
             imagePullPolicy: {{ .Values.scheduledTasks.pullPolicy }}
             env:
               - name: LIFETIME
-                value: "{{ .Values.scheduledTasks.datasetLifecycle.cacheLifetime }}"
+                value: {{ .Values.scheduledTasks.datasetLifecycle.cacheLifetime | quote }}
             command:
             - /usr/bin/curl
             - --request POST "http://{{ .Release.Name }}-servicex-app:8000/servicex/internal/dataset-lifecycle?age=$(LIFETIME)"


### PR DESCRIPTION
This is causing `helm` installation failures due to issues casting integer to string.

```
Error: INSTALLATION FAILED: 1 error occurred:
    * CronJob in version "v1" cannot be handled as a CronJob: json: cannot unmarshal number into Go struct field EnvVar.spec.jobTemplate.spec.template.spec.containers.env.value of type string
```