### PR TITLE
Make compression configurable in python codeGen

### DIFF
--- a/code_generator_python/README.md
+++ b/code_generator_python/README.md
@@ -49,3 +49,18 @@ if __name__ == "__main__":
     r = ds.get_data_pandas_df(encoded_selection)
     print(r)
 ```
+
+Output File Compression
+-----------------------
+For output files in ROOT formats (`root-file` or `root-rntuple`), the compression algorithm and level can be configured across all queries processed by this code generator. The compression parameters are set in the Helm chart configuration:
+
+```
+codeGen:
+  python:
+    compressionAlgorithm: ZSTD
+    compressionLevel: 5
+```
+
+**Supported compression algorithms:** `ZLIB`, `LZMA`, `LZ4`, `ZSTD`
+
+**Supported compression levels:** Integer values between 0 and 9.

--- a/code_generator_python/python_code_generator/python_translator.py
+++ b/code_generator_python/python_code_generator/python_translator.py
@@ -31,6 +31,9 @@ import shutil
 
 from servicex_codegen.code_generator import CodeGenerator, GeneratedFileResult
 
+ALLOWED_COMPRESSION_ALGORITHMS = {"ZLIB", "LZMA", "LZ4", "ZSTD"}
+ALLOWED_COMPRESSION_LEVELS = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+
 
 class PythonTranslator(CodeGenerator):
 
@@ -38,6 +41,30 @@ class PythonTranslator(CodeGenerator):
     def generate_code(self, query, cache_path: str):
 
         src = base64.b64decode(query).decode("ascii")
+
+        compression_algorithm = os.environ.get("COMPRESSION_ALGORITHM", "ZSTD")
+        try:
+            compression_level = int(os.environ.get("COMPRESSION_LEVEL", 5))
+        except ValueError:
+            raise RuntimeError(
+                f"Invalid compression level '{os.environ.get('COMPRESSION_LEVEL', 5)}'. "
+            )
+
+        if compression_algorithm not in ALLOWED_COMPRESSION_ALGORITHMS:
+            raise RuntimeError(
+                f"Invalid compression algorithm '{compression_algorithm}'. "
+            )
+
+        if compression_level not in ALLOWED_COMPRESSION_LEVELS:
+            raise RuntimeError(f"Invalid compression level '{compression_level}'. ")
+
+        src = f"""
+import os
+os.environ['COMPRESSION_ALGORITHM'] = '{compression_algorithm}'
+os.environ['COMPRESSION_LEVEL'] = '{compression_level}'
+
+{src}
+"""
         hash = "no-hash"
         query_file_path = os.path.join(cache_path, hash)
 

--- a/code_generator_python/python_code_generator/templates/transform_single_file.py
+++ b/code_generator_python/python_code_generator/templates/transform_single_file.py
@@ -51,8 +51,14 @@ def transform_single_file(file_path: str, output_path: Path, output_format: str)
                     awkward_arrays = {default_tree_name: output}
                 elif isinstance(output, dict):
                     awkward_arrays = output
+                compression_algorithm = os.environ.get("COMPRESSION_ALGORITHM")
+                compression_level = int(os.environ.get("COMPRESSION_LEVEL"))
+
                 with open(output_path, "b+w") as wfile:
-                    with uproot.recreate(wfile) as writer:
+                    compression_obj = getattr(uproot, compression_algorithm)(
+                        compression_level
+                    )
+                    with uproot.recreate(wfile, compression=compression_obj) as writer:
                         for key in awkward_arrays.keys():
                             total_events = awkward_arrays[key].__len__()
                             if output_format == "root-file":

--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -97,6 +97,8 @@ codeGen:
     tag: develop
     defaultScienceContainerImage: sslhep/servicex_science_image_combined_root
     defaultScienceContainerTag: 5.7.4-6.38.04
+    compressionAlgorithm: ZSTD
+    compressionLevel: 5
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
Propagate compression algorithm and level to python codegen, similarly to how it was done for uproot-raw codegen in  https://github.com/ssl-hep/ServiceX/pull/1091.

(don't merge just yet – testing this at Purdue first)