### PR TITLE
prevent name collision for x509-secrets-init job

### DIFF
--- a/helm/servicex/templates/x509-secrets/install-job.yaml
+++ b/helm/servicex/templates/x509-secrets/install-job.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 3
   template:


### PR DESCRIPTION
Prevent name collision for x509-secrets-init Job when one is left dangling by adding the `before-hook-creation` to the helm delete policy.