### PR TITLE
add request_id to sidecar logging

### DIFF
--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -197,7 +197,10 @@ class TransformerManager:
             )
 
         # Compute Environment Vars
-        env = [client.V1EnvVar(name="BASH_ENV", value="/servicex/.bashrc")]
+        env = [
+            client.V1EnvVar(name="BASH_ENV", value="/servicex/.bashrc"),
+            client.V1EnvVar(name="REQUEST_ID", value=request_id),
+        ]
 
         # provide pods with level and logging server info
         env += [
@@ -499,7 +502,13 @@ class TransformerManager:
 
     @staticmethod
     def _create_job(api_instance, job, namespace):
-        request_id = job.metadata.name.removeprefix("transformer-")
+        env_vars = {
+            e.name: e.value
+            for container in job.spec.template.spec.containers
+            for e in (container.env or [])
+            if e.value is not None
+        }
+        request_id = env_vars.get("REQUEST_ID", "")
         try:
             api_instance.create_namespaced_deployment(body=job, namespace=namespace)
             current_app.logger.info("Request deployment created.", extra={"requestId": request_id})
@@ -507,8 +516,7 @@ class TransformerManager:
             current_app.logger.exception(f"Exception during HPA Creation: {e}", extra={"requestId": request_id})
 
     @staticmethod
-    def _create_hpa(api_instance, hpa, namespace):
-        request_id = hpa.metadata.name.removeprefix("transformer-")
+    def _create_hpa(api_instance, hpa, namespace, request_id):
         try:
             api_instance.create_namespaced_horizontal_pod_autoscaler(
                 body=hpa, namespace=namespace
@@ -551,7 +559,7 @@ class TransformerManager:
         if current_app.config["TRANSFORMER_AUTOSCALE_ENABLED"]:
             autoscaler_api = kubernetes.client.AutoscalingV1Api()
             hpa = self.create_hpa_object(request_id, max_workers)
-            self._create_hpa(autoscaler_api, hpa, namespace)
+            self._create_hpa(autoscaler_api, hpa, namespace, request_id)
 
     @classmethod
     def shutdown_transformer_job(cls, request_id, namespace, quiet_errors=False):

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -199,7 +199,6 @@ class TransformerManager:
         # Compute Environment Vars
         env = [
             client.V1EnvVar(name="BASH_ENV", value="/servicex/.bashrc"),
-            client.V1EnvVar(name="REQUEST_ID", value=request_id),
         ]
 
         # provide pods with level and logging server info
@@ -501,14 +500,7 @@ class TransformerManager:
         return hpa
 
     @staticmethod
-    def _create_job(api_instance, job, namespace):
-        env_vars = {
-            e.name: e.value
-            for container in job.spec.template.spec.containers
-            for e in (container.env or [])
-            if e.value is not None
-        }
-        request_id = env_vars.get("REQUEST_ID", "")
+    def _create_job(api_instance, job, namespace, request_id):
         try:
             api_instance.create_namespaced_deployment(body=job, namespace=namespace)
             current_app.logger.info(
@@ -560,7 +552,7 @@ class TransformerManager:
             transformer_command,
         )
 
-        self._create_job(api_v1, job, namespace)
+        self._create_job(api_v1, job, namespace, request_id)
 
         if current_app.config["TRANSFORMER_AUTOSCALE_ENABLED"]:
             autoscaler_api = kubernetes.client.AutoscalingV1Api()

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -499,21 +499,23 @@ class TransformerManager:
 
     @staticmethod
     def _create_job(api_instance, job, namespace):
+        request_id = job.metadata.name.removeprefix("transformer-")
         try:
             api_instance.create_namespaced_deployment(body=job, namespace=namespace)
-            current_app.logger.info("Request deployment created.")
+            current_app.logger.info("Request deployment created.", extra={"requestId": request_id})
         except ApiException as e:
-            current_app.logger.exception(f"Exception during HPA Creation: {e}")
+            current_app.logger.exception(f"Exception during HPA Creation: {e}", extra={"requestId": request_id})
 
     @staticmethod
     def _create_hpa(api_instance, hpa, namespace):
+        request_id = hpa.metadata.name.removeprefix("transformer-")
         try:
             api_instance.create_namespaced_horizontal_pod_autoscaler(
                 body=hpa, namespace=namespace
             )
-            current_app.logger.info("HPA created.")
+            current_app.logger.info("HPA created.", extra={"requestId": request_id})
         except ApiException as e:
-            current_app.logger.exception(f"Exception during HPA Creation: {e}")
+            current_app.logger.exception(f"Exception during HPA Creation: {e}", extra={"requestId": request_id})
 
     def launch_transformer_jobs(
         self,
@@ -623,7 +625,8 @@ class TransformerManager:
         # delete RabbitMQ queue
         try:
             current_app.logger.info(
-                f"Stopping workers connected to transformer-{request_id}"
+                f"Stopping workers connected to transformer-{request_id}",
+                extra={"requestId": request_id},
             )
             cls.celery_app.control.cancel_consumer(f"transformer-{request_id}")
         except Exception as e:

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -502,9 +502,13 @@ class TransformerManager:
         request_id = job.metadata.name.removeprefix("transformer-")
         try:
             api_instance.create_namespaced_deployment(body=job, namespace=namespace)
-            current_app.logger.info("Request deployment created.", extra={"requestId": request_id})
+            current_app.logger.info(
+                "Request deployment created.", extra={"requestId": request_id}
+            )
         except ApiException as e:
-            current_app.logger.exception(f"Exception during HPA Creation: {e}", extra={"requestId": request_id})
+            current_app.logger.exception(
+                f"Exception during HPA Creation: {e}", extra={"requestId": request_id}
+            )
 
     @staticmethod
     def _create_hpa(api_instance, hpa, namespace):
@@ -515,7 +519,9 @@ class TransformerManager:
             )
             current_app.logger.info("HPA created.", extra={"requestId": request_id})
         except ApiException as e:
-            current_app.logger.exception(f"Exception during HPA Creation: {e}", extra={"requestId": request_id})
+            current_app.logger.exception(
+                f"Exception during HPA Creation: {e}", extra={"requestId": request_id}
+            )
 
     def launch_transformer_jobs(
         self,

--- a/transformer_sidecar/src/transformer_sidecar/science_container_command.py
+++ b/transformer_sidecar/src/transformer_sidecar/science_container_command.py
@@ -49,13 +49,19 @@ class ScienceContainerCommand:
 
     def synch(self):
         while True:
-            self.logger.debug("waiting for the GeT", extra={"requestId": self.request_id})
+            self.logger.debug(
+                "waiting for the GeT", extra={"requestId": self.request_id}
+            )
             req = self.conn.recv(4096)
             if not req:
-                self.logger.error("problem in getting GeT", extra={"requestId": self.request_id})
+                self.logger.error(
+                    "problem in getting GeT", extra={"requestId": self.request_id}
+                )
                 raise ScienceContainerException("problem in getting GeT")
             req1 = req.decode("utf8")
-            self.logger.debug(f"REQ >>>>>>>>>>>>>>>{req1}", extra={"requestId": self.request_id})
+            self.logger.debug(
+                f"REQ >>>>>>>>>>>>>>>{req1}", extra={"requestId": self.request_id}
+            )
             if req1.startswith("GeT"):
                 break
 
@@ -70,7 +76,9 @@ class ScienceContainerCommand:
         # if not req:
         #     break
         req2 = req.decode("utf8").strip()
-        self.logger.debug(f"STATUS RECEIVED: {req2}", extra={"requestId": self.request_id})
+        self.logger.debug(
+            f"STATUS RECEIVED: {req2}", extra={"requestId": self.request_id}
+        )
         return req2
 
     def confirm(self):

--- a/transformer_sidecar/src/transformer_sidecar/science_container_command.py
+++ b/transformer_sidecar/src/transformer_sidecar/science_container_command.py
@@ -35,10 +35,11 @@ class ScienceContainerException(Exception):
 
 
 class ScienceContainerCommand:
-    def __init__(self):
+    def __init__(self, request_id: str = ""):
         handler = logging.NullHandler()
         self.logger = logging.getLogger(__name__)
         self.logger.addHandler(handler)
+        self.request_id = request_id
 
         # Open a socket to the science container
         self.serv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -48,28 +49,28 @@ class ScienceContainerCommand:
 
     def synch(self):
         while True:
-            self.logger.debug("waiting for the GeT")
+            self.logger.debug("waiting for the GeT", extra={"requestId": self.request_id})
             req = self.conn.recv(4096)
             if not req:
-                self.logger.error("problem in getting GeT")
+                self.logger.error("problem in getting GeT", extra={"requestId": self.request_id})
                 raise ScienceContainerException("problem in getting GeT")
             req1 = req.decode("utf8")
-            self.logger.debug(f"REQ >>>>>>>>>>>>>>>{req1}")
+            self.logger.debug(f"REQ >>>>>>>>>>>>>>>{req1}", extra={"requestId": self.request_id})
             if req1.startswith("GeT"):
                 break
 
     def send(self, transform_request: dict):
         res = json.dumps(transform_request) + "\n"
-        self.logger.debug(f"sending: {res}")
+        self.logger.debug(f"sending: {res}", extra={"requestId": self.request_id})
         self.conn.send(res.encode())
 
     def await_response(self):
-        self.logger.debug("WAITING FOR STATUS...")
+        self.logger.debug("WAITING FOR STATUS...", extra={"requestId": self.request_id})
         req = self.conn.recv(4096)
         # if not req:
         #     break
         req2 = req.decode("utf8").strip()
-        self.logger.debug(f"STATUS RECEIVED: {req2}")
+        self.logger.debug(f"STATUS RECEIVED: {req2}", extra={"requestId": self.request_id})
         return req2
 
     def confirm(self):

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -331,9 +331,8 @@ def convert_to_parquet(source_path: Path) -> Optional[Path]:
         with open(source_path, "rb") as datafile:
             data = uproot.open(datafile)
             if len(data.keys(cycle=False)) != 1:
-                logger.error(f"Expected one tree found {data.keys()}")
+                logger.error(f"Expected one tree found {data.keys()}", extra={"requestId": request_id})
                 return None
-
             tree_name = data.keys()[0]
             all_data = data[tree_name].arrays(library="ak")
 
@@ -346,7 +345,7 @@ def convert_to_parquet(source_path: Path) -> Optional[Path]:
             temp_file.rename(parquet_file)
 
     except Exception as e:
-        logger.error(f"Failed to convert ROOT to Parquet: {e}")
+        logger.error(f"Failed to convert ROOT to Parquet: {e}", extra={"requestId": request_id})
         return None
 
     return parquet_file
@@ -472,7 +471,7 @@ def read_capabilities_file() -> dict[str, str]:
     The capabilities file is mounted in the pod at startup. It's possible for
     the code to start before the file is available. We'll wait for it here.
     """
-    logger.debug("Waiting for capabilities file")
+    logger.debug("Waiting for capabilities file", extra={"requestId": request_id})
     capabilities_file_path = Path(
         os.path.join(shared_dir, "transformer_capabilities.json")
     )
@@ -525,6 +524,7 @@ def init(args: Union[Namespace, SimpleNamespace], app: Celery) -> None:
     logger.info(
         "Startup finished.",
         extra={
+            "requestId": request_id,
             "user": startup_time.user,
             "sys": startup_time.system,
             "iowait": startup_time.iowait,
@@ -532,8 +532,8 @@ def init(args: Union[Namespace, SimpleNamespace], app: Celery) -> None:
         },
     )
 
-    science_container = ScienceContainerCommand()
-    logger.debug("Connected to science container", extra={"place": PLACE})
+    science_container = ScienceContainerCommand(request_id=request_id)
+    logger.debug("Connected to science container", extra={"requestId": request_id, "place": PLACE})
 
     app.worker_main(
         argv=[

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -331,7 +331,10 @@ def convert_to_parquet(source_path: Path) -> Optional[Path]:
         with open(source_path, "rb") as datafile:
             data = uproot.open(datafile)
             if len(data.keys(cycle=False)) != 1:
-                logger.error(f"Expected one tree found {data.keys()}", extra={"requestId": request_id})
+                logger.error(
+                    f"Expected one tree found {data.keys()}",
+                    extra={"requestId": request_id},
+                )
                 return None
             tree_name = data.keys()[0]
             all_data = data[tree_name].arrays(library="ak")
@@ -345,7 +348,9 @@ def convert_to_parquet(source_path: Path) -> Optional[Path]:
             temp_file.rename(parquet_file)
 
     except Exception as e:
-        logger.error(f"Failed to convert ROOT to Parquet: {e}", extra={"requestId": request_id})
+        logger.error(
+            f"Failed to convert ROOT to Parquet: {e}", extra={"requestId": request_id}
+        )
         return None
 
     return parquet_file
@@ -382,7 +387,10 @@ def convert_to_rntuple(source_path: Path) -> Optional[Path]:
                                 writer[key] = obj
 
     except Exception as e:
-        logger.error(f"Failed to convert ROOT TTree to RNTuple: {e}", extra={"requestId": request_id})
+        logger.error(
+            f"Failed to convert ROOT TTree to RNTuple: {e}",
+            extra={"requestId": request_id},
+        )
         return None
 
     return rntuple_file
@@ -533,7 +541,10 @@ def init(args: Union[Namespace, SimpleNamespace], app: Celery) -> None:
     )
 
     science_container = ScienceContainerCommand(request_id=request_id)
-    logger.debug("Connected to science container", extra={"requestId": request_id, "place": PLACE})
+    logger.debug(
+        "Connected to science container",
+        extra={"requestId": request_id, "place": PLACE},
+    )
 
     app.worker_main(
         argv=[

--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -382,7 +382,7 @@ def convert_to_rntuple(source_path: Path) -> Optional[Path]:
                                 writer[key] = obj
 
     except Exception as e:
-        logger.error(f"Failed to convert ROOT TTree to RNTuple: {e}")
+        logger.error(f"Failed to convert ROOT TTree to RNTuple: {e}", extra={"requestId": request_id})
         return None
 
     return rntuple_file


### PR DESCRIPTION
Adds `request_id` to sidecar logging statements that didn't have them as well as the `transformer_manager`.