### PR TITLE
Fix transaction leak in transformation submit endpoint (#1317)

### DIFF
--- a/servicex_app/servicex_app/code_gen_adapter.py
+++ b/servicex_app/servicex_app/code_gen_adapter.py
@@ -27,8 +27,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import requests
 from requests_toolbelt.multipart import decoder
-
-from servicex_app.models import TransformRequest
 from servicex_app.reliable_requests import REQUEST_TIMEOUT, servicex_retry
 
 
@@ -43,13 +41,18 @@ class CodeGenAdapter:
         return result
 
     def generate_code_for_selection(
-        self, request_record: TransformRequest, namespace: str, user_codegen_name: str
+        self,
+        selection_string: str,
+        request_id: str,
+        namespace: str,
+        user_codegen_name: str,
     ) -> tuple[str, str, str, str]:
         """
         Generates the C++ code for a request's selection string.
         Places the results in a ConfigMap resource in the
         Starts a transformation request, deploys transformers, and updates record.
-        :param request_record: A TransformationRequest.
+        :param selection_string: String representing the selection criteria.
+        :param request_id: ID of the request.
         :param namespace: Namespace in which to place resulting ConfigMap.
         :param user_codegen_name: Name provided by user for selecting the codegen URL
                from config dictionary
@@ -71,7 +74,7 @@ class CodeGenAdapter:
         result = self.post_request(
             post_url + "/servicex/generated-code",
             post_obj={
-                "code": request_record.selection,
+                "code": selection_string,
             },
         )
 
@@ -93,7 +96,7 @@ class CodeGenAdapter:
 
         return (
             self.transformer_manager.create_configmap_from_zip(
-                zipfile, request_record.request_id, namespace
+                zipfile, request_id, namespace
             ),
             transformer_image,
             transformer_language,

--- a/servicex_app/servicex_app/dataset_manager.py
+++ b/servicex_app/servicex_app/dataset_manager.py
@@ -64,7 +64,7 @@ class DatasetManager:
                 lookup_status=DatasetStatus.created,
                 did_finder=did.scheme,
             )
-            dataset.save_to_db()
+
             logger.info(
                 f"Created new dataset: {dataset.name}, id is {dataset.id}", extra=extras
             )
@@ -74,8 +74,7 @@ class DatasetManager:
                 extra=extras,
             )
             dataset.last_used = datetime.now(tz=timezone.utc)
-            dataset.save_to_db()
-
+        db.session.add(dataset)
         return cls(dataset, logger, db)
 
     @classmethod
@@ -107,7 +106,6 @@ class DatasetManager:
                 ],
             )
 
-            dataset.save_to_db()
             logger.info(
                 f"Created new dataset for file list. Dataset Id is {dataset.id}",
                 extra=extras,
@@ -118,8 +116,8 @@ class DatasetManager:
                 extra=extras,
             )
             dataset.last_used = datetime.now(tz=timezone.utc)
-            dataset.save_to_db()
 
+        db.session.add(dataset)
         return cls(dataset, logger, db)
 
     @classmethod

--- a/servicex_app/servicex_app/resources/transformation/submit.py
+++ b/servicex_app/servicex_app/resources/transformation/submit.py
@@ -33,6 +33,7 @@ from typing import Optional, List
 
 from flask import current_app
 from flask_restful import reqparse
+
 from servicex_app.dataset_manager import DatasetManager
 from servicex_app.decorators import auth_required
 from servicex_app.did_parser import DIDParser
@@ -135,15 +136,15 @@ class SubmitTransformationRequest(ServiceXResource):
             return DatasetManager.from_did(
                 parsed_did,
                 logger=current_app.logger,
-                extras={"requestId": request_id},
                 db=db,
+                extras={"requestId": request_id},
             )
         else:  # no dataset, only a list of files given
             return DatasetManager.from_file_list(
                 file_list,
                 logger=current_app.logger,
-                extras={"requestId": request_id},
                 db=db,
+                extras={"requestId": request_id},
             )
 
     def _setup_rabbit_queues(self, request_id: str):
@@ -167,11 +168,12 @@ class SubmitTransformationRequest(ServiceXResource):
 
     @auth_required
     def post(self):
+        # The general strategy is to do as much as possible before starting the DB
+        # transaction, so we don't hold the lock too long.
         request_id = str(
             uuid.uuid4()
         )  # make sure we have a request id for all messages
         try:
-
             try:
                 args = self.parser.parse_args()
             except BadRequest as bad_request:
@@ -180,7 +182,6 @@ class SubmitTransformationRequest(ServiceXResource):
                 return {"message": msg}, 400
 
             config = current_app.config
-            user = self.get_requesting_user()
 
             did = args.get("did")
             file_list = args.get("file-list")
@@ -194,18 +195,33 @@ class SubmitTransformationRequest(ServiceXResource):
                 current_app.logger.error(msg, extra={"requestId": request_id})
                 return {"message": msg}, 500
 
-            try:
-                dataset_manager = self._initialize_dataset_manager(
-                    did, file_list, request_id, config
-                )
-            except BadRequest as bad_request:
-                current_app.logger.error(
-                    str(bad_request), extra={"requestId": request_id}
-                )
-                return {"message": str(bad_request)}, 400
+            # The first thing to do is make sure the requested selection is correct
+            # and can generate the requested code.
+            (
+                generated_code_cm,
+                codegen_transformer_image,
+                transformer_language,
+                transformer_command,
+            ) = self.code_gen_service.generate_code_for_selection(
+                selection_string=args["selection"],
+                request_id=request_id,
+                namespace=namespace,
+                user_codegen_name=user_codegen_name,
+            )
+
+            _validate_custom_docker_image(codegen_transformer_image)
+
+            # Check to make sure the transformer docker image actually exists (if enabled)
+            if config["TRANSFORMER_VALIDATE_DOCKER_IMAGE"]:
+                if not self.docker_repo_adapter.check_image_exists(
+                    codegen_transformer_image
+                ):
+                    msg = f"Requested transformer docker image doesn't exist: {codegen_transformer_image}"  # noqa: E501
+                    current_app.logger.error(msg, extra={"requestId": request_id})
+                    return {"message": msg}, 500
 
             # If the user has requested an object store destination, now is the time
-            # to creat a bucket named after the request id
+            # to create a bucket named after the request id
             if (
                 self.object_store
                 and args["result-destination"] == TransformRequest.OBJECT_STORE_DEST
@@ -214,72 +230,78 @@ class SubmitTransformationRequest(ServiceXResource):
                 # TODO: need to check to make sure bucket was created
                 # WHat happens if object-store and object_store is None?
 
-            request_rec = TransformRequest(
-                request_id=str(request_id),
-                title=args.get("title"),
-                did=dataset_manager.name,
-                did_id=dataset_manager.id,
-                submit_time=datetime.now(tz=timezone.utc),
-                submitted_by=user.id if user is not None else None,
-                selection=args["selection"],
-                tree_name=args["tree-name"],
-                result_destination=args["result-destination"],
-                result_format=args["result-format"],
-                workers=args["workers"],
-                status=TransformStatus.submitted,
-                app_version=self._get_app_version(),
-                code_gen_image=code_gen_image_name,
-                files=0,
-            )
+            # Transaction 1: persist the Dataset record and obtain a committed DB ID.
+            # This must commit before the TransformRequest is created so that the
+            # auto-increment dataset.id is assigned by the database.
+            session = db.session
+            with session.begin():
+                try:
+                    dataset_manager = self._initialize_dataset_manager(
+                        did, file_list, request_id, config
+                    )
+                except BadRequest as bad_request:
+                    current_app.logger.error(
+                        str(bad_request), extra={"requestId": request_id}
+                    )
+                    return {"message": str(bad_request)}, 400
 
-            # The first thing to do is make sure the requested selection is correct,
-            # and can generate the requested code
-            (
-                request_rec.generated_code_cm,
-                codegen_transformer_image,
-                request_rec.transformer_language,
-                request_rec.transformer_command,
-            ) = self.code_gen_service.generate_code_for_selection(
-                request_rec, namespace, user_codegen_name
-            )
+            # Do NOT access any SQLAlchemy model attributes between the two begin()
+            # blocks — that would trigger SQLAlchemy's autobegin and cause the next
+            # session.begin() to raise InvalidRequestError.
 
-            _validate_custom_docker_image(codegen_transformer_image)
+            # Transaction 2: create the TransformRequest referencing the now-persisted
+            # Dataset ID.  Expired attributes on dataset_manager.dataset are lazy-loaded
+            # within this transaction.
+            with session.begin():
+                user = self.get_requesting_user()
 
-            request_rec.image = codegen_transformer_image
-
-            # Check to make sure the transformer docker image actually exists (if enabled)
-            if config["TRANSFORMER_VALIDATE_DOCKER_IMAGE"]:
-                if not self.docker_repo_adapter.check_image_exists(request_rec.image):
-                    msg = f"Requested transformer docker image doesn't exist: {request_rec.image}"
-                    current_app.logger.error(msg, extra={"requestId": request_id})
-                    return {"message": msg}, 500
-
-            request_rec.save_to_db()
-            dataset_manager.refresh()
-
-            # If this request has a fresh DID then submit the lookup request to the DID Finder
-            if dataset_manager.is_lookup_required:
-                dataset_manager.submit_lookup_request(
-                    self._generate_advertised_endpoint(
-                        "servicex/internal/transformation/"
-                    ),
-                    self.celery_app,
+                request_rec = TransformRequest(
+                    request_id=str(request_id),
+                    title=args.get("title"),
+                    did=dataset_manager.name,
+                    did_id=dataset_manager.id,
+                    submit_time=datetime.now(tz=timezone.utc),
+                    submitted_by=user.id if user is not None else None,
+                    selection=args["selection"],
+                    tree_name=args["tree-name"],
+                    result_destination=args["result-destination"],
+                    result_format=args["result-format"],
+                    workers=args["workers"],
+                    status=TransformStatus.submitted,
+                    app_version=self._get_app_version(),
+                    code_gen_image=code_gen_image_name,
+                    image=codegen_transformer_image,
+                    transformer_language=transformer_language,
+                    transformer_command=transformer_command,
+                    generated_code_cm=generated_code_cm,
+                    files=0,
                 )
-                request_rec.status = TransformStatus.lookup
-            elif dataset_manager.is_complete:
-                current_app.logger.info(
-                    "dataset already complete", extra={"requestId": str(request_id)}
-                )
-                dataset_manager.publish_files(request_rec, self.lookup_result_processor)
-                request_rec.status = TransformStatus.running
-            else:
-                current_app.logger.info(
-                    "another request received for dataset that is still being looked up ",
-                    extra={"requestId": str(request_id)},
-                )
-                request_rec.status = TransformStatus.pending_lookup
 
-            db.session.commit()
+                session.add(request_rec)
+
+                # If this request has a fresh DID then submit the lookup request to the DID Finder
+                if dataset_manager.is_lookup_required:
+                    dataset_manager.submit_lookup_request(
+                        self._generate_advertised_endpoint(
+                            "servicex/internal/transformation/"
+                        ),
+                        self.celery_app,
+                    )
+                    request_rec.status = TransformStatus.lookup
+                elif dataset_manager.is_complete:
+                    current_app.logger.info(
+                        "dataset already complete", extra={"requestId": str(request_id)}
+                    )
+                    dataset_manager.publish_files(
+                        request_rec, self.lookup_result_processor
+                    )
+                    request_rec.status = TransformStatus.running
+                else:
+                    current_app.logger.info(
+                        "another request received for dataset that is still being looked up ",
+                        extra={"requestId": str(request_id)},
+                    )
+                    request_rec.status = TransformStatus.pending_lookup
 
             # start transformers independently of the state of dataset.
             if current_app.config["TRANSFORMER_MANAGER_ENABLED"]:

--- a/servicex_app/servicex_app_test/resources/transformation/test_submit.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_submit.py
@@ -143,7 +143,11 @@ class TestSubmitTransformationRequest(ResourceTestBase):
         response = client.post("/servicex/transformation", json=request)
         assert response.status_code == 400
 
-    def test_submit_transformation_bad_did_scheme(self, client):
+    def test_submit_transformation_bad_did_scheme(self, mock_codegen):
+        client = self._test_client(
+            code_gen_service=mock_codegen,
+        )
+
         request = self._generate_transformation_request(did="foobar://my-did")
         response = client.post("/servicex/transformation", json=request)
         assert response.status_code == 400
@@ -456,14 +460,16 @@ class TestSubmitTransformationRequest(ResourceTestBase):
             )
             assert response.status_code == 500
 
-    def test_submit_transformation_missing_dataset_source(self, client):
+    def test_submit_transformation_missing_dataset_source(self, mock_codegen):
+        client = self._test_client(code_gen_service=mock_codegen)
         request = self._generate_transformation_request()
         request["did"] = None
         request["file-list"] = []
         response = client.post("/servicex/transformation", json=request)
         assert response.status_code == 400
 
-    def test_submit_transformation_duplicate_dataset_source(self, client):
+    def test_submit_transformation_duplicate_dataset_source(self, mock_codegen):
+        client = self._test_client(code_gen_service=mock_codegen)
         request = self._generate_transformation_request()
         request["did"] = "This did"
         request["file-list"] = ["file1.root", "file2.root"]
@@ -598,8 +604,8 @@ class TestSubmitTransformationRequest(ResourceTestBase):
 
         mock_code_gen = mocker.MagicMock(CodeGenAdapter)
 
-        def _side_effect(request_rec, namespace, codegen_name):
-            selection = json.loads(request_rec.selection)
+        def _side_effect(selection_string, request_id, namespace, user_codegen_name):
+            selection = json.loads(selection_string)
             selection_image = selection["image"]
 
             return (

--- a/servicex_app/servicex_app_test/test_code_gen_adapter.py
+++ b/servicex_app/servicex_app_test/test_code_gen_adapter.py
@@ -29,44 +29,46 @@ import pytest
 from servicex_app.code_gen_adapter import CodeGenAdapter
 from servicex_app.models import TransformRequest
 
+CODE_GEN_SERVICE_URLS = {
+    "uproot": "http://localhost:8000",
+    "xAOD": "http://localhost:8000",
+    "python": "http://localhost:8000",
+}
+
+
+@pytest.fixture
+def mock_transformer_manager(mocker):
+    return mocker.MagicMock()
+
+
+@pytest.fixture
+def transform_request():
+    request = TransformRequest()
+    request.request_id = "462-33"
+    request.selection = "test-string"
+    return request
+
 
 class TestCodeGenAdapter:
-    code_gen_service_urls = {
-        "uproot": "http://localhost:8000",
-        "xAOD": "http://localhost:8000",
-        "python": "http://localhost:8000",
-    }
+    def test_init(self, mock_transformer_manager):
+        service = CodeGenAdapter(CODE_GEN_SERVICE_URLS, mock_transformer_manager)
+        assert service.code_gen_service_urls == CODE_GEN_SERVICE_URLS
 
-    def _generate_test_request(self):
-        transform_request = TransformRequest()
-        transform_request.request_id = "462-33"
-        transform_request.selection = "test-string"
-        return transform_request
-
-    def test_init(self, mocker):
-        mock_transformer_manager = mocker.MagicMock()
-        service = CodeGenAdapter(self.code_gen_service_urls, mock_transformer_manager)
-        assert service.code_gen_service_urls == self.code_gen_service_urls
-
-    def test_generate_code_for_selection(self, mocker):
-
+    def test_generate_code_for_selection(
+        self, mocker, mock_transformer_manager, transform_request
+    ):
         mock_response = mocker.MagicMock()
         mock_response.status_code = 200
-
         mock_requests_post = mocker.patch("requests.post", return_value=mock_response)
 
         mock_parts = mocker.MagicMock()
         mock_transformer_image_part = mocker.MagicMock()
         mock_transformer_image_part.text = "my-transformer:test"
-
         mock_transformer_language_part = mocker.MagicMock()
         mock_transformer_language_part.text = "scala"
-
         mock_transformer_command_part = mocker.MagicMock()
         mock_transformer_command_part.text = "echo hello, world"
-
         mock_zip_part = mocker.MagicMock()
-
         mock_parts.parts = [
             mock_transformer_image_part,
             mock_transformer_language_part,
@@ -77,51 +79,59 @@ class TestCodeGenAdapter:
             "servicex_app.code_gen_adapter.decoder.MultipartDecoder.from_response",
             return_value=mock_parts,
         )
-
-        mock_transformer_manager = mocker.MagicMock()
         mock_zip = mocker.patch("zipfile.ZipFile")
         mocker.patch("io.BytesIO")
 
-        code_gen = CodeGenAdapter(self.code_gen_service_urls, mock_transformer_manager)
+        code_gen = CodeGenAdapter(CODE_GEN_SERVICE_URLS, mock_transformer_manager)
         config_map, transformer_image, transformer_language, transformer_command = (
             code_gen.generate_code_for_selection(
-                self._generate_test_request(), "servicex", "uproot"
+                transform_request.selection,
+                transform_request.request_id,
+                "servicex",
+                "uproot",
             )
         )
 
         assert transformer_image == "my-transformer:test"
         assert transformer_language == "scala"
         assert transformer_command == "echo hello, world"
-
         mock_requests_post.assert_called()
         mock_transformer_manager.create_configmap_from_zip.assert_called_with(
             mock_zip(), "462-33", "servicex"
         )
 
-    def test_generate_code_bad_response(self, mocker):
+    def test_generate_code_bad_response(
+        self, mocker, mock_transformer_manager, transform_request
+    ):
         mock_response = mocker.MagicMock()
         mock_response.status_code = 500
         mock_response.json = mocker.MagicMock(return_value={"Message": "Ooops"})
         mocker.patch("requests.post", return_value=mock_response)
-        mock_transformer_manager = mocker.MagicMock()
-        service = CodeGenAdapter(self.code_gen_service_urls, mock_transformer_manager)
+        service = CodeGenAdapter(CODE_GEN_SERVICE_URLS, mock_transformer_manager)
 
         with pytest.raises(ValueError) as eek:
             service.generate_code_for_selection(
-                self._generate_test_request(), "servicex", "uproot"
+                transform_request.selection,
+                transform_request.request_id,
+                "servicex",
+                "uproot",
             )
         assert str(eek.value) == "Failed to generate translation code: Ooops"
 
-    def test_wrong_user_input_codegen(self, mocker):
+    def test_wrong_user_input_codegen(
+        self, mocker, mock_transformer_manager, transform_request
+    ):
         mock_response = mocker.MagicMock()
         mock_response.status_code = 500
         mock_response.json = mocker.MagicMock(return_value={"Message": "Ooops"})
         mocker.patch("requests.post", return_value=mock_response)
-        mock_transformer_manager = mocker.MagicMock()
-        service = CodeGenAdapter(self.code_gen_service_urls, mock_transformer_manager)
+        service = CodeGenAdapter(CODE_GEN_SERVICE_URLS, mock_transformer_manager)
 
         with pytest.raises(ValueError) as eek:
             service.generate_code_for_selection(
-                self._generate_test_request(), "servicex", "foo"
+                transform_request.selection,
+                transform_request.request_id,
+                "servicex",
+                "foo",
             )
         assert str(eek.value) == "foo, code generator unavailable for use"

--- a/servicex_app/servicex_app_test/test_dataset_manager.py
+++ b/servicex_app/servicex_app_test/test_dataset_manager.py
@@ -94,9 +94,10 @@ class TestDatasetManager(ResourceTestBase):
     def test_from_new_did(self, client):
         did = "rucio://my-did?files=1"
         with client.application.app_context():
-            dm = DatasetManager.from_did(
-                DIDParser(did), logger=client.application.logger, db=db
-            )
+            with db.session.begin():
+                dm = DatasetManager.from_did(
+                    DIDParser(did), logger=client.application.logger, db=db
+                )
             assert dm.dataset.name == did
             assert dm.dataset.did_finder == "rucio"
             assert dm.dataset.lookup_status == DatasetStatus.created
@@ -125,7 +126,7 @@ class TestDatasetManager(ResourceTestBase):
             assert dm.dataset.did_finder == "rucio"
             assert dm.dataset.lookup_status == DatasetStatus.looking
             assert dm.dataset.id == d.id
-            assert dm.dataset.last_used > datetime.fromtimestamp(0)
+            assert dm.dataset.last_used > datetime.fromtimestamp(0, tz=timezone.utc)
 
     def test_from_new_file_list(self, client):
         file_list = [
@@ -133,9 +134,10 @@ class TestDatasetManager(ResourceTestBase):
             "root://eospublic.cern.ch/2.root",
         ]
         with client.application.app_context():
-            dm = DatasetManager.from_file_list(
-                file_list, logger=client.application.logger, db=db
-            )
+            with db.session.begin():
+                dm = DatasetManager.from_file_list(
+                    file_list, logger=client.application.logger, db=db
+                )
             assert (
                 dm.dataset.name
                 == "985d119e9da637c5b7f89c133f60689259f0fe5db0ee4b3d993270aafdc5b82a"
@@ -145,6 +147,7 @@ class TestDatasetManager(ResourceTestBase):
 
             # See that the dataset is saved to the database
             assert dm.dataset.id is not None
+
             d_copy = Dataset.find_by_id(dm.dataset.id)
             assert d_copy
             assert (
@@ -177,7 +180,7 @@ class TestDatasetManager(ResourceTestBase):
             assert dm.dataset.did_finder == "user"
             assert dm.dataset.lookup_status == DatasetStatus.created
             assert dm.dataset.id == d.id
-            assert dm.dataset.last_used > datetime.fromtimestamp(0)
+            assert dm.dataset.last_used > datetime.fromtimestamp(0, tz=timezone.utc)
 
     def test_from_dataset_id(self, client):
         file_list = [
@@ -274,11 +277,12 @@ class TestDatasetManager(ResourceTestBase):
 
     def test_refresh(self, client):
         with client.application.app_context():
-            dm = DatasetManager.from_did(
-                DIDParser("rucio://my-did?files=1"),
-                logger=client.application.logger,
-                db=db,
-            )
+            with db.session.begin():
+                dm = DatasetManager.from_did(
+                    DIDParser("rucio://my-did?files=1"),
+                    logger=client.application.logger,
+                    db=db,
+                )
 
             # To be fair, this test isn't really  verifying the refresh method, since
             # SQLAlchemy is serving the dataset instance out of a shared cache
@@ -305,11 +309,12 @@ class TestDatasetManager(ResourceTestBase):
     def test_submit_lookup_request(self, mocker, client):
         mock_celery = mocker.Mock()
         with client.application.app_context():
-            d = DatasetManager.from_did(
-                did=DIDParser("rucio://my-did?files=1"),
-                logger=client.application.logger,
-                db=db,
-            )
+            with db.session.begin():
+                d = DatasetManager.from_did(
+                    did=DIDParser("rucio://my-did?files=1"),
+                    logger=client.application.logger,
+                    db=db,
+                )
             d.submit_lookup_request("http://hit-me/here", mock_celery)
 
             assert d.dataset.lookup_status == DatasetStatus.looking
@@ -350,29 +355,29 @@ class TestDatasetManager(ResourceTestBase):
             )
 
     def test_add_files(self, mocker, client, celery_worker):
+        mock_publisher = mocker.patch(
+            "servicex_app.celery.server_tasks.add_files_to_processing_queue"
+        )
+
+        file_list = [
+            "root://eospublic.cern.ch/1.root",
+            "root://eospublic.cern.ch/2.root",
+        ]
+        first_request = self._generate_transform_request()
+        first_request.request_id = "first_request"
+        first_request.files = 2
+
+        second_request = self._generate_transform_request()
+        second_request.request_id = "second_request"
+        second_request.files = 2
         with client.application.app_context():
-            mock_publisher = mocker.patch(
-                "servicex_app.celery.server_tasks.add_files_to_processing_queue"
-            )
-
-            file_list = [
-                "root://eospublic.cern.ch/1.root",
-                "root://eospublic.cern.ch/2.root",
-            ]
-            first_request = self._generate_transform_request()
-            first_request.request_id = "first_request"
-            first_request.files = 2
-
-            second_request = self._generate_transform_request()
-            second_request.request_id = "second_request"
-            second_request.files = 2
-
-            d = DatasetManager.from_file_list(
-                file_list,
-                logger=client.application.logger,
-                extras={"request_id": first_request.request_id},
-                db=db,
-            )
+            with db.session.begin():
+                d = DatasetManager.from_file_list(
+                    file_list,
+                    logger=client.application.logger,
+                    extras={"request_id": first_request.request_id},
+                    db=db,
+                )
             first_request.did_id = d.id
             second_request.did_id = d.id
 


### PR DESCRIPTION
Previously the submit endpoint opened implicit SQLAlchemy transactions the moment it touched any model attribute, then held those transactions open across slow external I/O (HTTP calls to the code-generation service and the Docker registry).  This caused unnecessary lock contention and left connections checked out from the pool for the full duration of every submit request.

Root cause
----------
`SubmitTransformationRequest.post()` performed the following steps inside a single, implicit transaction:

1. Created/fetched the Dataset record and called `dataset.save_to_db()`.
2. Built a `TransformRequest` object, then called `request_rec.save_to_db()`.
3. Made an HTTP POST to the code-gen service (`generate_code_for_selection`).
4. Optionally made another HTTP call to validate the transformer Docker image.
5. Called `db.session.commit()`.

Steps 3–4 could take several seconds; the DB connection (and any row-level locks) was held for that entire window.

Fix
---
Restructured the submit flow so that all external I/O happens *before* any database transaction is opened:

1. **Code generation first (no transaction)** – Call `generate_code_for_selection` before touching the DB.  The method signature was also simplified: instead of receiving a full `TransformRequest` ORM object, it now accepts the two primitive values it actually needs (`selection_string` and `request_id`), removing the hidden coupling to the model and making it possible to call this outside of the DB Transaction.

2. **Docker image validation (no transaction)** – The image-existence check remains outside any transaction.

3. **Object-store bucket creation (no transaction)** – Unchanged in position; still outside the transaction block.

4. **Transaction 1 – persist Dataset** – A short `with session.begin()` block calls `_initialize_dataset_manager`, which now calls `db.session.add(dataset)` instead of `dataset.save_to_db()`.  The context manager commits immediately on exit, assigning the auto-increment `dataset.id` before it is referenced by the TransformRequest.

5. **Transaction 2 – persist TransformRequest** – A second `with session.begin()` block builds and adds the `TransformRequest` using all values already computed in step 1 (image, language, command, configmap name).  Status routing (lookup / running / pending_lookup) and the Celery DID-finder submission also happen inside this transaction, so the request is never visible to other readers in an inconsistent state.

`dataset_manager.py` changes
-----------------------------
Removed the individual `save_to_db()` calls that were scattered through `from_did` and `from_file_list`.  Both paths now call `db.session.add(dataset)` once at the end of the method, letting the *caller's* transaction boundary control the commit.

Test updates
------------
* Updated `test_code_gen_adapter.py` to pass `selection_string` and `request_id` as keyword arguments instead of a `TransformRequest` object.
* Updated `test_dataset_manager.py` to wrap `from_did` / `from_file_list` calls in `with db.session.begin()` blocks, matching the new requirement that callers own the transaction.
* Fixed two timezone-aware comparison assertions that were failing with Python's `datetime.fromtimestamp(0)` (now uses `tz=timezone.utc`).
* Fixed three submit tests (`test_submit_transformation_bad_did_scheme`, `test_submit_transformation_missing_dataset_source`, `test_submit_transformation_duplicate_dataset_source`) that failed because code-gen is now called before the dataset path, so a `mock_codegen` fixture is required even for tests that exercise dataset-validation errors.