### PR TITLE
1339 logging metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,17 @@ repos:
     rev: "7.3.0"
     hooks:
       - id: flake8
+  - repo: local
+    hooks:
+      - id: check-log-extras
+        name: Validate logging extra= keys against schema
+        language: python
+        entry: python hooks/check_log_extras.py
+        types: [python]
+        args:
+          - --schema=logging_schema.json
+          # To also require extra= on every log call, uncomment:
+          # - --require-extras
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 26.3.1
     hooks:

--- a/did_finder_rucio/src/rucio_did_finder/lookup_request.py
+++ b/did_finder_rucio/src/rucio_did_finder/lookup_request.py
@@ -93,11 +93,13 @@ class LookupRequest:
         if n_files:
             avg_replicas = float(total_paths) / n_files
 
-        metric = {
-            "dataset_id": self.dataset_id,
-            "n_files": n_files,
-            "size": ds_size,
-            "avg_replicas": avg_replicas,
-            "lookup_duration": (lookup_finish - lookup_start).total_seconds(),
-        }
-        self.logger.info("Lookup finished. ", extra=metric)
+        self.logger.info(
+            "Lookup finished. ",
+            extra={
+                "dataset_id": self.dataset_id,
+                "num_files": n_files,
+                "dataset_size": ds_size,
+                "average_replicas": avg_replicas,
+                "lookup_duration": (lookup_finish - lookup_start).total_seconds(),
+            },
+        )

