### PR TITLE
Accept multiple result reports

### DIFF
--- a/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
+++ b/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
@@ -19,7 +19,7 @@
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# FOR ANY DIresultT, INDIresultT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
 # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
@@ -30,6 +30,7 @@ import time
 from datetime import datetime, timezone
 from functools import wraps
 from logging import Logger
+from typing import Optional
 
 from flask import current_app, request
 from sqlalchemy.exc import IntegrityError
@@ -109,18 +110,16 @@ class TransformerFileComplete(ServiceXResource):
         try:
             session = db.session
 
-            try:
-                # Add the transformation result to the database and verify that
-                # we've not processed this file already
-                self.save_transform_result(request_id, info, session)
-            except IntegrityError:
-                logger.warning("Ignoring duplicate result report", extra=log_extra)
-                return "Ignoring duplicate result report", 200
+            # Add the transformation result to the database and check if
+            # we've processed this file already (return value will be True if so)
+            if orig_counts := self.save_transform_result(request_id, info, session):
+                logger.warning("Duplicate result report", extra=(log_extra |
+                               {"new_info": info, "old_info": orig_counts}))
 
             # Lookup the transformation request and increment either the successful
             # or failed file count
             transform_req = self.record_file_complete(
-                session, current_app.logger, request_id, info, log_extra
+                session, current_app.logger, request_id, info, log_extra, orig_counts
             )
 
             if transform_req is None:
@@ -165,6 +164,7 @@ class TransformerFileComplete(ServiceXResource):
         request_id: str,
         info: dict[str, str],
         log_extra: dict[str, str],
+        orig_counts: Optional[dict[str, str]]
     ) -> TransformRequest | None:
 
         with session.begin():
@@ -180,6 +180,19 @@ class TransformerFileComplete(ServiceXResource):
                 msg = f"Request not found with id: '{request_id}'"
                 logger.error(msg, extra=log_extra)
                 return None
+
+            if orig_counts:
+                # undo previous statistics accumulation
+                if orig_counts["status"] == "success":
+                    transform_req.files_completed -= 1
+                    if transform_req.total_events is None:
+                        logger.warning("Previous successful file registration, "
+                                       "but no total events in transform")
+                    else:
+                        transform_req.total_events -= orig_counts["total-events"]
+                        transform_req.total_bytes -= orig_counts["total-bytes"]
+                else:
+                    transform_req.files_failed -= 1
 
             if info["status"] == "success":
                 transform_req.files_completed += 1
@@ -198,18 +211,38 @@ class TransformerFileComplete(ServiceXResource):
     @file_complete_ops_retry
     def save_transform_result(request_id: str, info: dict[str, str], session: Session):
         with session.begin():
