### PR TITLE
Protect against possible race condition if dataset is empty

### DIFF
--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -34,6 +34,8 @@ from kubernetes.client.rest import ApiException
 from typing import Optional
 import time
 import urllib3
+from tenacity import (Retrying, RetryError, stop_after_attempt, wait_random_exponential,
+                      retry_if_exception_type)
 
 from servicex_app.models import TransformRequest, TransformStatus
 
@@ -551,39 +553,60 @@ class TransformerManager:
         try:
             if current_app.config["TRANSFORMER_AUTOSCALE_ENABLED"]:
                 autoscaler_api = kubernetes.client.AutoscalingV1Api()
-                autoscaler_api.delete_namespaced_horizontal_pod_autoscaler(
-                    name="transformer-" + request_id, namespace=namespace
-                )
-        except ApiException:
+                try:
+                    for attempt in Retrying(wait=wait_random_exponential(max=60),
+                                            stop=stop_after_attempt(3),
+                                            retry=retry_if_exception_type(ApiException)):
+                        with attempt:
+                            autoscaler_api.delete_namespaced_horizontal_pod_autoscaler(
+                                name="transformer-" + request_id, namespace=namespace
+                            )
+                except RetryError as e:
+                    e.reraise()
+        except ApiException as e:
             if not quiet_errors:
                 current_app.logger.exception(
                     "Exception during Job HPA Shut Down",
-                    extra={"requestId": request_id},
+                    extra={"requestId": request_id, "status_code": e.status},
                 )
 
         try:
             api_core = client.CoreV1Api()
             configmap_name = "{}-generated-source".format(request_id)
-            api_core.delete_namespaced_config_map(
-                name=configmap_name, namespace=namespace
-            )
-        except ApiException:
+            try:
+                for attempt in Retrying(wait=wait_random_exponential(max=60),
+                                        stop=stop_after_attempt(3),
+                                        retry=retry_if_exception_type(ApiException)):
+                    with attempt:
+                        api_core.delete_namespaced_config_map(
+                            name=configmap_name, namespace=namespace
+                        )
+            except RetryError as e:
+                e.reraise()
+        except ApiException as e:
             if not quiet_errors:
                 current_app.logger.exception(
                     "Exception during Job ConfigMap cleanup",
-                    extra={"requestId": request_id},
+                    extra={"requestId": request_id, "status_code": e.status},
                 )
 
         try:
             api_v1 = client.AppsV1Api()
-            api_v1.delete_namespaced_deployment(
-                name="transformer-" + request_id, namespace=namespace
-            )
-        except ApiException:
+            try:
+                for attempt in Retrying(wait=wait_random_exponential(max=60),
+                                        stop=stop_after_attempt(3),
+                                        retry=retry_if_exception_type(ApiException)):
+                    with attempt:
+                        api_v1.delete_namespaced_deployment(
+                            name="transformer-" + request_id, namespace=namespace
+                        )
+            except RetryError as e:
+                e.reraise()
+        except ApiException as e:
             if not quiet_errors:
                 current_app.logger.exception(
                     "Exception during Job Deployment Shut Down",
-                    extra={"requestId": request_id},
+                    extra={"requestId": request_id, "status_code": e.status},
                 )
 
         # delete RabbitMQ queue

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -571,6 +571,25 @@ class TransformerManager:
                 )
 
         try:
+            api_v1 = client.AppsV1Api()
+            try:
+                for attempt in Retrying(wait=wait_random_exponential(max=60),
+                                        stop=stop_after_attempt(3),
+                                        retry=retry_if_exception_type(ApiException)):
+                    with attempt:
+                        api_v1.delete_namespaced_deployment(
+                            name="transformer-" + request_id, namespace=namespace
+                        )
+            except RetryError as e:
+                e.reraise()
+        except ApiException as e:
+            if not quiet_errors:
+                current_app.logger.exception(
+                    "Exception during Job Deployment Shut Down",
+                    extra={"requestId": request_id, "status_code": e.status},
+                )
+
+        try:
             api_core = client.CoreV1Api()
             configmap_name = "{}-generated-source".format(request_id)
             try:
@@ -587,25 +606,6 @@ class TransformerManager:
             if not quiet_errors:
                 current_app.logger.exception(
                     "Exception during Job ConfigMap cleanup",
-                    extra={"requestId": request_id, "status_code": e.status},
-                )
-
-        try:
-            api_v1 = client.AppsV1Api()
-            try:
-                for attempt in Retrying(wait=wait_random_exponential(max=60),
-                                        stop=stop_after_attempt(3),
-                                        retry=retry_if_exception_type(ApiException)):
-                    with attempt:
-                        api_v1.delete_namespaced_deployment(
-                            name="transformer-" + request_id, namespace=namespace
-                        )
-            except RetryError as e:
-                e.reraise()
-        except ApiException as e:
-            if not quiet_errors:
-                current_app.logger.exception(
-                    "Exception during Job Deployment Shut Down",
                     extra={"requestId": request_id, "status_code": e.status},
                 )
 

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -34,8 +34,13 @@ from kubernetes.client.rest import ApiException
 from typing import Optional
 import time
 import urllib3
-from tenacity import (Retrying, RetryError, stop_after_attempt, wait_random_exponential,
-                      retry_if_exception_type)
+from tenacity import (
+    Retrying,
+    RetryError,
+    stop_after_attempt,
+    wait_random_exponential,
+    retry_if_exception_type,
+)
 
 from servicex_app.models import TransformRequest, TransformStatus
 
@@ -554,9 +559,11 @@ class TransformerManager:
             if current_app.config["TRANSFORMER_AUTOSCALE_ENABLED"]:
                 autoscaler_api = kubernetes.client.AutoscalingV1Api()
                 try:
-                    for attempt in Retrying(wait=wait_random_exponential(max=60),
-                                            stop=stop_after_attempt(3),
-                                            retry=retry_if_exception_type(ApiException)):
+                    for attempt in Retrying(
+                        wait=wait_random_exponential(max=60),
+                        stop=stop_after_attempt(3),
+                        retry=retry_if_exception_type(ApiException),
+                    ):
                         with attempt:
                             autoscaler_api.delete_namespaced_horizontal_pod_autoscaler(
                                 name="transformer-" + request_id, namespace=namespace
@@ -573,9 +580,11 @@ class TransformerManager:
         try:
             api_v1 = client.AppsV1Api()
             try:
-                for attempt in Retrying(wait=wait_random_exponential(max=60),
-                                        stop=stop_after_attempt(3),
-                                        retry=retry_if_exception_type(ApiException)):
+                for attempt in Retrying(
+                    wait=wait_random_exponential(max=60),
+                    stop=stop_after_attempt(3),
+                    retry=retry_if_exception_type(ApiException),
+                ):
                     with attempt:
                         api_v1.delete_namespaced_deployment(
                             name="transformer-" + request_id, namespace=namespace
@@ -593,9 +602,11 @@ class TransformerManager:
             api_core = client.CoreV1Api()
             configmap_name = "{}-generated-source".format(request_id)
             try:
-                for attempt in Retrying(wait=wait_random_exponential(max=60),
-                                        stop=stop_after_attempt(3),
-                                        retry=retry_if_exception_type(ApiException)):
+                for attempt in Retrying(
+                    wait=wait_random_exponential(max=60),
+                    stop=stop_after_attempt(3),
+                    retry=retry_if_exception_type(ApiException),
+                ):
                     with attempt:
                         api_core.delete_namespaced_config_map(
                             name=configmap_name, namespace=namespace

--- a/servicex_app/servicex_app_test/test_transformer_manager.py
+++ b/servicex_app/servicex_app_test/test_transformer_manager.py
@@ -722,13 +722,15 @@ class TestTransformerManager(ResourceTestBase):
         mock_api = mocker.MagicMock(kubernetes.client.AppsV1Api)
         mocker.patch.object(kubernetes.client, "AppsV1Api", return_value=mock_api)
         mock_api.delete_namespaced_deployment.side_effect = (
-            kubernetes.client.rest.ApiException(), None
+            kubernetes.client.rest.ApiException(),
+            None,
         )
 
         mock_core_api = mocker.MagicMock(kubernetes.client.CoreV1Api)
         mocker.patch.object(kubernetes.client, "CoreV1Api", return_value=mock_core_api)
         mock_core_api.delete_namespaced_config_map.side_effect = (
-            kubernetes.client.rest.ApiException(), None
+            kubernetes.client.rest.ApiException(),
+            None,
         )
 
         mock_autoscaling = mocker.Mock()
@@ -736,7 +738,8 @@ class TestTransformerManager(ResourceTestBase):
             kubernetes.client, "AutoscalingV1Api", return_value=mock_autoscaling
         )
         mock_autoscaling.delete_namespaced_horizontal_pod_autoscaler.side_effect = (
-            kubernetes.client.rest.ApiException(), None
+            kubernetes.client.rest.ApiException(),
+            None,
         )
 
         transformer = TransformerManager("external-kubernetes")
@@ -751,7 +754,10 @@ class TestTransformerManager(ResourceTestBase):
             transformer.shutdown_transformer_job("1234", "my-ns")
             assert mock_api.delete_namespaced_deployment.call_count == 2
             assert mock_core_api.delete_namespaced_config_map.call_count == 2
-            assert mock_autoscaling.delete_namespaced_horizontal_pod_autoscaler.call_count == 2
+            assert (
+                mock_autoscaling.delete_namespaced_horizontal_pod_autoscaler.call_count
+                == 2
+            )
             assert client.application.logger.exception.call_count == 0
 
     def test_shutdown_transformer_jobs_no_autoscaler(self, mocker):

--- a/servicex_app/servicex_app_test/test_transformer_manager.py
+++ b/servicex_app/servicex_app_test/test_transformer_manager.py
@@ -714,6 +714,46 @@ class TestTransformerManager(ResourceTestBase):
             )
         client.application.logger.exception.assert_not_called()
 
+    def test_shutdown_transformer_jobs_exceptions_once(self, mocker):
+        import kubernetes
+
+        mocker.patch.object(kubernetes.config, "load_kube_config")
+
+        mock_api = mocker.MagicMock(kubernetes.client.AppsV1Api)
+        mocker.patch.object(kubernetes.client, "AppsV1Api", return_value=mock_api)
+        mock_api.delete_namespaced_deployment.side_effect = (
+            kubernetes.client.rest.ApiException(), None
+        )
+
+        mock_core_api = mocker.MagicMock(kubernetes.client.CoreV1Api)
+        mocker.patch.object(kubernetes.client, "CoreV1Api", return_value=mock_core_api)
+        mock_core_api.delete_namespaced_config_map.side_effect = (
+            kubernetes.client.rest.ApiException(), None
+        )
+
+        mock_autoscaling = mocker.Mock()
+        mocker.patch.object(
+            kubernetes.client, "AutoscalingV1Api", return_value=mock_autoscaling
+        )
+        mock_autoscaling.delete_namespaced_horizontal_pod_autoscaler.side_effect = (
+            kubernetes.client.rest.ApiException(), None
+        )
+
+        transformer = TransformerManager("external-kubernetes")
+        transformer.persistent_volume_claim_exists = mocker.Mock(return_value=True)
+        transformer.celery_app.control.cancel_consumer = mocker.MagicMock()
+
+        client = self._test_client(transformation_manager=transformer)
+        client.application.logger = mocker.MagicMock()
+
+        # default mode with exceptions
+        with client.application.app_context():
+            transformer.shutdown_transformer_job("1234", "my-ns")
+            assert mock_api.delete_namespaced_deployment.call_count == 2
+            assert mock_core_api.delete_namespaced_config_map.call_count == 2
+            assert mock_autoscaling.delete_namespaced_horizontal_pod_autoscaler.call_count == 2
+            assert client.application.logger.exception.call_count == 0
+
     def test_shutdown_transformer_jobs_no_autoscaler(self, mocker):
         import kubernetes
 


### PR DESCRIPTION
It seems that it may be possible for k8s to have enough of a delay creating a transformer deployment that we could try to shut down a deployment for having zero files before the deployment is fully created. In that case we have deleted the configmap but not the deployment, and we have the appearance of a lingering deployment with no configmap, stuck forever in `ContainerCreating`. Add retries to all the shutdown commands; also try to delete the deployment before the configmap.