--- a/did_finder_xrootd/src/servicex_did_finder_xrootd/celery.py
+++ b/did_finder_xrootd/src/servicex_did_finder_xrootd/celery.py
@@ -68,7 +68,7 @@ def find_files(
     """
     __log.info(
         "DID Lookup request received.",
-        extra={"dataset_id": info["dataset-id"], "dataset": did_name},
+        extra={"dataset_id": info["dataset-id"], "dataset_name": did_name},
     )
 
     try:

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -49,6 +49,12 @@ ServiceX uses a slightly modified GitLab flow. Each repository has a main branch
     pip install pre-commit
     pre-commit install
     ```
+    - The pre-commit hook that validates `logging extra=` keys
+    (`hooks/check_log_extras.py`) has its own unit tests. They are discovered
+    automatically by `python -m pytest`, or you can run them in isolation with:
+    ```
+    python -m pytest hooks/
+    ```
 1. Develop your contribution:
     - Pull latest changes from upstream:
     ```

--- a/hooks/check_log_extras.py
+++ b/hooks/check_log_extras.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+"""Pre-commit hook: validate logging extra= keys against logging_schema.json."""
+import argparse
+import ast
+import json
+import sys
+from pathlib import Path
+
+LOG_METHODS = frozenset(
+    {"debug", "info", "warning", "warn", "error", "critical", "exception", "fatal", "log"}
+)
+
+
+def load_schema(schema_path: str) -> frozenset:
+    path = Path(schema_path)
+    if not path.exists():
+        print(f"check-log-extras: schema file not found: {schema_path}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        data = json.loads(path.read_text())
+        return frozenset(data["properties"].keys())
+    except (json.JSONDecodeError, KeyError) as exc:
+        print(f"check-log-extras: invalid schema file {schema_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _extract_literal_keys(node):
+    """Return a list of (key_str, lineno) for fully-literal extra= dicts, or None to skip."""
+    if isinstance(node, ast.Dict):
+        # Any spread (**x) means a None key in ast.Dict.keys
+        if any(k is None for k in node.keys):
+            return None
+        keys = []
+        for k in node.keys:
+            if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                keys.append((k.value, k.lineno))
+            else:
+                # Computed key (f-string, variable, etc.) — skip the whole dict
+                return None
+        return keys
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left = _extract_literal_keys(node.left)
+        right = _extract_literal_keys(node.right)
+        if left is None or right is None:
+            return None
+        return left + right
+    # Variable, call, ternary, etc. — skip
+    return None
+
+
+class LogExtraVisitor(ast.NodeVisitor):
+    def __init__(self, filepath: str, allowed_keys: frozenset, require_extras: bool):
+        self.filepath = filepath
+        self.allowed_keys = allowed_keys
+        self.require_extras = require_extras
+        self.errors: list[str] = []
+
+    def visit_Call(self, node: ast.Call):
+        if isinstance(node.func, ast.Attribute) and node.func.attr in LOG_METHODS:
+            extra_kw = next((kw for kw in node.keywords if kw.arg == "extra"), None)
+            if extra_kw is None:
+                if self.require_extras:
+                    self.errors.append(
+                        f"{self.filepath}:{node.lineno}: log call is missing extra="
+                    )
+            else:
+                keys = _extract_literal_keys(extra_kw.value)
+                if keys is not None:
+                    for key, lineno in keys:
+                        if key not in self.allowed_keys:
+                            self.errors.append(
+                                f"{self.filepath}:{lineno}: invalid logging extra key: '{key}'"
+                            )
+        self.generic_visit(node)
+
+
+def check_file(filepath: str, allowed_keys: frozenset, require_extras: bool) -> list[str]:
+    source = Path(filepath).read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=filepath)
+    except SyntaxError as exc:
+        print(f"check-log-extras: syntax error in {filepath}: {exc}", file=sys.stderr)
+        return []
+    visitor = LogExtraVisitor(filepath, allowed_keys, require_extras)
+    visitor.visit(tree)
+    return visitor.errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate logging extra= keys against schema.")
+    parser.add_argument(
+        "--schema",
+        default="logging_schema.json",
+        help="Path to logging_schema.json (default: logging_schema.json)",
+    )
+    parser.add_argument(
+        "--require-extras",
+        action="store_true",
+        help="Fail if any log call is missing extra=",
+    )
+    parser.add_argument("files", nargs="*", help="Python files to check")
+    args = parser.parse_args()
+
+    allowed_keys = load_schema(args.schema)
+    all_errors: list[str] = []
+    for filepath in args.files:
+        all_errors.extend(check_file(filepath, allowed_keys, args.require_extras))
+
+    for err in all_errors:
+        print(err)
+
+    sys.exit(1 if all_errors else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/check_log_extras.py
+++ b/hooks/check_log_extras.py
@@ -54,6 +54,7 @@ class LogExtraVisitor(ast.NodeVisitor):
         self.allowed_keys = allowed_keys
         self.require_extras = require_extras
         self.errors: list[str] = []
+        self.warnings: list[str] = []
 
     def visit_Call(self, node: ast.Call):
         if isinstance(node.func, ast.Attribute) and node.func.attr in LOG_METHODS:
@@ -65,7 +66,12 @@ class LogExtraVisitor(ast.NodeVisitor):
                     )
             else:
                 keys = _extract_literal_keys(extra_kw.value)
-                if keys is not None:
+                if keys is None:
+                    self.warnings.append(
+                        f"{self.filepath}:{extra_kw.value.lineno}: "
+                        f"extra= value is not a literal dict — skipping schema validation"
+                    )
+                else:
                     for key, lineno in keys:
                         if key not in self.allowed_keys:
                             self.errors.append(
@@ -74,16 +80,19 @@ class LogExtraVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
 
-def check_file(filepath: str, allowed_keys: frozenset, require_extras: bool) -> list[str]:
+def check_file(
+    filepath: str, allowed_keys: frozenset, require_extras: bool
+) -> tuple[list[str], list[str]]:
+    """Return (errors, warnings) for the given file."""
     source = Path(filepath).read_text(encoding="utf-8")
     try:
         tree = ast.parse(source, filename=filepath)
     except SyntaxError as exc:
         print(f"check-log-extras: syntax error in {filepath}: {exc}", file=sys.stderr)
-        return []
+        return [], []
     visitor = LogExtraVisitor(filepath, allowed_keys, require_extras)
     visitor.visit(tree)
-    return visitor.errors
+    return visitor.errors, visitor.warnings
 
 
 def main():
@@ -103,8 +112,14 @@ def main():
 
     allowed_keys = load_schema(args.schema)
     all_errors: list[str] = []
+    all_warnings: list[str] = []
     for filepath in args.files:
-        all_errors.extend(check_file(filepath, allowed_keys, args.require_extras))
+        errors, warnings = check_file(filepath, allowed_keys, args.require_extras)
+        all_errors.extend(errors)
+        all_warnings.extend(warnings)
+
+    for warning in all_warnings:
+        print(f"WARNING: {warning}", file=sys.stderr)
 
     for err in all_errors:
         print(err)

--- a/hooks/check_log_extras.py
+++ b/hooks/check_log_extras.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Pre-commit hook: validate logging extra= keys against logging_schema.json."""
+
 import argparse
 import ast
 import json
@@ -7,20 +8,35 @@ import sys
 from pathlib import Path
 
 LOG_METHODS = frozenset(
-    {"debug", "info", "warning", "warn", "error", "critical", "exception", "fatal", "log"}
+    {
+        "debug",
+        "info",
+        "warning",
+        "warn",
+        "error",
+        "critical",
+        "exception",
+        "fatal",
+        "log",
+    }
 )
 
 
 def load_schema(schema_path: str) -> frozenset:
     path = Path(schema_path)
     if not path.exists():
-        print(f"check-log-extras: schema file not found: {schema_path}", file=sys.stderr)
+        print(
+            f"check-log-extras: schema file not found: {schema_path}", file=sys.stderr
+        )
         sys.exit(1)
     try:
         data = json.loads(path.read_text())
         return frozenset(data["properties"].keys())
     except (json.JSONDecodeError, KeyError) as exc:
-        print(f"check-log-extras: invalid schema file {schema_path}: {exc}", file=sys.stderr)
+        print(
+            f"check-log-extras: invalid schema file {schema_path}: {exc}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 
@@ -96,7 +112,9 @@ def check_file(
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Validate logging extra= keys against schema.")
+    parser = argparse.ArgumentParser(
+        description="Validate logging extra= keys against schema."
+    )
     parser.add_argument(
         "--schema",
         default="logging_schema.json",

--- a/hooks/test_check_log_extras.py
+++ b/hooks/test_check_log_extras.py
@@ -1,0 +1,165 @@
+"""Tests for check_log_extras.py.
+
+Each test writes a small Python snippet to a temp file and calls check_file()
+directly, making it easy to see exactly what the hook accepts or rejects.
+"""
+
+import textwrap
+
+import pytest
+
+from check_log_extras import check_file
+
+# A small fixed set of allowed keys — tests don't depend on the real schema file.
+ALLOWED = frozenset({"request_id", "file_id", "dataset_id"})
+
+
+def make_py(tmp_path, code: str) -> str:
+    """Write dedented Python code to a temp file and return the path string."""
+    p = tmp_path / "sample.py"
+    p.write_text(textwrap.dedent(code))
+    return str(p)
+
+
+# ── accept cases ──────────────────────────────────────────────────────────────
+
+
+def test_valid_key_accepted(tmp_path):
+    path = make_py(
+        tmp_path,
+        """
+        logger.info("msg", extra={"request_id": "abc"})
+        """,
+    )
+    errors, warnings = check_file(path, ALLOWED, require_extras=False)
+    assert errors == []
+    assert warnings == []
+
+
+def test_multiple_valid_keys_accepted(tmp_path):
+    path = make_py(
+        tmp_path,
+        """
+        logger.info("msg", extra={"request_id": "abc", "file_id": 1})
+        """,
+    )
+    errors, warnings = check_file(path, ALLOWED, require_extras=False)
+    assert errors == []
+    assert warnings == []
+
+
+def test_no_extra_without_require_accepted(tmp_path):
+    path = make_py(
+        tmp_path,
+        """
+        logger.info("something happened")
+        """,
+    )
+    errors, warnings = check_file(path, ALLOWED, require_extras=False)
+    assert errors == []
+    assert warnings == []
+
+
+def test_pipe_merge_of_valid_dicts_accepted(tmp_path):
+    path = make_py(
+        tmp_path,
+        """
+        logger.info("msg", extra={"request_id": "x"} | {"file_id": 1})
+        """,
+    )
+    errors, warnings = check_file(path, ALLOWED, require_extras=False)
+    assert errors == []
+    assert warnings == []
+
+
+def test_variable_extra_emits_warning_not_error(tmp_path):
+    """A variable dict can't be validated statically — warn instead of failing."""
+    path = make_py(
+        tmp_path,
+        """
+        ctx = {"request_id": "x"}
+        logger.info("msg", extra=ctx)
+        """,
+    )
+    errors, warnings = check_file(path, ALLOWED, require_extras=False)
+    assert errors == []
+    assert len(warnings) == 1
+
+
+def test_spread_dict_emits_warning_not_error(tmp_path):
+    """A dict with **spread can't be validated statically — warn instead of failing."""
+    path = make_py(
+        tmp_path,
+        """
+        logger.info("msg", extra={**base, "request_id": "x"})
+        """,
+    )
+    errors, warnings = check_file(path, ALLOWED, require_extras=False)
+    assert errors == []
+    assert len(warnings) == 1
+
+
+# ── reject cases ──────────────────────────────────────────────────────────────
+
+
+def test_invalid_key_rejected(tmp_path):
+    path = make_py(
+        tmp_path,
+        """
+        logger.info("msg", extra={"bad_key": "oops"})
+        """,
+    )
+    errors, warnings = check_file(path, ALLOWED, require_extras=False)
+    assert len(errors) == 1
+    assert "bad_key" in errors[0]
+
+
+def test_missing_extra_rejected_when_required(tmp_path):
+    path = make_py(
+        tmp_path,
+        """
+        logger.info("something happened")
+        """,
+    )
+    errors, warnings = check_file(path, ALLOWED, require_extras=True)
+    assert len(errors) == 1
+    assert "missing extra=" in errors[0]
+
+
+def test_mixed_keys_only_invalid_ones_flagged(tmp_path):
+    path = make_py(
+        tmp_path,
+        """
+        logger.info("msg", extra={"request_id": "ok", "typo_key": "bad"})
+        """,
+    )
+    errors, warnings = check_file(path, ALLOWED, require_extras=False)
+    assert len(errors) == 1
+    assert "typo_key" in errors[0]
+
+
+def test_pipe_merge_with_invalid_key_rejected(tmp_path):
+    path = make_py(
+        tmp_path,
+        """
+        logger.info("msg", extra={"request_id": "x"} | {"bad_key": 1})
+        """,
+    )
+    errors, warnings = check_file(path, ALLOWED, require_extras=False)
+    assert len(errors) == 1
+    assert "bad_key" in errors[0]
+
+
+def test_multiple_violations_all_reported(tmp_path):
+    """Every bad call in a file is reported, not just the first."""
+    path = make_py(
+        tmp_path,
+        """
+        logger.info("one", extra={"bad_one": 1})
+        logger.debug("two", extra={"bad_two": 2})
+        """,
+    )
+    errors, warnings = check_file(path, ALLOWED, require_extras=False)
+    assert len(errors) == 2
+    assert any("bad_one" in e for e in errors)
+    assert any("bad_two" in e for e in errors)

--- a/hooks/test_check_log_extras.py
+++ b/hooks/test_check_log_extras.py
@@ -6,8 +6,6 @@ directly, making it easy to see exactly what the hook accepts or rejects.
 
 import textwrap
 
-import pytest
-
 from check_log_extras import check_file
 
 # A small fixed set of allowed keys — tests don't depend on the real schema file.

--- a/logging_schema.json
+++ b/logging_schema.json
@@ -4,19 +4,12 @@
   "properties": {
     "request_id": {
       "type": "string",
-      "description": "Core context — whenever available"
+      "description": "ServiceX request ID"
     },
-    "dataset_id": {
-      "type": "integer",
-      "description": "Core context — dataset record ID"
-    },
-    "file_id": {
-      "type": "integer",
-      "description": "Core context — file record ID"
-    },
+
     "place": {
       "type": "object",
-      "description": "Core context",
+      "description": "Location where the microservice is running.",
       "properties": {
         "host": { "type": "string" },
         "site": { "type": "string" },
@@ -24,7 +17,41 @@
       },
       "additionalProperties": false
     },
-    "file_path": {
+
+    "dataset_name": {
+      "type": "string",
+      "description": "Dataset-related - dataset name"
+    },
+    "dataset_id": {
+      "type": "integer",
+      "description": "Core context — dataset record ID"
+    },
+    "dataset_size": {
+      "type": "integer",
+      "description": "Dataset-related — dataset size in bytes"
+    },
+    "average_replicas": {
+      "type": "number",
+      "description": "Dataset-related — average number of replicas for files in dataset"
+    },
+    "lookup_duration": {
+      "type": "number",
+      "description": "Dataset-related — duration of lookup operation in seconds"
+    },
+    "file_id": {
+      "type": "integer",
+      "description": "Core context — file record ID"
+    },
+    "replicas": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Dataset-related — list of replica locations"
+    },
+    "result_path": {
+      "type": "string",
+      "description": "File-related — output path where file will be written"
+    },
+    "input_path": {
       "type": "string",
       "description": "File-related — input path being processed"
     },
@@ -60,13 +87,17 @@
       "type": "integer",
       "description": "Completion events — failed file counter"
     },
-    "error": {
+    "error_message": {
       "type": "string",
       "description": "Error/exception logs — message or repr"
     },
     "error_type": {
       "type": "string",
       "description": "Error/exception logs — error-category code"
+    },
+    "retry_status": {
+      "type": "string",
+      "description": "Error/exception logs — retry status from tenactiy"
     },
     "log_body": {
       "type": "string",
@@ -78,7 +109,7 @@
     },
     "num_files": {
       "type": "integer",
-      "description": "Queue context — number of files in a batch"
+      "description": "Number of files submitted for processing"
     },
     "metric": {
       "type": "object",

--- a/logging_schema.json
+++ b/logging_schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "request_id": {
+      "type": "string",
+      "description": "Core context — whenever available"
+    },
+    "dataset_id": {
+      "type": "integer",
+      "description": "Core context — dataset record ID"
+    },
+    "file_id": {
+      "type": "integer",
+      "description": "Core context — file record ID"
+    },
+    "place": {
+      "type": "object",
+      "description": "Core context",
+      "properties": {
+        "host": { "type": "string" },
+        "site": { "type": "string" },
+        "pod":  { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "file_path": {
+      "type": "string",
+      "description": "File-related — input path being processed"
+    },
+    "object_name": {
+      "type": "string",
+      "description": "File-related — output object name in object store"
+    },
+    "elapsed": {
+      "type": "number",
+      "description": "Completion events — wall-clock seconds"
+    },
+    "user": {
+      "type": "number",
+      "description": "Completion events — CPU user time"
+    },
+    "sys": {
+      "type": "number",
+      "description": "Completion events — CPU system time"
+    },
+    "iowait": {
+      "type": "number",
+      "description": "Completion events — I/O wait time"
+    },
+    "files_remaining": {
+      "type": "integer",
+      "description": "Completion events — remaining file counter"
+    },
+    "files_completed": {
+      "type": "integer",
+      "description": "Completion events — completed file counter"
+    },
+    "files_failed": {
+      "type": "integer",
+      "description": "Completion events — failed file counter"
+    },
+    "error": {
+      "type": "string",
+      "description": "Error/exception logs — message or repr"
+    },
+    "error_type": {
+      "type": "string",
+      "description": "Error/exception logs — error-category code"
+    },
+    "log_body": {
+      "type": "string",
+      "description": "Error/exception logs — captured science container output"
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Queue context — Celery task name"
+    },
+    "num_files": {
+      "type": "integer",
+      "description": "Queue context — number of files in a batch"
+    },
+    "metric": {
+      "type": "object",
+      "description": "Status-update events — structured transformer-progress payload"
+    },
+    "deleted": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Lifecycle events — deletion summary list"
+    }
+  },
+  "additionalProperties": false
+}

--- a/servicex_app/servicex_app/celery/server_tasks.py
+++ b/servicex_app/servicex_app/celery/server_tasks.py
@@ -85,7 +85,6 @@ def add_files_to_processing_queue(request, files):
         "Added files to processing queue",
         extra={
             "num_files": len(files),
-            "file_path": [_["paths"] for _ in files],
             "task_id": celery_task_name(request["request_id"]),
             "request_id": request["request_id"],
         },

--- a/servicex_app/servicex_app/celery/server_tasks.py
+++ b/servicex_app/servicex_app/celery/server_tasks.py
@@ -85,8 +85,8 @@ def add_files_to_processing_queue(request, files):
         "Added files to processing queue",
         extra={
             "num_files": len(files),
-            "paths": [_["paths"] for _ in files],
+            "file_path": [_["paths"] for _ in files],
             "task_id": celery_task_name(request["request_id"]),
-            "requestId": request["request_id"],
+            "request_id": request["request_id"],
         },
     )

--- a/servicex_app/servicex_app/resources/internal/fileset_complete.py
+++ b/servicex_app/servicex_app/resources/internal/fileset_complete.py
@@ -53,7 +53,7 @@ class FilesetComplete(ServiceXResource):
 
         current_app.logger.info(
             "Completed fileset for datasetID",
-            extra={"dataset_id": dataset_id, "elapsed-time": summary["elapsed-time"]},
+            extra={"dataset_id": dataset_id, "elapsed": summary["elapsed-time"]},
         )
         dataset.n_files = summary["files"]
         dataset.events = summary["total-events"]

--- a/servicex_app/servicex_app/resources/internal/fileset_error.py
+++ b/servicex_app/servicex_app/resources/internal/fileset_error.py
@@ -58,7 +58,7 @@ class FilesetError(ServiceXResource):
                     "dataset_id": dataset_id,
                     "elapsed": summary["elapsed-time"],
                     "error_type": summary["error-type"],
-                    "error": summary["message"],
+                    "error_message": summary["message"],
                 },
             )
             return "", 422
@@ -69,7 +69,7 @@ class FilesetError(ServiceXResource):
                 "dataset_id": dataset_id,
                 "elapsed": summary["elapsed-time"],
                 "error_type": summary["error-type"],
-                "error": summary["message"],
+                "error_message": summary["message"],
             },
         )
 
@@ -95,7 +95,7 @@ class FilesetError(ServiceXResource):
                     "dataset_id": dataset_id,
                     "elapsed": summary["elapsed-time"],
                     "error_type": summary["error-type"],
-                    "error": summary["message"],
+                    "error_message": summary["message"],
                     "request_id": t_request.request_id,
                 },
             )