-            rec = TransformationResult(
-                file_id=info["file-id"],
-                request_id=request_id,
-                file_path=info["file-path"],
-                transform_status=info["status"],
-                transform_time=info["total-time"],
-                total_bytes=info["total-bytes"],
-                total_events=info["total-events"],
-                avg_rate=info["avg-rate"],
-                s3_object_name=info["s3-object-name"],
+            orig_counts = None
+            result = (
+                session.query(TransformationResult)
+                .filter_by(request_id=request_id, file_id=info["file_id"])
+                .with_for_update()
+                .one_or_none()
             )
-            session.add(rec)
+            if result:
+                orig_counts = {"status": result.transform_status,
+                               "total-events": result.total_events,
+                               "total-bytes": result.total_bytes}
+                result.file_path = info["file-path"]
+                result.transform_status = info["status"]
+                result.transform_time = info["total-time"]
+                result.total_bytes = info["total-bytes"]
+                result.total_events = info["total-events"]
+                result.avg_rate = info["avg-rate"]
+                result.s3_object_name = info["s3-object-name"]
+            else:
+                result = TransformationResult(
+                    file_id=info["file-id"],
+                    request_id=request_id,
+                    file_path=info["file-path"],
+                    transform_status=info["status"],
+                    transform_time=info["total-time"],
+                    total_bytes=info["total-bytes"],
+                    total_events=info["total-events"],
+                    avg_rate=info["avg-rate"],
+                    s3_object_name=info["s3-object-name"],
+                )
+            session.add(result)
+        return orig_counts
 
     @staticmethod
     @file_complete_ops_retry

--- a/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
+++ b/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
@@ -216,9 +216,9 @@ class TransformerFileComplete(ServiceXResource):
     def save_transform_result(request_id: str, info: dict[str, str], session: Session):
         with session.begin():
             orig_counts = None
-            result = (
+            result: TransformationResult = (
                 session.query(TransformationResult)
-                .filter_by(request_id=request_id, file_id=info["file_id"])
+                .filter_by(request_id=request_id, file_id=info["file-id"])
                 .with_for_update()
                 .one_or_none()
             )

--- a/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
+++ b/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
@@ -113,8 +113,10 @@ class TransformerFileComplete(ServiceXResource):
             # Add the transformation result to the database and check if
             # we've processed this file already (return value will be True if so)
             if orig_counts := self.save_transform_result(request_id, info, session):
-                logger.warning("Duplicate result report", extra=(log_extra |
-                               {"new_info": info, "old_info": orig_counts}))
+                logger.warning(
+                    "Duplicate result report",
+                    extra=(log_extra | {"new_info": info, "old_info": orig_counts}),
+                )
 
             # Lookup the transformation request and increment either the successful
             # or failed file count
@@ -164,7 +166,7 @@ class TransformerFileComplete(ServiceXResource):
         request_id: str,
         info: dict[str, str],
         log_extra: dict[str, str],
-        orig_counts: Optional[dict[str, str]]
+        orig_counts: Optional[dict[str, str]],
     ) -> TransformRequest | None:
 
         with session.begin():
@@ -186,8 +188,10 @@ class TransformerFileComplete(ServiceXResource):
                 if orig_counts["status"] == "success":
                     transform_req.files_completed -= 1
                     if transform_req.total_events is None:
-                        logger.warning("Previous successful file registration, "
-                                       "but no total events in transform")
+                        logger.warning(
+                            "Previous successful file registration, "
+                            "but no total events in transform"
+                        )
                     else:
                         transform_req.total_events -= orig_counts["total-events"]
                         transform_req.total_bytes -= orig_counts["total-bytes"]
@@ -219,9 +223,11 @@ class TransformerFileComplete(ServiceXResource):
                 .one_or_none()
             )
             if result:
-                orig_counts = {"status": result.transform_status,
-                               "total-events": result.total_events,
-                               "total-bytes": result.total_bytes}
+                orig_counts = {
+                    "status": result.transform_status,
+                    "total-events": result.total_events,
+                    "total-bytes": result.total_bytes,
+                }
                 result.file_path = info["file-path"]
                 result.transform_status = info["status"]
                 result.transform_time = info["total-time"]

--- a/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
@@ -189,8 +189,13 @@ class TestTransformFileComplete(ResourceTestBase):
         trqmock.filter_by.assert_called_with(request_id="1234")
         assert fake_transform_request.files_completed == 1
         assert fake_transform_request.files_failed == 0
-        assert fake_transform_request.total_bytes == file_complete_response["total-bytes"]
-        assert fake_transform_request.total_events == file_complete_response["total-events"]
+        assert (
+            fake_transform_request.total_bytes == file_complete_response["total-bytes"]
+        )
+        assert (
+            fake_transform_request.total_events
+            == file_complete_response["total-events"]
+        )
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
         db_session.add.assert_called_once()
         assert db_session.add.call_args[0][0].file_id == 42
@@ -279,8 +284,9 @@ class TestTransformFileComplete(ResourceTestBase):
             json=file_complete_response,
         )
 
-        assert fake_transform_request.total_bytes == (orig_total_bytes 
-                                                      + file_complete_response["total-bytes"])
+        assert fake_transform_request.total_bytes == (
+            orig_total_bytes + file_complete_response["total-bytes"]
+        )
 
         fake_transformation_result.total_bytes = file_complete_response["total-bytes"]
 
