### PR TITLE
Fix dataset lifecycle jobs

### DIFF
--- a/helm/servicex/templates/dataset-lifecycle/cronjob.yaml
+++ b/helm/servicex/templates/dataset-lifecycle/cronjob.yaml
@@ -21,5 +21,7 @@ spec:
                 value: {{ .Values.scheduledTasks.datasetLifecycle.cacheLifetime | quote }}
             command:
             - /usr/bin/curl
-            - --request POST "http://{{ .Release.Name }}-servicex-app:8000/servicex/internal/dataset-lifecycle?age=$(LIFETIME)"
+            - --json
+            - '{"age": $(LIFETIME)}'
+            - "http://{{ .Release.Name }}-servicex-app:8000/servicex/internal/dataset-lifecycle"
           restartPolicy: OnFailure

--- a/servicex_app/servicex_app/resources/internal/dataset_lifecycle_ops.py
+++ b/servicex_app/servicex_app/resources/internal/dataset_lifecycle_ops.py
@@ -38,7 +38,7 @@ class DatasetLifecycleOps(ServiceXResource):
         """
         Obsolete cached datasets older than N hours
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         try:
             age = float(request.get_json().get("age", 24))
         except Exception:

--- a/servicex_app/servicex_app_test/resources/internal/test_dataset_lifecycle_ops.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_dataset_lifecycle_ops.py
@@ -41,8 +41,8 @@ class TestDatasetLifecycle(ResourceTestBase):
         with patch("servicex_app.models.Dataset.get_all") as dsfunc:
             dsfunc.return_value = [
                 Dataset(
-                    last_used=datetime(2022, 1, 1, tzinfo=timezone.utc),
-                    last_updated=datetime(2022, 1, 1, tzinfo=timezone.utc),
+                    last_used=datetime(2022, 1, 1),
+                    last_updated=datetime(2022, 1, 1),
                     id=1,
                     name="not-orphaned",
                     events=100,
@@ -52,8 +52,8 @@ class TestDatasetLifecycle(ResourceTestBase):
                     did_finder="rucio",
                 ),
                 Dataset(
-                    last_used=datetime.now(timezone.utc),
-                    last_updated=datetime.now(timezone.utc),
+                    last_used=datetime.now(),
+                    last_updated=datetime.now(),
                     id=2,
                     name="orphaned",
                     events=100,

--- a/servicex_app/servicex_app_test/resources/internal/test_dataset_lifecycle_ops.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_dataset_lifecycle_ops.py
@@ -25,7 +25,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from datetime import datetime, timezone
+from datetime import datetime
 from unittest.mock import patch
 
 from pytest import fixture


### PR DESCRIPTION
"Improvements" were made after validation of functioning dataset lifecycle task which in fact broke it - one in the datetime handling and one in the batch job configuration. Fix these (combination is validated to work on testing-3).

Co-Pilot explains what is happening here:
> Note on the change in the PR: The new version adds .replace(tzinfo=None) which strips the timezone information, converting it from a timezone-aware to a timezone-naive datetime. This suggests the code needs to compare against database timestamps that are stored without timezone information.