--- a/servicex_app/servicex_app/resources/internal/fileset_error.py
+++ b/servicex_app/servicex_app/resources/internal/fileset_error.py
@@ -56,9 +56,9 @@ class FilesetError(ServiceXResource):
                 "Dataset lookup error received for unknown dataset",
                 extra={
                     "dataset_id": dataset_id,
-                    "elapsed-time": summary["elapsed-time"],
-                    "error-type": summary["error-type"],
-                    "_message": summary["message"],
+                    "elapsed": summary["elapsed-time"],
+                    "error_type": summary["error-type"],
+                    "error": summary["message"],
                 },
             )
             return "", 422
@@ -67,9 +67,9 @@ class FilesetError(ServiceXResource):
             "Error in file lookup",
             extra={
                 "dataset_id": dataset_id,
-                "elapsed-time": summary["elapsed-time"],
-                "error-type": summary["error-type"],
-                "_message": summary["message"],
+                "elapsed": summary["elapsed-time"],
+                "error_type": summary["error-type"],
+                "error": summary["message"],
             },
         )
 
@@ -93,10 +93,10 @@ class FilesetError(ServiceXResource):
                 "Shutting down transformer because of dataset lookup problem",
                 extra={
                     "dataset_id": dataset_id,
-                    "elapsed-time": summary["elapsed-time"],
-                    "error-type": summary["error-type"],
-                    "_message": summary["message"],
-                    "requestId": t_request.request_id,
+                    "elapsed": summary["elapsed-time"],
+                    "error_type": summary["error-type"],
+                    "error": summary["message"],
+                    "request_id": t_request.request_id,
                 },
             )
 