@@ -302,8 +308,9 @@ class TestTransformFileComplete(ResourceTestBase):
         assert fake_transform_request.files_completed == 7
         assert fake_transform_request.files_failed == 2
 
-        assert fake_transform_request.total_bytes == (orig_total_bytes 
-                                                      + file_complete_response["total-bytes"])
+        assert fake_transform_request.total_bytes == (
+            orig_total_bytes + file_complete_response["total-bytes"]
+        )
 
         assert db_session.add.call_count == 2
         assert isinstance(db_session.add.mock_calls[0][1][0], TransformationResult)
@@ -378,7 +385,9 @@ class TestTransformFileComplete(ResourceTestBase):
         trqmock.filter_by.assert_called_with(request_id="1234")
         assert fake_transform_request.files_completed == 6
         assert fake_transform_request.files_failed == 2
-        assert fake_transform_request.total_bytes == file_complete_response["total-bytes"]
+        assert (
+            fake_transform_request.total_bytes == file_complete_response["total-bytes"]
+        )
 
         assert db_session.add.call_count == 1
         assert isinstance(db_session.add.mock_calls[0][1][0], TransformationResult)

--- a/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
@@ -81,6 +81,7 @@ class TestTransformFileComplete(ResourceTestBase):
                 return trqmock
             else:
                 return othermock
+
         db_session.query.side_effect = switcher
         return trqmock.filter_by.return_value.with_for_update.return_value.one_or_none
 
@@ -223,8 +224,9 @@ class TestTransformFileComplete(ResourceTestBase):
             json=file_complete_response,
         )
 
-        othermock.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = \
+        othermock.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = (
             fake_transformation_result
+        )
 
         response2 = test_client.put(
             "/servicex/internal/transformation/1234/file-complete",
@@ -256,7 +258,9 @@ class TestTransformFileComplete(ResourceTestBase):
         file_complete_response,
         test_client,
     ):
-        trqmock.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = None
+        trqmock.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = (
+            None
+        )
         response = test_client.put(
             "/servicex/internal/transformation/1234/file-complete",
             json=file_complete_response,

--- a/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
@@ -28,7 +28,6 @@
 
 import psycopg2
 import pytest
-from sqlalchemy.exc import IntegrityError
 
 from servicex_app.models import TransformationResult, TransformRequest, TransformStatus
 from servicex_app.transformer_manager import TransformerManager
@@ -60,13 +59,30 @@ class TestTransformFileComplete(ResourceTestBase):
         return fake_request
 
     @pytest.fixture
-    def mock_transform_request_lookup(self, mocker, db_session, fake_transform_request):
-        db_session.query.return_value.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = (  # noqa: E501
+    def trqmock(self, mocker, fake_transform_request):
+        rv = mocker.Mock()
+        rv.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = (  # noqa: E501
             fake_transform_request
         )
-        return (
-            db_session.query.return_value.filter_by.return_value.with_for_update.return_value.one_or_none  # noqa: E501
+        return rv
+
+    @pytest.fixture
+    def othermock(self, mocker):
+        rv = mocker.Mock()
+        rv.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = (  # noqa: E501
+            None
         )
+        return rv
+
+    @pytest.fixture
+    def mock_transform_request_lookup(self, db_session, trqmock, othermock):
+        def switcher(cls):
+            if cls == TransformRequest:
+                return trqmock
+            else:
+                return othermock
+        db_session.query.side_effect = switcher
+        return trqmock.filter_by.return_value.with_for_update.return_value.one_or_none
 
     @pytest.fixture
     def test_client(self, mock_transformer_manager):
@@ -86,10 +102,24 @@ class TestTransformFileComplete(ResourceTestBase):
             "s3-object-name": "file://s3-object-name",
         }
 
+    @pytest.fixture
+    def fake_transformation_result(self):
+        return TransformationResult(
+            file_path="/foo/bar.root",
+            file_id=42,
+            transform_status="success",
+            transform_time=100,
+            total_events=10000,
+            total_bytes=325684,
+            avg_rate=30.2,
+            s3_object_name="file://s3-object-name",
+        )
+
     def test_put_transform_file_complete_files_remaining(
         self,
         mock_transformer_manager,
         db_session,
+        trqmock,
         mock_transform_request_lookup,
         fake_transform_request,
         file_complete_response,
@@ -103,7 +133,7 @@ class TestTransformFileComplete(ResourceTestBase):
         )
         assert response.status_code == 200
         assert fake_transform_request.finish_time is None
-        db_session.query.return_value.filter_by.assert_called_with(request_id="1234")
+        trqmock.filter_by.assert_called_with(request_id="1234")
         assert fake_transform_request.files_completed == 1
         assert fake_transform_request.files_failed == 2
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
@@ -114,6 +144,7 @@ class TestTransformFileComplete(ResourceTestBase):
         self,
         mock_transformer_manager,
         db_session,
+        trqmock,
         mock_transform_request_lookup,
         fake_transform_request,
         file_complete_response,
@@ -129,7 +160,7 @@ class TestTransformFileComplete(ResourceTestBase):
         )
         assert response.status_code == 200
         assert fake_transform_request.finish_time is None
-        db_session.query.return_value.filter_by.assert_called_with(request_id="1234")
+        trqmock.filter_by.assert_called_with(request_id="1234")
         assert fake_transform_request.files_completed == 1
         assert fake_transform_request.files_failed == 2
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
@@ -140,6 +171,7 @@ class TestTransformFileComplete(ResourceTestBase):
         self,
         mock_transformer_manager,
         db_session,
+        trqmock,
         mock_transform_request_lookup,
         fake_transform_request,
         file_complete_response,
@@ -154,7 +186,7 @@ class TestTransformFileComplete(ResourceTestBase):
         )
 
         assert response.status_code == 200
