### PR TITLE
Update TopCP docker image tag

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -174,7 +174,7 @@ codeGen:
     pullPolicy: Always
     tag: develop
     defaultScienceContainerImage: sslhep/servicex_science_image_topcp
-    defaultScienceContainerTag: 25.2.74-v2.23.0
+    defaultScienceContainerTag: 25.2.66-v2.22.0
     resources:
       requests:
         cpu: 100m

--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -174,7 +174,7 @@ codeGen:
     pullPolicy: Always
     tag: develop
     defaultScienceContainerImage: sslhep/servicex_science_image_topcp
-    defaultScienceContainerTag: 25.2.66-v2.22.0
+    defaultScienceContainerTag: 25.2.74-v2.23.0
     resources:
       requests:
         cpu: 100m

--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -174,7 +174,7 @@ codeGen:
     pullPolicy: Always
     tag: develop
     defaultScienceContainerImage: sslhep/servicex_science_image_topcp
-    defaultScienceContainerTag: 2.17.0-25.2.45
+    defaultScienceContainerTag: 25.2.74-v2.23.0
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
Update TopCP docker image tag to the latest version: `25.2.74-v2.23.0`