### PR TITLE
remove need to specify app for flask CLI and update documentation

### DIFF
--- a/docs/deployment/admin_page.md
+++ b/docs/deployment/admin_page.md
@@ -14,7 +14,7 @@ Returns a CSV of all users in the database with how many transformations have be
 The reporting module is also available from the flask admin CLI:
 
 ```commandline
-$ flask --app 'app:app' reports
+$ flask reports
 Usage: flask reports [OPTIONS] COMMAND [ARGS]...
 
 Options:
@@ -23,14 +23,14 @@ Options:
 Commands:
   user-transformation-count
 
-$ flask --app 'app:app' reports user-transformation-count --help
+$ flask reports user-transformation-count --help
 Usage: flask reports user-transformation-count [OPTIONS]
 
 Options:
   --days INTEGER  Number of days to look back
   --help          Show this message and exit.
 
-$ flask --app 'app:app' reports user-transformation-count
+$ flask reports user-transformation-count
 Name,Email,Institution,Experiment,Transforms (Last 30 Days)
 Test User,test@gmail.com,CERN,ATLAS,1
 ```

--- a/helm/servicex/templates/app/deployment.yaml
+++ b/helm/servicex/templates/app/deployment.yaml
@@ -61,7 +61,7 @@ spec:
         - name: APP_CONFIG_FILE
           value: "/opt/servicex/app.conf"
         - name: FLASK_APP
-          value: "/home/servicex/servicex/app.py"
+          value: "/home/servicex/servicex_app/app.py"
         - name: INSTANCE_NAME
           value: "{{ .Release.Name }}"
         - name: LOG_LEVEL

--- a/servicex_app/Dockerfile
+++ b/servicex_app/Dockerfile
@@ -25,8 +25,6 @@ ADD gai.conf /etc/gai.conf
 
 RUN chmod +x boot.sh
 
-#ENV FLASK_APP servicex
-
 USER servicex
 
 EXPOSE 5000


### PR DESCRIPTION
Fix the FLASK_APP env variable definition (managed with helm). This will allow the flask CLI including `flask reports` to work without needing to specify an app location.