-        db_session.query.return_value.filter_by.assert_called_with(request_id="1234")
+        trqmock.filter_by.assert_called_with(request_id="1234")
         assert fake_transform_request.files_completed == 8
         assert fake_transform_request.files_failed == 2
 
@@ -175,26 +207,24 @@ class TestTransformFileComplete(ResourceTestBase):
         mocker,
         mock_transformer_manager,
         db_session,
+        trqmock,
+        othermock,
         mock_transform_request_lookup,
         fake_transform_request,
+        fake_transformation_result,
         file_complete_response,
         test_client,
     ):
         fake_transform_request.files_completed = 6
         fake_transform_request.files_failed = 2
-        db_session.add.side_effect = [
-            None,
-            IntegrityError(
-                "duplicate key value violates unique constraint",
-                params=["request_id"],
-                orig=Exception(),
-            ),
-        ]
 
         response1 = test_client.put(
             "/servicex/internal/transformation/1234/file-complete",
             json=file_complete_response,
         )
+
+        othermock.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = \
+            fake_transformation_result
 
         response2 = test_client.put(
             "/servicex/internal/transformation/1234/file-complete",
@@ -204,7 +234,7 @@ class TestTransformFileComplete(ResourceTestBase):
         assert response1.status_code == 200
         assert response2.status_code == 200
 
-        db_session.query.return_value.filter_by.assert_called_with(request_id="1234")
+        trqmock.filter_by.assert_called_with(request_id="1234")
         assert fake_transform_request.files_completed == 7
         assert fake_transform_request.files_failed == 2
 
@@ -220,19 +250,20 @@ class TestTransformFileComplete(ResourceTestBase):
         self,
         mock_transformer_manager,
         db_session,
+        trqmock,
         mock_transform_request_lookup,
         fake_transform_request,
         file_complete_response,
         test_client,
     ):
-        mock_transform_request_lookup.return_value = None
+        trqmock.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = None
         response = test_client.put(
             "/servicex/internal/transformation/1234/file-complete",
             json=file_complete_response,
         )
 
         assert response.status_code == 404
-        db_session.query.return_value.filter_by.assert_called_with(request_id="1234")
+        trqmock.filter_by.assert_called_with(request_id="1234")
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
 
     def test_database_error_request_read(
@@ -240,12 +271,13 @@ class TestTransformFileComplete(ResourceTestBase):
         mocker,
         mock_transformer_manager,
         db_session,
+        trqmock,
         mock_transform_request_lookup,
         fake_transform_request,
         file_complete_response,
         test_client,
     ):
