### PR TITLE
Replace slashes by underscores and not colons

### DIFF
--- a/transformer_sidecar/src/transformer_sidecar/transformer.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer.py
@@ -182,7 +182,7 @@ def transform_file(
             # of the input file.
             result_extension = ".parquet" if result_format == "parquet" else ""
             hashed_file_name = hash_path(
-                _file_path.replace("/", ":") + result_extension
+                _file_path.replace("/", "_") + result_extension
             )
 
             # The transformer will write results here as they are generated. This


### PR DESCRIPTION
Having colons in the object names causes issues with URL generation and fsspec, since colons have a special meaning in URL parsing and fsspec language. Underscores are much more neutral.