### PR TITLE
Implement the row lock to prevent multiple lookups for the same dataset

### DIFF
--- a/servicex_app/servicex_app/dataset_manager.py
+++ b/servicex_app/servicex_app/dataset_manager.py
@@ -160,6 +160,9 @@ class DatasetManager:
     def refresh(self):
         self.db.session.refresh(self.dataset)
 
+    def lock(self):
+        self.db.session.refresh(self.dataset, with_for_update=True)
+
     def submit_lookup_request(self, advertised_endpoint, celery_app: Celery):
         task_id = celery_app.send_task(
             f"{self.did.microservice_queue}.lookup_dataset",

--- a/servicex_app/servicex_app/resources/transformation/submit.py
+++ b/servicex_app/servicex_app/resources/transformation/submit.py
@@ -282,6 +282,7 @@ class SubmitTransformationRequest(ServiceXResource):
                 session.add(request_rec)
 
                 # If this request has a fresh DID then submit the lookup request to the DID Finder
+                dataset_manager.lock()  # refresh the dataset status, lock row
                 if dataset_manager.is_lookup_required:
                     dataset_manager.submit_lookup_request(
                         self._generate_advertised_endpoint(

--- a/servicex_app/servicex_app_test/test_dataset_manager.py
+++ b/servicex_app/servicex_app_test/test_dataset_manager.py
@@ -41,6 +41,8 @@ from servicex_app.models import (
 )
 from servicex_app.models import db
 from servicex_app_test.resource_test_base import ResourceTestBase
+from sqlalchemy import event
+from sqlalchemy.orm import Session
 
 
 def mock_dataset(status: str, mocker) -> Dataset:
@@ -291,6 +293,30 @@ class TestDatasetManager(ResourceTestBase):
             d2.save_to_db()
             dm.refresh()
             assert dm.dataset.lookup_status == DatasetStatus.complete
+
+    def test_lock(self, client):
+        def receive_orm_execute(state):
+            if state.is_select:
+                assert state.statement._for_update_arg is not None
+
+        with client.application.app_context():
+            with db.session.begin():
+                dm = DatasetManager.from_did(
+                    DIDParser("rucio://my-did?files=1"),
+                    logger=client.application.logger,
+                    db=db,
+                )
+
+            with db.session.begin():
+                try:
+                    event.listen(Session, "do_orm_execute", receive_orm_execute)
+                    # Before lock, we will NOT have a FOR UPDATE argument
+                    with pytest.raises(AssertionError):
+                        dm.dataset.id
+                    # the lock will issue SELECT with the FOR UPDATE
+                    dm.lock()
+                finally:
+                    event.remove(Session, "do_orm_execute", receive_orm_execute)
 
     def test_is_complete(self, client):
         with client.application.app_context():


### PR DESCRIPTION
#1317 refactored transactions for the dataset lookup, but it did not implement an actual lock, so it did not fix the race condition. Add a method to force the issuance of a `SELECT ... FOR UPDATE` in the relevant place.