### PR TITLE
Fix error in job submission

### DIFF
--- a/servicex_app/servicex_app/resources/transformation/submit.py
+++ b/servicex_app/servicex_app/resources/transformation/submit.py
@@ -275,6 +275,8 @@ class SubmitTransformationRequest(ServiceXResource):
                     transformer_command=transformer_command,
                     generated_code_cm=generated_code_cm,
                     files=0,
+                    files_completed=0,
+                    files_failed=0,
                 )
 
                 session.add(request_rec)


### PR DESCRIPTION
#1324 refactored code so that the created `TransformRequest` for a submission was not saved to the database before being used to dispatch available files. However that saving set the values of `files_completed` and `files_failed`, which otherwise are `None`, causing the computation of `files_remaining` in the JSON serialization to fail.