### PR TITLE
Switch to combined ROOT+uproot image where relevant

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -55,8 +55,8 @@ codeGen:
     image: sslhep/servicex_code_gen_raw_uproot
     pullPolicy: Always
     tag: develop
-    defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
-    defaultScienceContainerTag: 5.6.9
+    defaultScienceContainerImage: sslhep/servicex_science_image_combined_root
+    defaultScienceContainerTag: 5.6.9-6.36.06
     compressionAlgorithm: ZSTD
     compressionLevel: 5
     resources:
@@ -76,8 +76,8 @@ codeGen:
     image: sslhep/servicex_code_gen_func_adl_uproot
     pullPolicy: Always
     tag: develop
-    defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
-    defaultScienceContainerTag: 5.6.9
+    defaultScienceContainerImage: sslhep/servicex_science_image_combined_root
+    defaultScienceContainerTag: 5.6.9-6.36.06
     resources:
       requests:
         cpu: 100m
@@ -95,8 +95,8 @@ codeGen:
     image: sslhep/servicex_code_gen_python
     pullPolicy: Always
     tag: develop
-    defaultScienceContainerImage: sslhep/servicex_func_adl_uproot_transformer
-    defaultScienceContainerTag: 5.6.9
+    defaultScienceContainerImage: sslhep/servicex_science_image_combined_root
+    defaultScienceContainerTag: 5.6.9-6.36.06
     resources:
       requests:
         cpu: 100m
@@ -114,8 +114,8 @@ codeGen:
     image: sslhep/servicex_code_gen_python
     pullPolicy: Always
     tag: develop
-    defaultScienceContainerImage: sslhep/servicex_science_image_root
-    defaultScienceContainerTag: 6.36.00
+    defaultScienceContainerImage: sslhep/servicex_science_image_combined_root
+    defaultScienceContainerTag: 5.6.9-6.36.06
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
We have a new `pixi`-based science image which allows us to combine ROOT+uproot (and also includes a few other things like `pandas`). This enables e.g. `RDataFrame` bridging to awkward arrays. The new science container also reduces maintenance complexity since it is Alma 9-based unlike the Ubuntu-based uproot-only images.