--- a/servicex_app/servicex_app/resources/internal/transform_status.py
+++ b/servicex_app/servicex_app/resources/internal/transform_status.py
@@ -19,7 +19,7 @@ class TransformationStatusInternal(ServiceXResource):
         if status["severity"] == "fatal":
             current_app.logger.error(
                 f"Fatal error reported from " f"{status['source']}: {status['info']}",
-                extra={"requestId": request_id},
+                extra={"request_id": request_id},
             )
 
             submitted_request = TransformRequest.lookup(request_id)
@@ -31,5 +31,5 @@ class TransformationStatusInternal(ServiceXResource):
         else:
             current_app.logger.info(
                 "Transformation Status Update",
-                extra={"requestId": request_id, "metric": status},
+                extra={"request_id": request_id, "metric": status},
             )

--- a/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
+++ b/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
@@ -101,9 +101,9 @@ class TransformerFileComplete(ServiceXResource):
         info = request.get_json()
         logger = current_app.logger
         log_extra = {
-            "requestId": request_id,
-            "file-id": info["file-id"],
-            "s3-object-name": info["s3-object-name"],
+            "request_id": request_id,
+            "file_id": info["file-id"],
+            "object_name": info["s3-object-name"],
         }
 
         logger.info("FileComplete", extra={**log_extra, "metric": info})
