### PR TITLE
Add helm installation name and k8s namespace to local/port-forward.sh

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,6 @@
 minikube-mount-app: minikube mount $LOCAL_DIR:/mnt/servicex
 minikube-mount-topcp: minikube mount $LOCAL_DIR/code_generator_TopCPToolkit:/mnt/topcp
-helm-install: sleep 5; cd $CHART_DIR && helm install -f $VALUES_FILE servicex . && tail -f /dev/null
+helm-install: sleep 5; cd $CHART_DIR && helm install -f "$VALUES_FILE" "${HELM_INSTALLATION_NAME:-servicex}" . && tail -f /dev/null
 port-forward-app: sleep 30 && cd $LOCAL_DIR && bash local/port-forward.sh app
 port-forward-minio: sleep 20 && cd $LOCAL_DIR && bash local/port-forward.sh minio
 port-forward-db: sleep 20 && cd $LOCAL_DIR && bash local/port-forward.sh db

--- a/docs/development/running_locally.md
+++ b/docs/development/running_locally.md
@@ -109,11 +109,12 @@ To do this, open your `~/.bashrc` and add the three environment variables previo
 LOCAL_DIR=/Users/mattshirley/work/ServiceX/
 CHART_DIR=$LOCAL_DIR/helm/servicex
 VALUES_FILE=local-values.yaml
+# HELM_INSTALLATION_NAME=servicex-local # this is optional, will default to servicex
 
 alias servicex-up='cd $CHART_DIR && overmind start'
-alias servicex-down='helm delete servicex'
+alias servicex-down='helm delete "${HELM_INSTALLATION_NAME:-servicex}"'
 alias servicex-start='servicex-up; servicex-down;'