-        mock_transform_request_lookup.side_effect = [
+        trqmock.filter_by.return_value.with_for_update.return_value.one_or_none.side_effect = [
             psycopg2.OperationalError("server closed the connection unexpectedly"),
             fake_transform_request,
         ]
@@ -259,7 +291,7 @@ class TestTransformFileComplete(ResourceTestBase):
 
         # Verify that we retried after the database error
         assert mock_transform_request_lookup.call_count == 2
-        db_session.query.return_value.filter_by.assert_called_with(request_id="1234")
+        trqmock.filter_by.assert_called_with(request_id="1234")
 
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
 
@@ -267,6 +299,7 @@ class TestTransformFileComplete(ResourceTestBase):
         self,
         mock_transformer_manager,
         db_session,
+        trqmock,
         mock_transform_request_lookup,
         fake_transform_request,
         file_complete_response,
@@ -286,7 +319,7 @@ class TestTransformFileComplete(ResourceTestBase):
         assert fake_transform_request.finish_time is None
 
         # Verify that we retried after the database error
-        db_session.query.return_value.filter_by.assert_called_with(request_id="1234")
+        trqmock.filter_by.assert_called_with(request_id="1234")
 
         mock_transformer_manager.shutdown_transformer_job.assert_not_called()
 

--- a/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
@@ -141,6 +141,60 @@ class TestTransformFileComplete(ResourceTestBase):
         db_session.add.assert_called_once()
         assert db_session.add.call_args[0][0].file_id == 42
 
+    def test_put_transform_file_complete_failed_files_remaining(
+        self,
+        mock_transformer_manager,
+        db_session,
+        trqmock,
+        mock_transform_request_lookup,
+        fake_transform_request,
+        file_complete_response,
+        test_client,
+    ):
+        fake_transform_request.files_completed = 0
+        fake_transform_request.files_failed = 2
+        file_complete_response["status"] = "failed"
+        response = test_client.put(
+            "/servicex/internal/transformation/1234/file-complete",
+            json=file_complete_response,
+        )
+        assert response.status_code == 200
+        assert fake_transform_request.finish_time is None
+        trqmock.filter_by.assert_called_with(request_id="1234")
+        assert fake_transform_request.files_completed == 0
+        assert fake_transform_request.files_failed == 3
+        mock_transformer_manager.shutdown_transformer_job.assert_not_called()
+        db_session.add.assert_called_once()
+        assert db_session.add.call_args[0][0].file_id == 42
+
+    def test_put_transform_file_complete_first_file_files_remaining(
+        self,
+        mock_transformer_manager,
+        db_session,
+        trqmock,
+        mock_transform_request_lookup,
+        fake_transform_request,
+        file_complete_response,
+        test_client,
+    ):
+        fake_transform_request.files_completed = 0
+        fake_transform_request.files_failed = 0
+        fake_transform_request.total_bytes = None
+        fake_transform_request.total_events = None
+        response = test_client.put(
+            "/servicex/internal/transformation/1234/file-complete",
+            json=file_complete_response,
+        )
+        assert response.status_code == 200
+        trqmock.filter_by.assert_called_with(request_id="1234")
+        assert fake_transform_request.files_completed == 1
+        assert fake_transform_request.files_failed == 0
+        assert fake_transform_request.total_bytes == file_complete_response["total-bytes"]
+        assert fake_transform_request.total_events == file_complete_response["total-events"]
+        mock_transformer_manager.shutdown_transformer_job.assert_not_called()
+        db_session.add.assert_called_once()
+        assert db_session.add.call_args[0][0].file_id == 42
+
     def test_put_transform_file_complete_unknown_files_remaining(
         self,
         mock_transformer_manager,
@@ -219,14 +273,22 @@ class TestTransformFileComplete(ResourceTestBase):
         fake_transform_request.files_completed = 6
         fake_transform_request.files_failed = 2
 
+        orig_total_bytes = fake_transform_request.total_bytes
         response1 = test_client.put(
             "/servicex/internal/transformation/1234/file-complete",
             json=file_complete_response,
         )
 
+        assert fake_transform_request.total_bytes == (orig_total_bytes 
+                                                      + file_complete_response["total-bytes"])
+
+        fake_transformation_result.total_bytes = file_complete_response["total-bytes"]
+
         othermock.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = (
             fake_transformation_result
         )
+
+        file_complete_response["total-bytes"] += 1000
 
         response2 = test_client.put(
             "/servicex/internal/transformation/1234/file-complete",
@@ -240,13 +302,87 @@ class TestTransformFileComplete(ResourceTestBase):
         assert fake_transform_request.files_completed == 7
         assert fake_transform_request.files_failed == 2
 
+        assert fake_transform_request.total_bytes == (orig_total_bytes 
+                                                      + file_complete_response["total-bytes"])
+
         assert db_session.add.call_count == 2
         assert isinstance(db_session.add.mock_calls[0][1][0], TransformationResult)
         assert db_session.add.mock_calls[0][1][0].file_id == 42
 
-        assert db_session.add.call_count == 2
-        assert db_session.add.mock_calls[0][1][0].file_id == 42
         assert db_session.add.mock_calls[1][1][0].file_id == 42
+
+    def test_put_transform_file_complete_duplicate_report_previous_failure(
+        self,
+        mocker,
+        mock_transformer_manager,
+        db_session,
+        trqmock,
+        othermock,
+        mock_transform_request_lookup,
+        fake_transform_request,
+        fake_transformation_result,
+        file_complete_response,
+        test_client,
+    ):
+        fake_transform_request.files_completed = 6
+        fake_transform_request.files_failed = 2
+
+        fake_transformation_result.transform_status = "failure"
+        othermock.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = (
+            fake_transformation_result
+        )
+
+        response1 = test_client.put(
+            "/servicex/internal/transformation/1234/file-complete",
+            json=file_complete_response,
+        )
+
+        assert response1.status_code == 200
+
+        trqmock.filter_by.assert_called_with(request_id="1234")
+        assert fake_transform_request.files_completed == 7
+        assert fake_transform_request.files_failed == 1
+
+        assert db_session.add.call_count == 1
+        assert isinstance(db_session.add.mock_calls[0][1][0], TransformationResult)
+        assert db_session.add.mock_calls[0][1][0].file_id == 42
+
+    def test_put_transform_file_complete_duplicate_report_weird_transform_state(
+        self,
+        mocker,
+        mock_transformer_manager,
+        db_session,
+        trqmock,
+        othermock,
+        mock_transform_request_lookup,
+        fake_transform_request,
+        fake_transformation_result,
+        file_complete_response,
+        test_client,
+    ):
+        fake_transform_request.files_completed = 6
+        fake_transform_request.files_failed = 2
+        fake_transform_request.total_events = None
+
+        othermock.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = (
+            fake_transformation_result
+        )
+
+        response1 = test_client.put(
+            "/servicex/internal/transformation/1234/file-complete",
+            json=file_complete_response,
+        )
+
+        assert response1.status_code == 200
+
+        trqmock.filter_by.assert_called_with(request_id="1234")
+        assert fake_transform_request.files_completed == 6
+        assert fake_transform_request.files_failed == 2
+        assert fake_transform_request.total_bytes == file_complete_response["total-bytes"]
+
+        assert db_session.add.call_count == 1
+        assert isinstance(db_session.add.mock_calls[0][1][0], TransformationResult)
+        assert db_session.add.mock_calls[0][1][0].file_id == 42
 
     def test_put_transform_file_complete_unknown_request_id(
         self,


### PR DESCRIPTION
Retrying a transformation may result in an output with a different size (which then breaks file accounting and creates a mismatch with the file in S3). By the time the file is reported to the `servicex_app`, the result has already been uploaded to S3 so this is a fait accompli, so we might as well update the DB record for the file instead of whining about it. Addresses #1318.