### PR TITLE
Fix deadlock of #1403

### DIFF
--- a/servicex_app/migrations/versions/1.8.3a.py
+++ b/servicex_app/migrations/versions/1.8.3a.py
@@ -17,12 +17,19 @@ depends_on = None
 
 def upgrade():
     op.drop_index(op.f("ix_datasets_name"), table_name="datasets")
-    op.create_index(op.f("ix_datasets_name"), "datasets", ["name"],
-                    unique=True,
-                    postgresql_where=text("stale IS FALSE"))
+    op.create_index(
+        op.f("ix_datasets_name"),
+        "datasets",
+        ["name"],
+        unique=True,
+        postgresql_where=text("stale IS FALSE"),
+    )
 
 
 def downgrade():
-    op.drop_index(op.f("ix_datasets_name"), table_name="datasets",
-                  postgresql_where=text("stale IS FALSE"))
-    op.create_index(op.f('ix_datasets_name'), 'datasets', ['name'], unique=False)
+    op.drop_index(
+        op.f("ix_datasets_name"),
+        table_name="datasets",
+        postgresql_where=text("stale IS FALSE"),
+    )
+    op.create_index(op.f("ix_datasets_name"), "datasets", ["name"], unique=False)

--- a/servicex_app/migrations/versions/1.8.3a.py
+++ b/servicex_app/migrations/versions/1.8.3a.py
@@ -1,0 +1,28 @@
+"""
+add partial unique index to datasets
+
+Revision ID: v1_8_3a
+Revises: v1_8_3
+Create Date: 2026-05-11 20:13:17.154362
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "v1_8_3a"
+down_revision = "v1_8_3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index(op.f("ix_datasets_name"), table_name="datasets")
+    op.create_index(op.f("ix_datasets_name"), "datasets", ["name"],
+                    unique=True,
+                    postgresql_where=text("stale IS FALSE"))
+
+
+def downgrade():
+    op.drop_index(op.f("ix_datasets_name"), table_name="datasets",
+                  postgresql_where=text("stale IS FALSE"))
+    op.create_index(op.f('ix_datasets_name'), 'datasets', ['name'], unique=False)

--- a/servicex_app/servicex_app/dataset_manager.py
+++ b/servicex_app/servicex_app/dataset_manager.py
@@ -121,11 +121,9 @@ class DatasetManager:
             if dataset is None:
                 raise RuntimeError(f"Dataset {name} should be created")
             dataset.files = [
-                        DatasetFile(
-                            paths=file, adler32="xxx", file_events=0, file_size=0
-                        )
-                        for file in file_list
-                    ]
+                DatasetFile(paths=file, adler32="xxx", file_events=0, file_size=0)
+                for file in file_list
+            ]
 
             logger.info(
                 f"Upserted dataset for file list. Dataset Id is {dataset.id}",

--- a/servicex_app/servicex_app/dataset_manager.py
+++ b/servicex_app/servicex_app/dataset_manager.py
@@ -113,12 +113,6 @@ class DatasetManager:
                     last_updated=dataset_timestamp,
                     lookup_status=DatasetStatus.complete,
                     did_finder="user",
-                    files=[
-                        DatasetFile(
-                            paths=file, adler32="xxx", file_events=0, file_size=0
-                        )
-                        for file in file_list
-                    ],
                 )
                 .on_conflict_do_nothing()
             )
@@ -126,6 +120,12 @@ class DatasetManager:
             dataset = Dataset.find_by_name(name, with_lock=True)
             if dataset is None:
                 raise RuntimeError(f"Dataset {name} should be created")
+            dataset.files = [
+                        DatasetFile(
+                            paths=file, adler32="xxx", file_events=0, file_size=0
+                        )
+                        for file in file_list
+                    ]
 
             logger.info(
                 f"Upserted dataset for file list. Dataset Id is {dataset.id}",

--- a/servicex_app/servicex_app/dataset_manager.py
+++ b/servicex_app/servicex_app/dataset_manager.py
@@ -52,11 +52,11 @@ class DatasetManager:
         cls,
         did: DIDParser,
         logger: Logger,
-        extras: dict[str, str] = None,
-        db: SQLAlchemy = None,
+        db: SQLAlchemy,
+        extras: dict[str, str] = {},
     ):
-        dataset = Dataset.find_by_name(
-            did.full_did, with_lock=True
+        dataset = Dataset.find_by_name_with_lock(
+            did.full_did
         )  # strictly speaking, unnecessary
         if not dataset:
             dataset_timestamp = datetime.now(tz=timezone.utc)
@@ -72,9 +72,8 @@ class DatasetManager:
                 .on_conflict_do_nothing()
             )
             db.session.execute(statement)
-            dataset = Dataset.find_by_name(did.full_did, with_lock=True)
-            if dataset is None:
-                raise RuntimeError(f"Dataset {did.full_did} should be created")
+            dataset = Dataset.find_by_name_with_lock(did.full_did)
+            assert dataset is not None, "Dataset {did.full_did} should exist"
 
             logger.info(
                 f"Upserted dataset: {dataset.name}, id is {dataset.id}", extra=extras
@@ -97,11 +96,11 @@ class DatasetManager:
         cls,
         file_list: List[str],
         logger: Logger,
-        extras: dict[str, str] = None,
-        db: SQLAlchemy = None,
+        db: SQLAlchemy,
+        extras: dict[str, str] = {},
     ):
         name = cls.file_list_hash(file_list)
-        dataset = Dataset.find_by_name(name, with_lock=True)
+        dataset = Dataset.find_by_name_with_lock(name)
 
         if not dataset:
             dataset_timestamp = datetime.now(tz=timezone.utc)
@@ -117,9 +116,9 @@ class DatasetManager:
                 .on_conflict_do_nothing()
             )
             db.session.execute(statement)
-            dataset = Dataset.find_by_name(name, with_lock=True)
-            if dataset is None:
-                raise RuntimeError(f"Dataset {name} should be created")
+            dataset = Dataset.find_by_name_with_lock(name)
+            assert dataset is not None, f"Dataset {name} should exist"
+
             dataset.files = [
                 DatasetFile(paths=file, adler32="xxx", file_events=0, file_size=0)
                 for file in file_list

--- a/servicex_app/servicex_app/dataset_manager.py
+++ b/servicex_app/servicex_app/dataset_manager.py
@@ -55,16 +55,22 @@ class DatasetManager:
         extras: dict[str, str] = None,
         db: SQLAlchemy = None,
     ):
-        dataset = Dataset.find_by_name(did.full_did, with_lock=True)  # strictly speaking, unnecessary
+        dataset = Dataset.find_by_name(
+            did.full_did, with_lock=True
+        )  # strictly speaking, unnecessary
         if not dataset:
             dataset_timestamp = datetime.now(tz=timezone.utc)
-            statement = insert(Dataset).values(
-                name=did.full_did,
-                last_used=dataset_timestamp,
-                last_updated=dataset_timestamp,
-                lookup_status=DatasetStatus.created,
-                did_finder=did.scheme,
-            ).on_conflict_do_nothing()
+            statement = (
+                insert(Dataset)
+                .values(
+                    name=did.full_did,
+                    last_used=dataset_timestamp,
+                    last_updated=dataset_timestamp,
+                    lookup_status=DatasetStatus.created,
+                    did_finder=did.scheme,
+                )
+                .on_conflict_do_nothing()
+            )
             db.session.execute(statement)
             dataset = Dataset.find_by_name(did.full_did, with_lock=True)
             if dataset is None:
@@ -99,17 +105,23 @@ class DatasetManager:
 
         if not dataset:
             dataset_timestamp = datetime.now(tz=timezone.utc)
-            statement = insert(Dataset).values(
-                name=name,
-                last_used=dataset_timestamp,
-                last_updated=dataset_timestamp,
-                lookup_status=DatasetStatus.complete,
-                did_finder="user",
-                files=[
-                    DatasetFile(paths=file, adler32="xxx", file_events=0, file_size=0)
-                    for file in file_list
-                ],
-            ).on_conflict_do_nothing()
+            statement = (
+                insert(Dataset)
+                .values(
+                    name=name,
+                    last_used=dataset_timestamp,
+                    last_updated=dataset_timestamp,
+                    lookup_status=DatasetStatus.complete,
+                    did_finder="user",
+                    files=[
+                        DatasetFile(
+                            paths=file, adler32="xxx", file_events=0, file_size=0
+                        )
+                        for file in file_list
+                    ],
+                )
+                .on_conflict_do_nothing()
+            )
             db.session.execute(statement)
             dataset = Dataset.find_by_name(name, with_lock=True)
             if dataset is None:

--- a/servicex_app/servicex_app/dataset_manager.py
+++ b/servicex_app/servicex_app/dataset_manager.py
@@ -32,6 +32,7 @@ from typing import List
 
 from celery import Celery
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.dialects.postgresql import insert
 from servicex_app.did_parser import DIDParser
 from servicex_app.lookup_result_processor import LookupResultProcessor
 from servicex_app.models import Dataset, DatasetFile, TransformRequest, DatasetStatus
@@ -54,19 +55,23 @@ class DatasetManager:
         extras: dict[str, str] = None,
         db: SQLAlchemy = None,
     ):
-        dataset = Dataset.find_by_name(did.full_did)
+        dataset = Dataset.find_by_name(did.full_did, with_lock=True)  # strictly speaking, unnecessary
         if not dataset:
             dataset_timestamp = datetime.now(tz=timezone.utc)
-            dataset = Dataset(
+            statement = insert(Dataset).values(
                 name=did.full_did,
                 last_used=dataset_timestamp,
                 last_updated=dataset_timestamp,
                 lookup_status=DatasetStatus.created,
                 did_finder=did.scheme,
-            )
+            ).on_conflict_do_nothing()
+            db.session.execute(statement)
+            dataset = Dataset.find_by_name(did.full_did, with_lock=True)
+            if dataset is None:
+                raise RuntimeError(f"Dataset {did.full_did} should be created")
 
             logger.info(
-                f"Created new dataset: {dataset.name}, id is {dataset.id}", extra=extras
+                f"Upserted dataset: {dataset.name}, id is {dataset.id}", extra=extras
             )
         else:
             logger.info(
@@ -90,11 +95,11 @@ class DatasetManager:
         db: SQLAlchemy = None,
     ):
         name = cls.file_list_hash(file_list)
-        dataset = Dataset.find_by_name(name)
+        dataset = Dataset.find_by_name(name, with_lock=True)
 
         if not dataset:
             dataset_timestamp = datetime.now(tz=timezone.utc)
-            dataset = Dataset(
+            statement = insert(Dataset).values(
                 name=name,
                 last_used=dataset_timestamp,
                 last_updated=dataset_timestamp,
@@ -104,10 +109,14 @@ class DatasetManager:
                     DatasetFile(paths=file, adler32="xxx", file_events=0, file_size=0)
                     for file in file_list
                 ],
-            )
+            ).on_conflict_do_nothing()
+            db.session.execute(statement)
+            dataset = Dataset.find_by_name(name, with_lock=True)
+            if dataset is None:
+                raise RuntimeError(f"Dataset {name} should be created")
 
             logger.info(
-                f"Created new dataset for file list. Dataset Id is {dataset.id}",
+                f"Upserted dataset for file list. Dataset Id is {dataset.id}",
                 extra=extras,
             )
         else:
@@ -159,9 +168,6 @@ class DatasetManager:
 
     def refresh(self):
         self.db.session.refresh(self.dataset)
-
-    def lock(self):
-        self.db.session.refresh(self.dataset, with_for_update=True)
 
     def submit_lookup_request(self, advertised_endpoint, celery_app: Celery):
         task_id = celery_app.send_task(

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -520,11 +520,8 @@ class Dataset(db.Model):
         return result_obj
 
     @classmethod
-    def find_by_name(cls, name, with_lock=False) -> Optional["Dataset"]:
-        if with_lock:
-            return cls.query.filter_by(name=name, stale=False).with_for_update().first()
-        else:
-            return cls.query.filter_by(name=name, stale=False).first()
+    def find_by_name_with_lock(cls, name) -> Optional["Dataset"]:
+        return cls.query.filter_by(name=name, stale=False).with_for_update().first()
 
     @classmethod
     def find_by_id(cls, id) -> Optional["Dataset"]:

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -494,10 +494,9 @@ class Dataset(db.Model):
     transform_requests = relationship("TransformRequest", back_populates="dataset")
 
     __table_args__ = (
-        db.Index("ix_datasets_name", name,
-                 unique=True,
-                 postgresql_where=(stale.is_(False))
-                 ),
+        db.Index(
+            "ix_datasets_name", name, unique=True, postgresql_where=(stale.is_(False))
+        ),
     )
 
     def save_to_db(self):

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -480,7 +480,7 @@ class Dataset(db.Model):
     __tablename__ = "datasets"
 
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(1024), unique=False, nullable=False, index=True)
+    name = db.Column(db.String(1024), unique=False, nullable=False)
     last_used = db.Column(db.DateTime, nullable=False)
     last_updated = db.Column(db.DateTime, nullable=True)
     did_finder = db.Column(db.String(64), nullable=False)
@@ -492,6 +492,13 @@ class Dataset(db.Model):
 
     files = relationship("DatasetFile", back_populates="dataset")
     transform_requests = relationship("TransformRequest", back_populates="dataset")
+
+    __table_args__ = (
+        db.Index("ix_datasets_name", name,
+                 unique=True,
+                 postgresql_where=(stale.is_(False))
+                 ),
+    )
 
     def save_to_db(self):
         db.session.add(self)
@@ -514,8 +521,11 @@ class Dataset(db.Model):
         return result_obj
 
     @classmethod
-    def find_by_name(cls, name) -> Optional["Dataset"]:
-        return cls.query.filter_by(name=name, stale=False).first()
+    def find_by_name(cls, name, with_lock=False) -> Optional["Dataset"]:
+        if with_lock:
+            return cls.query.filter_by(name=name, stale=False).with_for_update().first()
+        else:
+            return cls.query.filter_by(name=name, stale=False).first()
 
     @classmethod
     def find_by_id(cls, id) -> Optional["Dataset"]:

--- a/servicex_app/servicex_app/resources/transformation/submit.py
+++ b/servicex_app/servicex_app/resources/transformation/submit.py
@@ -230,11 +230,11 @@ class SubmitTransformationRequest(ServiceXResource):
                 # TODO: need to check to make sure bucket was created
                 # WHat happens if object-store and object_store is None?
 
-            # Transaction 1: persist the Dataset record and obtain a committed DB ID.
-            # This must commit before the TransformRequest is created so that the
-            # auto-increment dataset.id is assigned by the database.
             session = db.session
             with session.begin():
+                # persist the Dataset record and obtain a committed DB ID.
+                # This is flushed before the TransformRequest is created so that the
+                # auto-increment dataset.id is assigned by the database.
                 try:
                     dataset_manager = self._initialize_dataset_manager(
                         did, file_list, request_id, config
@@ -244,15 +244,12 @@ class SubmitTransformationRequest(ServiceXResource):
                         str(bad_request), extra={"request_id": request_id}
                     )
                     return {"message": str(bad_request)}, 400
+                # Flush any new dataset ID
+                db.session.flush()
 
-            # Do NOT access any SQLAlchemy model attributes between the two begin()
-            # blocks — that would trigger SQLAlchemy's autobegin and cause the next
-            # session.begin() to raise InvalidRequestError.
-
-            # Transaction 2: create the TransformRequest referencing the now-persisted
-            # Dataset ID.  Expired attributes on dataset_manager.dataset are lazy-loaded
-            # within this transaction.
-            with session.begin():
+                # create the TransformRequest referencing the now-persisted
+                # Dataset ID.  Expired attributes on dataset_manager.dataset are lazy-loaded
+                # within this transaction.
                 user = self.get_requesting_user()
 
                 request_rec = TransformRequest(
@@ -282,7 +279,6 @@ class SubmitTransformationRequest(ServiceXResource):
                 session.add(request_rec)
 
                 # If this request has a fresh DID then submit the lookup request to the DID Finder
-                dataset_manager.lock()  # refresh the dataset status, lock row
                 if dataset_manager.is_lookup_required:
                     dataset_manager.submit_lookup_request(
                         self._generate_advertised_endpoint(

--- a/servicex_app/servicex_app_test/test_dataset_manager.py
+++ b/servicex_app/servicex_app_test/test_dataset_manager.py
@@ -294,30 +294,6 @@ class TestDatasetManager(ResourceTestBase):
             dm.refresh()
             assert dm.dataset.lookup_status == DatasetStatus.complete
 
-    def test_lock(self, client):
-        def receive_orm_execute(state):
-            if state.is_select:
-                assert state.statement._for_update_arg is not None
-
-        with client.application.app_context():
-            with db.session.begin():
-                dm = DatasetManager.from_did(
-                    DIDParser("rucio://my-did?files=1"),
-                    logger=client.application.logger,
-                    db=db,
-                )
-
-            with db.session.begin():
-                try:
-                    event.listen(Session, "do_orm_execute", receive_orm_execute)
-                    # Before lock, we will NOT have a FOR UPDATE argument
-                    with pytest.raises(AssertionError):
-                        dm.dataset.id
-                    # the lock will issue SELECT with the FOR UPDATE
-                    dm.lock()
-                finally:
-                    event.remove(Session, "do_orm_execute", receive_orm_execute)
-
     def test_is_complete(self, client):
         with client.application.app_context():
             d = Dataset()

--- a/servicex_app/servicex_app_test/test_dataset_manager.py
+++ b/servicex_app/servicex_app_test/test_dataset_manager.py
@@ -41,8 +41,6 @@ from servicex_app.models import (
 )
 from servicex_app.models import db
 from servicex_app_test.resource_test_base import ResourceTestBase
-from sqlalchemy import event
-from sqlalchemy.orm import Session
 
 
 def mock_dataset(status: str, mocker) -> Dataset:


### PR DESCRIPTION
PR #1403 introduced a potential deadlock due to the presence of multiple transactions affecting a single dataset in the `submit.py` code path. Put those both in a single transaction. Also add Postgres upsert logic to ensure non-stale entries in `datasets` are unique, so we only create one dataset entry per DID even if multiple requests are made in a short time.