-alias servicex-upgrade='cd $CHART_DIR && helm upgrade -f $VALUES_FILE servicex .'
+alias servicex-upgrade='cd $CHART_DIR && helm upgrade -f $VALUES_FILE "${HELM_INSTALLATION_NAME:-servicex}" .'
 ```
 
 After adding the aliases, refresh your `.bashrc` file:

--- a/local/port-forward.sh
+++ b/local/port-forward.sh
@@ -2,38 +2,75 @@
 
 set -euo pipefail
 
-# Parse namespace argument (defaults to 'servicex')
-NAMESPACE="${2:-servicex}"
+# Default values
+K8S_NAMESPACE="default"
+HELM_NAME="servicex"
+SERVICE_TYPE=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --namespace)
+            K8S_NAMESPACE="$2"
+            shift 2
+            ;;
+        --helm-name)
+            HELM_NAME="$2"
+            shift 2
+            ;;
+        app|minio|db)
+            SERVICE_TYPE="$1"
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [app|minio|db] [OPTIONS]"
+            echo ""
+            echo "Services:"
+            echo "  app   - Port forward to ServiceX app (8000)"
+            echo "  minio - Port forward to Minio (9000)"
+            echo "  db    - Port forward to PostgreSQL (5432)"
+            echo ""
+            echo "Options:"
+            echo "  --namespace NAMESPACE    Kubernetes namespace (default: default)"
+            echo "  --helm-name NAME         Helm installation name (default: servicex)"
+            echo "  -h, --help              Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'"
+            echo "Run '$0 --help' for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Validate service type is provided
+if [ -z "$SERVICE_TYPE" ]; then
+    echo "Error: Service type is required"
+    echo "Usage: $0 [app|minio|db] [OPTIONS]"
+    echo "Run '$0 --help' for more information"
+    exit 1
+fi
 
 # Service configuration
-case "${1:-}" in
+case "$SERVICE_TYPE" in
     app)
-        SERVICE="${NAMESPACE}-servicex-app"
+        SERVICE="${HELM_NAME}-servicex-app"
         PORT="8000"
         ;;
     minio)
-        SERVICE="${NAMESPACE}-minio"
+        SERVICE="${HELM_NAME}-minio"
         PORT="9000"
         ;;
     db)
-        SERVICE="${NAMESPACE}-postgresql"
+        SERVICE="${HELM_NAME}-postgresql"
         PORT="5432"
-        ;;
-    *)
-        echo "Usage: $0 [app|minio|db] [namespace]"
-        echo "  app   - Port forward to ServiceX app (8000)"
-        echo "  minio - Port forward to Minio (9000)"
-        echo "  db    - Port forward to PostgreSQL (5432)"
-        echo ""
-        echo "Optional arguments:"
-        echo "  namespace - Kubernetes namespace (default: servicex)"
-        exit 1
         ;;
 esac
 
 # Check if service is available
-echo "Checking if service $SERVICE is available..."
-while ! kubectl get service "$SERVICE" --namespace="${NAMESPACE}" >/dev/null 2>&1; do
+echo "Checking if service $SERVICE is available in namespace $K8S_NAMESPACE..."
+while ! kubectl get service "$SERVICE" --namespace="$K8S_NAMESPACE" >/dev/null 2>&1; do
     echo "Service not found, waiting..."
     sleep 2
 done
@@ -42,7 +79,7 @@ done
 echo "Checking if pods are running..."
 while true; do
     # Try to find running pods by looking for endpoints
-    ENDPOINTS=$(kubectl get endpoints "$SERVICE" --namespace="${NAMESPACE}" -o jsonpath='{.subsets[0].addresses}' 2>/dev/null || echo "")
+    ENDPOINTS=$(kubectl get endpoints "$SERVICE" --namespace="$K8S_NAMESPACE" -o jsonpath='{.subsets[0].addresses}' 2>/dev/null || echo "")
     if [ -n "$ENDPOINTS" ] && [ "$ENDPOINTS" != "null" ]; then
         echo "Service has ready endpoints"
         break
@@ -62,4 +99,4 @@ cleanup() {
 trap cleanup SIGINT SIGTERM
 
 # Start port forwarding
-kubectl port-forward --namespace="${NAMESPACE}" "svc/$SERVICE" "${PORT}:${PORT}"
+kubectl port-forward --namespace="$K8S_NAMESPACE" "svc/$SERVICE" "${PORT}:${PORT}"

--- a/local/port-forward.sh
+++ b/local/port-forward.sh
@@ -2,32 +2,38 @@
 
 set -euo pipefail
 
+# Parse namespace argument (defaults to 'servicex')
+NAMESPACE="${2:-servicex}"
+
 # Service configuration
 case "${1:-}" in
     app)
-        SERVICE="servicex-servicex-app"
+        SERVICE="${NAMESPACE}-servicex-app"
         PORT="8000"
         ;;
     minio)
-        SERVICE="servicex-minio"
+        SERVICE="${NAMESPACE}-minio"
         PORT="9000"
         ;;
     db)
-        SERVICE="servicex-postgresql"
+        SERVICE="${NAMESPACE}-postgresql"
         PORT="5432"
         ;;
     *)
-        echo "Usage: $0 [app|minio|db]"
+        echo "Usage: $0 [app|minio|db] [namespace]"
         echo "  app   - Port forward to ServiceX app (8000)"
         echo "  minio - Port forward to Minio (9000)"
         echo "  db    - Port forward to PostgreSQL (5432)"
+        echo ""
+        echo "Optional arguments:"
+        echo "  namespace - Kubernetes namespace (default: servicex)"
         exit 1
         ;;
 esac
 
 # Check if service is available
 echo "Checking if service $SERVICE is available..."
-while ! kubectl get service "$SERVICE" --namespace="${NAMESPACE:-default}" >/dev/null 2>&1; do
+while ! kubectl get service "$SERVICE" --namespace="${NAMESPACE}" >/dev/null 2>&1; do
     echo "Service not found, waiting..."
     sleep 2
 done
@@ -36,7 +42,7 @@ done
 echo "Checking if pods are running..."
 while true; do
     # Try to find running pods by looking for endpoints
-    ENDPOINTS=$(kubectl get endpoints "$SERVICE" --namespace="${NAMESPACE:-default}" -o jsonpath='{.subsets[0].addresses}' 2>/dev/null || echo "")
+    ENDPOINTS=$(kubectl get endpoints "$SERVICE" --namespace="${NAMESPACE}" -o jsonpath='{.subsets[0].addresses}' 2>/dev/null || echo "")
     if [ -n "$ENDPOINTS" ] && [ "$ENDPOINTS" != "null" ]; then
         echo "Service has ready endpoints"
         break
@@ -56,4 +62,4 @@ cleanup() {
 trap cleanup SIGINT SIGTERM
 
 # Start port forwarding
-kubectl port-forward --namespace="${NAMESPACE:-default}" "svc/$SERVICE" "${PORT}:${PORT}"
+kubectl port-forward --namespace="${NAMESPACE}" "svc/$SERVICE" "${PORT}:${PORT}"

--- a/local/port-forward.sh
+++ b/local/port-forward.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Default values
 K8S_NAMESPACE="default"
-HELM_NAME="servicex"
+HELM_NAME="${HELM_INSTALLATION_NAME:-servicex}"
 SERVICE_TYPE=""
 
 # Parse arguments


### PR DESCRIPTION
Update the `local/port-forward.sh` script (used in local development). To support custom Helm installation names as well as k8s namespaces via the `--helm-name` and `--namespace` arguments respectively.