@@ -114,8 +114,8 @@ class TransformerFileComplete(ServiceXResource):
             # we've processed this file already (return value will be True if so)
             if orig_counts := self.save_transform_result(request_id, info, session):
                 logger.warning(
-                    "Duplicate result report",
-                    extra=(log_extra | {"new_info": info, "old_info": orig_counts}),
+                    f"Duplicate result report - new_info: {info}, old_info: {orig_counts}",
+                    extra=log_extra,
                 )
 
             # Lookup the transformation request and increment either the successful
@@ -148,7 +148,7 @@ class TransformerFileComplete(ServiceXResource):
                     "files_remaining": transform_req.files_remaining,
                     "files_completed": transform_req.files_completed,
                     "files_failed": transform_req.files_failed,
-                    "report_processed_time": (time.time() - start_time),
+                    "elapsed": (time.time() - start_time),
                 },
             )
             return "Ok", 200
@@ -264,7 +264,7 @@ class TransformerFileComplete(ServiceXResource):
 
         logger.info(
             "Request completed. Shutting down transformers",
-            extra={"requestId": transform_req.request_id},
+            extra={"request_id": transform_req.request_id},
         )
         namespace = current_app.config["TRANSFORMER_NAMESPACE"]
         transformer_manager.shutdown_transformer_job(

--- a/servicex_app/servicex_app/resources/servicex_resource.py
+++ b/servicex_app/servicex_app/resources/servicex_resource.py
@@ -92,7 +92,7 @@ class ServiceXResource(Resource):
 
         current_app.logger.info(
             f"Lunching {request_rec.workers} transformers.",
-            extra={"requestId": request_rec.request_id},
+            extra={"request_id": request_rec.request_id},
         )
 
         transformer_manager.launch_transformer_jobs(

--- a/servicex_app/servicex_app/resources/transformation/cancel.py
+++ b/servicex_app/servicex_app/resources/transformation/cancel.py
@@ -46,11 +46,11 @@ class CancelTransform(ServiceXResource):
         transform_req = TransformRequest.lookup(request_id)
         if not transform_req:
             msg = f"Transformation request not found with id: {request_id}"
-            current_app.logger.warning(msg, extra={"requestId": request_id})
+            current_app.logger.warning(msg, extra={"request_id": request_id})
             return {"message": msg}, 404
         elif transform_req.status.is_complete:
             msg = f"Transform request with id {request_id} is not in progress."
-            current_app.logger.warning(msg, extra={"requestId": request_id})
+            current_app.logger.warning(msg, extra={"request_id": request_id})
             return {"message": msg}, 400
 
         namespace = current_app.config["TRANSFORMER_NAMESPACE"]
@@ -64,7 +64,7 @@ class CancelTransform(ServiceXResource):
                 else:
                     current_app.logger.error(
                         f"Got Kubernetes api exception: {exc.reason}",
-                        extra={"requestId": request_id},
+                        extra={"request_id": request_id},
                     )
                     return {"message": exc.reason}, exc.status
 

--- a/servicex_app/servicex_app/resources/transformation/delete.py
+++ b/servicex_app/servicex_app/resources/transformation/delete.py
@@ -45,12 +45,12 @@ class DeleteTransform(ServiceXResource):
             transform_req = TransformRequest.lookup(request_id)
             if not transform_req:
                 msg = f"Transformation request not found with id: {request_id}"
-                current_app.logger.warning(msg, extra={"requestId": request_id})
+                current_app.logger.warning(msg, extra={"request_id": request_id})
                 return {"message": msg}, 404
 
             if not transform_req.status.is_complete:
                 msg = f"Transform request with id {request_id} is still in progress."
-                current_app.logger.warning(msg, extra={"requestId": request_id})
+                current_app.logger.warning(msg, extra={"request_id": request_id})
                 return {"message": msg}, 400
 
             user = self.get_requesting_user()

--- a/servicex_app/servicex_app/resources/transformation/deployment.py
+++ b/servicex_app/servicex_app/resources/transformation/deployment.py
@@ -19,7 +19,7 @@ class DeploymentStatus(ServiceXResource):
         status = self.transformer_manager.get_deployment_status(request_id)
         if status is None:
             msg = f"Deployment not found: '{request_id}'"
-            current_app.logger.error(msg, extra={"requestId": request_id})
+            current_app.logger.error(msg, extra={"request_id": request_id})
             return {"message": msg}, 404
         current_app.logger.debug(
             f"Transformation deployment request: {status.to_dict()}"

--- a/servicex_app/servicex_app/resources/transformation/get_one.py
+++ b/servicex_app/servicex_app/resources/transformation/get_one.py
@@ -42,7 +42,7 @@ class TransformationRequest(ServiceXResource):
         transform = TransformRequest.lookup(request_id)
         if not transform:
             msg = f"Transformation request not found with id: {request_id}"
-            current_app.logger.error(msg, extra={"requestId": request_id})
+            current_app.logger.error(msg, extra={"request_id": request_id})
             return {"message": msg}, 404
 
         transform_json = transform.to_json()

--- a/servicex_app/servicex_app/resources/transformation/status.py
+++ b/servicex_app/servicex_app/resources/transformation/status.py
@@ -44,7 +44,7 @@ class TransformationStatus(ServiceXResource):
         transform = TransformRequest.lookup(request_id)
         if not transform:
             msg = f"Transformation request not found with id: {request_id}"
-            current_app.logger.error(msg, extra={"requestId": request_id})
+            current_app.logger.error(msg, extra={"request_id": request_id})
             return {"message": msg}, 404
 
         status_request = status_request_parser.parse_args()
@@ -73,6 +73,6 @@ class TransformationStatus(ServiceXResource):
             )
         current_app.logger.debug(
             "Transformation status",
-            extra={"requestId": request_id, "metric": result_dict},
+            extra={"request_id": request_id, "metric": result_dict},
         )
         return jsonify(result_dict)

--- a/servicex_app/servicex_app/resources/transformation/submit.py
+++ b/servicex_app/servicex_app/resources/transformation/submit.py
@@ -137,14 +137,14 @@ class SubmitTransformationRequest(ServiceXResource):
                 parsed_did,
                 logger=current_app.logger,
                 db=db,
-                extras={"requestId": request_id},
+                extras={"request_id": request_id},
             )
         else:  # no dataset, only a list of files given
             return DatasetManager.from_file_list(
                 file_list,
                 logger=current_app.logger,
                 db=db,
-                extras={"requestId": request_id},
+                extras={"request_id": request_id},
             )
 
     def _setup_rabbit_queues(self, request_id: str):
@@ -178,7 +178,7 @@ class SubmitTransformationRequest(ServiceXResource):
                 args = self.parser.parse_args()
             except BadRequest as bad_request:
                 msg = f"The json request was malformed: {str(bad_request)}"
-                current_app.logger.error(msg, extra={"requestId": request_id})
+                current_app.logger.error(msg, extra={"request_id": request_id})
                 return {"message": msg}, 400
 
             config = current_app.config
@@ -192,7 +192,7 @@ class SubmitTransformationRequest(ServiceXResource):
 
             if not code_gen_image_name:
                 msg = f"Invalid Codegen Image Passed in Request: {user_codegen_name}"
-                current_app.logger.error(msg, extra={"requestId": request_id})
+                current_app.logger.error(msg, extra={"request_id": request_id})
                 return {"message": msg}, 500
 
             # The first thing to do is make sure the requested selection is correct
@@ -217,7 +217,7 @@ class SubmitTransformationRequest(ServiceXResource):
                     codegen_transformer_image
                 ):
                     msg = f"Requested transformer docker image doesn't exist: {codegen_transformer_image}"  # noqa: E501
