### PR TITLE
remove need to log out when `flask user make-admin` is run.

### DIFF
--- a/servicex_app/servicex_app/decorators.py
+++ b/servicex_app/servicex_app/decorators.py
@@ -11,7 +11,7 @@ from flask import (
     url_for,
 )
 from flask_jwt_extended import get_jwt_identity, jwt_required, verify_jwt_in_request
-from flask_jwt_extended.exceptions import NoAuthorizationError, UserClaimsVerificationError
+from flask_jwt_extended.exceptions import NoAuthorizationError
 
 from servicex_app.models import UserModel, db
 

--- a/servicex_app/servicex_app/decorators.py
+++ b/servicex_app/servicex_app/decorators.py
@@ -11,7 +11,7 @@ from flask import (
     url_for,
 )
 from flask_jwt_extended import get_jwt_identity, jwt_required, verify_jwt_in_request
-from flask_jwt_extended.exceptions import NoAuthorizationError
+from flask_jwt_extended.exceptions import NoAuthorizationError, UserClaimsVerificationError
 
 from servicex_app.models import UserModel, db
 
@@ -124,12 +124,13 @@ def is_admin_user() -> bool:
     if not current_app.config.get("ENABLE_AUTH"):
         return False
     if session.get("is_authenticated"):
-        return bool(session.get("admin"))
+        user = UserModel.find_by_email(session.get("email"))
+        return user is not None and user.admin
     try:
         verify_jwt_in_request(locations=["headers"])
         user = get_jwt_user()
         return user is not None and user.admin
-    except (NoAuthorizationError, Exception):
+    except NoAuthorizationError:
         return False
 
 

--- a/servicex_app/servicex_app_test/test_decorators.py
+++ b/servicex_app/servicex_app_test/test_decorators.py
@@ -163,12 +163,12 @@ class TestDecorators(WebTestBase):
             assert response.json == data
 
     def test_admin_decorator_integration_oauth_authorized(self, mocker, user):
+        user.admin = True
         client = self._test_client(extra_config={"ENABLE_AUTH": True})
         data = {"users": [{"id": 1234}]}
         mocker.patch("servicex_app.models.UserModel.return_all", return_value=data)
         with client.session_transaction() as sess:
             sess["is_authenticated"] = True
-            sess["admin"] = True
         with client.application.app_context():
             response: Response = client.get("users")
             assert response.status_code == 200
@@ -178,7 +178,6 @@ class TestDecorators(WebTestBase):
         client = self._test_client(extra_config={"ENABLE_AUTH": True})
         with client.session_transaction() as sess:
             sess["is_authenticated"] = True
-            sess["admin"] = False
         with client.application.app_context():
             response: Response = client.get("users")
             assert response.status_code == 401


### PR DESCRIPTION
I observed a "bug" while testing the `flask user make-admin` command. After the CLI command is run, the user does not immediately see the "Admin" panel on the navbar. The user must log out and log back in. (The problem is that the server cannot invalidate a session without installing additional server side session middleware which seems outside the scope of this issue.)

To resolve, this PR checks against the actual db user.admin value every time the `is_admin_user` is run. That function is executed every UI page load and is nested inside `@auth_required` which is most routes. This seems kind of heavy overhead to add given how rarely the `make-admin` CLI command will be run. I think an acceptable (and simpler) alternative would be to add output to the `make-admin` command to instruct the user to log out and log back in. Please share thoughts on whether these changes should be made.