-                    current_app.logger.error(msg, extra={"requestId": request_id})
+                    current_app.logger.error(msg, extra={"request_id": request_id})
                     return {"message": msg}, 500
 
             # If the user has requested an object store destination, now is the time
@@ -241,7 +241,7 @@ class SubmitTransformationRequest(ServiceXResource):
                     )
                 except BadRequest as bad_request:
                     current_app.logger.error(
-                        str(bad_request), extra={"requestId": request_id}
+                        str(bad_request), extra={"request_id": request_id}
                     )
                     return {"message": str(bad_request)}, 400
 
@@ -292,7 +292,8 @@ class SubmitTransformationRequest(ServiceXResource):
                     request_rec.status = TransformStatus.lookup
                 elif dataset_manager.is_complete:
                     current_app.logger.info(
-                        "dataset already complete", extra={"requestId": str(request_id)}
+                        "dataset already complete",
+                        extra={"request_id": str(request_id)},
                     )
                     dataset_manager.publish_files(
                         request_rec, self.lookup_result_processor
@@ -301,7 +302,7 @@ class SubmitTransformationRequest(ServiceXResource):
                 else:
                     current_app.logger.info(
                         "another request received for dataset that is still being looked up ",
-                        extra={"requestId": str(request_id)},
+                        extra={"request_id": str(request_id)},
                     )
                     request_rec.status = TransformStatus.pending_lookup
 
@@ -313,12 +314,12 @@ class SubmitTransformationRequest(ServiceXResource):
                 )
 
             current_app.logger.info(
-                "Transformation request submitted!", extra={"requestId": request_id}
+                "Transformation request submitted!", extra={"request_id": request_id}
             )
             return {"request_id": str(request_id)}
         except Exception as eek:
             current_app.logger.exception(
                 "Got exception while submitting transformation request",
-                extra={"requestId": request_id},
+                extra={"request_id": request_id},
             )
             return {"message": f"Something went wrong ({str(eek)})"}, 500

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -574,7 +574,7 @@ class TransformerManager:
             if not quiet_errors:
                 current_app.logger.exception(
                     "Exception during Job HPA Shut Down",
-                    extra={"requestId": request_id, "status_code": e.status},
+                    extra={"request_id": request_id, "retry_status": e.status},
                 )
 
         try:
@@ -595,7 +595,7 @@ class TransformerManager:
             if not quiet_errors:
                 current_app.logger.exception(
                     "Exception during Job Deployment Shut Down",
-                    extra={"requestId": request_id, "status_code": e.status},
+                    extra={"request_id": request_id, "retry_status": e.status},
                 )
 
         try:
@@ -617,7 +617,7 @@ class TransformerManager:
             if not quiet_errors:
                 current_app.logger.exception(
                     "Exception during Job ConfigMap cleanup",
-                    extra={"requestId": request_id, "status_code": e.status},
+                    extra={"request_id": request_id, "retry_status": e.status},
                 )
 
         # delete RabbitMQ queue
@@ -626,7 +626,7 @@ class TransformerManager:
                 f"Stopping workers connected to transformer-{request_id}"
             )
             cls.celery_app.control.cancel_consumer(f"transformer-{request_id}")
-        except Exception as e:
+        except Exception:
             if not quiet_errors:
                 current_app.logger.exception(
                     "Exception during Celery queue cancellation",

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -79,7 +79,7 @@ class TransformerManager:
 
         current_app.logger.info(
             f"Launching {request_rec.workers} transformers.",
-            extra={"requestId": request_rec.request_id},
+            extra={"request_id": request_rec.request_id},
         )
 
         self.launch_transformer_jobs(
@@ -630,7 +630,7 @@ class TransformerManager:
             if not quiet_errors:
                 current_app.logger.exception(
                     "Exception during Celery queue cancellation",
-                    extra={"requestId": request_id, "exception": e},
+                    extra={"request_id": request_id},
                 )
 
     @staticmethod

--- a/servicex_app/servicex_app_test/resources/transformation/test_submit.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_submit.py
@@ -200,7 +200,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
             )
 
             mock_dataset_manager_from_did.assert_called_with(
-                ANY, db=ANY, extras={"requestId": request_id}, logger=ANY
+                ANY, db=ANY, extras={"request_id": request_id}, logger=ANY
             )
             assert (
                 mock_dataset_manager_from_did.call_args[0][0].full_did
@@ -239,7 +239,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
                 assert saved_obj
 
             mock_dataset_manager_from_did.assert_called_with(
-                ANY, db=ANY, extras={"requestId": request_id}, logger=ANY
+                ANY, db=ANY, extras={"request_id": request_id}, logger=ANY
             )
 
             assert (
@@ -286,7 +286,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
             assert saved_obj.did_id == 42
 
             mock_dataset_manager_from_did.assert_called_with(
-                ANY, db=ANY, extras={"requestId": request_id}, logger=ANY
+                ANY, db=ANY, extras={"request_id": request_id}, logger=ANY
             )
             assert (
                 mock_dataset_manager_from_did.call_args[0][0].full_did
@@ -332,7 +332,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
             assert saved_obj.status == TransformStatus.pending_lookup
 
             mock_dataset_manager_from_did.assert_called_with(
-                ANY, db=ANY, extras={"requestId": request_id}, logger=ANY
+                ANY, db=ANY, extras={"request_id": request_id}, logger=ANY
             )
             assert (
                 mock_dataset_manager_from_did.call_args[0][0].full_did
@@ -370,7 +370,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
             request_id = response.json["request_id"]
 
             mock_dataset_manager_from_did.assert_called_with(
-                ANY, db=ANY, extras={"requestId": request_id}, logger=ANY
+                ANY, db=ANY, extras={"request_id": request_id}, logger=ANY
             )
             assert (
                 mock_dataset_manager_from_did.call_args[0][0].full_did
@@ -418,7 +418,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
             request_id = response.json["request_id"]
             submitted_request = TransformRequest.lookup(request_id)
             mock_dataset_manager_from_files.assert_called_with(
-                file_list, db=ANY, extras={"requestId": request_id}, logger=ANY
+                file_list, db=ANY, extras={"request_id": request_id}, logger=ANY
             )
 
             mock_transform_manager.start_transformers.assert_called_with(

--- a/transformer_sidecar/src/transformer_sidecar/object_store_manager.py
+++ b/transformer_sidecar/src/transformer_sidecar/object_store_manager.py
@@ -101,7 +101,7 @@ class ObjectStoreManager:
 
             self.logger.info(
                 "OSM > created object.",
-                extra={"requestId": bucket, "object": result.object_name},
+                extra={"request_id": bucket, "object_name": result.object_name},
             )
 
         except (RetryError, S3Error) as e:

--- a/transformer_sidecar/src/transformer_sidecar/servicex_adapter.py
+++ b/transformer_sidecar/src/transformer_sidecar/servicex_adapter.py
@@ -39,7 +39,7 @@ MAX_RETRIES = 3
 RETRY_DELAY = 2
 
 PLACE = {
-    "host_name": os.getenv("HOST_NAME", "unknown"),
+    "host": os.getenv("HOST_NAME", "unknown"),
     "site": os.getenv("site", "unknown"),
 }
 
@@ -115,15 +115,15 @@ class ServiceXAdapter:
                 self.logger.info(
                     "Put file complete.",
                     extra={
-                        "requestId": rec.request_id,
-                        "file-id": rec.file_id,
+                        "request_id": rec.request_id,
+                        "file_id": rec.file_id,
                         "place": PLACE,
-                        "file_path": rec.file_path,
-                        "s3-object-name": rec.s3_object_name,
+                        "input_path": rec.file_path,
+                        "object_name": rec.s3_object_name,
                     },
                 )
             except requests.exceptions.ConnectionError:
                 self.logger.exception(
                     "Connection Error in put_file_complete",
-                    extra={"requestId": rec.request_id, "place": PLACE},
+                    extra={"request_id": rec.request_id, "place": PLACE},
                 )

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -81,7 +81,7 @@ request_id: str = ""
 MAX_PATH_LEN = 255
 
 PLACE = {
-    "host_name": os.getenv("HOST_NAME", "unknown"),
+    "host": os.getenv("HOST_NAME", "unknown"),
     "site": os.getenv("site", "unknown"),
     "pod": os.getenv("POD_NAME", "unknown"),
 }
@@ -119,13 +119,12 @@ def transform_file(
     We will examine this log file to see if the transform succeeded or failed
     """
 
-    log_extra = {"requestId": request_id, "file-id": file_id, "place": PLACE}
+    log_extra = {"request_id": request_id, "file_id": file_id, "place": PLACE}
 
     transform_request = {
         "file-id": file_id,
         "request-id": request_id,
         "status": "unknown",
-        "error": None,
     }
 
     # If we are converting root to another format here, then the transformer
@@ -145,13 +144,7 @@ def transform_file(
 
     logger.info(
         "got transform request.",
-        extra={
-            **log_extra,
-            "paths": _file_paths,
-            "result-destination": result_destination,
-            "result-format": result_format,
-            "service-endpoint": service_endpoint,
-        },
+        extra={**log_extra, "replicas": _file_paths, "result_path": result_destination},
     )
     servicex = ServiceXAdapter(service_endpoint)
 
@@ -175,7 +168,7 @@ def transform_file(
                 "trying to transform file",
                 extra={
                     **log_extra,
-                    "file-path": _file_path,
+                    "input_path": _file_path,
                 },
             )
 
@@ -240,12 +233,7 @@ def transform_file(
                     servicex.put_file_complete(rec)
 
                 transform_success = True
-                ts = {
-                    **log_extra,
-                    "file-size": transformer_stats.file_size,
-                    "total-events": transformer_stats.total_events,
-                }
-                logger.info("Transformer stats.", extra=ts)
+                logger.info("Transformer stats.", extra=log_extra)
                 science_container.confirm()
                 break
 
@@ -256,7 +244,7 @@ def transform_file(
         if not transform_success:
             hf = {
                 **log_extra,
-                "file-path": _file_paths[0],
+                "input_path": _file_paths[0],
                 "log_body": transformer_stats.log_body,
             }
             logger.error(f"Hard Failure: {transformer_stats.error_info}", extra=hf)
@@ -325,7 +313,7 @@ def convert_to_parquet(source_path: Path) -> Optional[Path]:
 
     logger.info(
         "Converting ROOT to Parquet.",
-        extra={"requestId": request_id, "source_path": source_path},
+        extra={"request_id": request_id, "input_path": str(source_path)},
     )
     try:
         with open(source_path, "rb") as datafile:
@@ -411,10 +399,10 @@ def upload_file(
     logger.info(
         "Uploading file to object store.",
         extra={
-            "requestId": request_id,
-            "file-id": rec.file_id,
+            "request_id": request_id,
+            "file_id": rec.file_id,
             "place": PLACE,
-            "objectName": object_name,
+            "object_name": object_name,
         },
     )
     t0 = time.time()
@@ -423,10 +411,10 @@ def upload_file(
         logger.info(
             "File uploaded to object store.",
             extra={
-                "requestId": request_id,
-                "file-id": rec.file_id,
+                "request_id": request_id,
+                "file_id": rec.file_id,
                 "place": PLACE,
-                "objectName": object_name,
+                "object_name": object_name,
                 "elapsed": time.time() - t0,
             },
         )
@@ -437,10 +425,10 @@ def upload_file(
         logger.error(
             f"Error uploading file to object store: {e}",
             extra={
-                "requestId": request_id,
+                "request_id": request_id,
                 "place": PLACE,
-                "file-id": rec.file_id,
-                "objectName": object_name,
+                "file_id": rec.file_id,
+                "object_name": object_name,
             },
         )
         rec.status = "failure"
@@ -685,7 +673,7 @@ if __name__ == "__main__":  # pragma: no cover
 
     logger.debug(
         "Shutting down transformer",
-        extra={"requestId": request_id, "place": PLACE},
+        extra={"request_id": request_id, "place": PLACE},
     )
     science_container.close()
 

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -348,7 +348,7 @@ def convert_to_rntuple(source_path: Path) -> Optional[Path]:
 
     logger.info(
         "Converting ROOT TTree to RNTuple.",
-        extra={"requestId": request_id, "source_path": source_path},
+        extra={"request_id": request_id, "input_path": source_path},
     )
 
     rntuple_file = source_path.with_suffix(".rntuple.root")


### PR DESCRIPTION
Fixes #1339 

# Problem
The `extras` property on our logging statement is picked up by logstash and stored as searchable metadata in ElasticSearch. We don't have standards for these keys and so the metadata is all over the place with various spellings like `request-id`, `RequestID`, etc etc this makes it hard to create meaningful dashboards or comprehensive searches.

# Approach
I asked claude to analyze the code and suggest a schema for this metadata. After some review, this is now in [logging_schema.json](https://github.com/ssl-hep/ServiceX/blob/1339_logging_metadata/logging_schema.json).

I then asked claude to create a [local pre-commit hook](https://github.com/ssl-hep/ServiceX/blob/1339_logging_metadata/hooks/check_log_extras.py) that looks for `extras` in log statements and validates the keys against the schema.

This won't work with log statements that use a dictionary variable, so the hook prints a warning for those.

Eventually we may want to ensure all log statements have at least minimal `extras` metadata, so the pre-commit hook has an option to report log statements that lack the metadata.

Finally I went through the code and fixed all of the log statements to match the schema.
