### PR TITLE
admin page and cli improvements

### DIFF
--- a/servicex_app/servicex_app/__init__.py
+++ b/servicex_app/servicex_app/__init__.py
@@ -210,19 +210,19 @@ def create_app(
         list_users(email_filter)
 
     @user_cli.command("approve")
-    @click.argument("sub")
-    def approve_user_command(sub):
-        approve_user(sub)
+    @click.argument("email")
+    def approve_user_command(email):
+        approve_user(email)
 
     @user_cli.command("make-admin")
-    @click.argument("sub")
-    def make_admin_command(sub):
-        set_user_admin(sub, True)
+    @click.argument("email")
+    def make_admin_command(email):
+        set_user_admin(email, True)
 
     @user_cli.command("revoke-admin")
-    @click.argument("sub")
-    def revoke_admin_command(sub):
-        set_user_admin(sub, False)
+    @click.argument("email")
+    def revoke_admin_command(email):
+        set_user_admin(email, False)
 
     app.cli.add_command(user_cli)
 

--- a/servicex_app/servicex_app/cli/user_commands.py
+++ b/servicex_app/servicex_app/cli/user_commands.py
@@ -51,33 +51,36 @@ def list_users(email_filter=None) -> None:
         )
 
 
-def approve_user(sub: str) -> None:
-    user = UserModel.find_by_sub(sub)
+def approve_user(email: str) -> None:
+    user = UserModel.find_by_email(email)
     if user and user.pending:
         user.pending = False
         user.save_to_db()
-        print(f"User {sub} approved")
+        print(f"User {email} approved")
     elif user and not user.pending:
-        print(f"User {sub} already approved")
+        print(f"User {email} already approved")
     else:
-        print(f"User {sub} not found")
+        print(f"User {email} not found")
 
 
-def set_user_admin(sub: str, value: bool = True) -> None:
-    user = UserModel.find_by_sub(sub)
+def set_user_admin(email: str, value: bool = True) -> None:
+    user = UserModel.find_by_email(email)
     if not user:
-        print(f"User {sub} not found")
+        print(f"User {email} not found")
+        return
 
     if user.admin == value:
         if user.admin:
-            print(f"User {sub} already admin")
+            print(f"User {email} already admin")
         else:
-            print(f"User {sub} already not admin")
+            print(f"User {email} already not admin")
         return
 
     user.admin = value
     user.save_to_db()
     if user.admin:
-        print(f"User {sub} made admin")
+        print(f"User {email} made admin")
+        print()
+        print(f"Please instruct the user to log out and log back in for these changes to take effect!")
     else:
-        print(f"User {sub} admin privileges revoked")
+        print(f"User {email} admin privileges revoked")

--- a/servicex_app/servicex_app/cli/user_commands.py
+++ b/servicex_app/servicex_app/cli/user_commands.py
@@ -82,7 +82,7 @@ def set_user_admin(email: str, value: bool = True) -> None:
         print(f"User {email} made admin")
         print()
         print(
-            f"Please instruct the user to log out and log back in for these changes to take effect!"
+            "Please instruct the user to log out and log back in for these changes to take effect!"
         )
     else:
         print(f"User {email} admin privileges revoked")

--- a/servicex_app/servicex_app/cli/user_commands.py
+++ b/servicex_app/servicex_app/cli/user_commands.py
@@ -81,6 +81,8 @@ def set_user_admin(email: str, value: bool = True) -> None:
     if user.admin:
         print(f"User {email} made admin")
         print()
-        print(f"Please instruct the user to log out and log back in for these changes to take effect!")
+        print(
+            f"Please instruct the user to log out and log back in for these changes to take effect!"
+        )
     else:
         print(f"User {email} admin privileges revoked")

--- a/servicex_app/servicex_app/web/admin/__init__.py
+++ b/servicex_app/servicex_app/web/admin/__init__.py
@@ -13,6 +13,10 @@ class AdminAuthMixin:
             return False
 
         user = UserModel.find_by_email(email)
+
+        if user is None:
+            return False
+
         return user.admin
 
     def inaccessible_callback(self, name, **kwargs):

--- a/servicex_app/servicex_app/web/admin/__init__.py
+++ b/servicex_app/servicex_app/web/admin/__init__.py
@@ -1,13 +1,19 @@
-from flask import redirect, url_for
+from flask import redirect, url_for, session
 
-from servicex_app.decorators import is_admin_user
+from servicex_app.models import UserModel
 
 
 class AdminAuthMixin:
     endpoint: str | None = None
 
     def is_accessible(self):
-        return is_admin_user()
+        email = session.get("email")
+
+        if email is None:
+            return False
+
+        user = UserModel.find_by_email(email)
+        return user.admin
 
     def inaccessible_callback(self, name, **kwargs):
         return redirect(url_for("home"))

--- a/servicex_app/servicex_app_test/test_app_init.py
+++ b/servicex_app/servicex_app_test/test_app_init.py
@@ -29,3 +29,31 @@ class TestAppInit:
         monkeypatch.delenv("ALLOWED_IMAGE_PREFIXES", raising=False)
         with pytest.raises(ValueError, match="must be configured"):
             servicex_app.create_app()
+
+
+class TestUserCli:
+    @pytest.fixture
+    def app(self):
+        os.environ["APP_CONFIG_FILE"] = str(
+            os.path.join(os.path.dirname(__file__), "test.config")
+        )
+        os.environ["ALLOWED_IMAGE_PREFIXES"] = '["sslhep/"]'
+        return servicex_app.create_app()
+
+    def test_approve_command_dispatches_to_approve_user(self, app, mocker):
+        mock = mocker.patch("servicex_app.approve_user")
+        result = app.test_cli_runner().invoke(args=["user", "approve", "x@y.com"])
+        assert result.exit_code == 0
+        mock.assert_called_once_with("x@y.com")
+
+    def test_make_admin_command_dispatches_to_set_user_admin(self, app, mocker):
+        mock = mocker.patch("servicex_app.set_user_admin")
+        result = app.test_cli_runner().invoke(args=["user", "make-admin", "x@y.com"])
+        assert result.exit_code == 0
+        mock.assert_called_once_with("x@y.com", True)
+
+    def test_revoke_admin_command_dispatches_to_set_user_admin(self, app, mocker):
+        mock = mocker.patch("servicex_app.set_user_admin")
+        result = app.test_cli_runner().invoke(args=["user", "revoke-admin", "x@y.com"])
+        assert result.exit_code == 0
+        mock.assert_called_once_with("x@y.com", False)

--- a/servicex_app/servicex_app_test/test_cli_user_commands.py
+++ b/servicex_app/servicex_app_test/test_cli_user_commands.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from servicex_app.cli.user_commands import list_users, set_user_admin
+from servicex_app.cli.user_commands import approve_user, list_users, set_user_admin
 
 
 def _make_user(
@@ -124,3 +124,38 @@ class TestSetUserAdmin:
         set_user_admin(user.email, value=False)
         user.save_to_db.assert_not_called()
         assert "already not admin" in capsys.readouterr().out
+
+    def test_user_not_found(self, mocker, capsys):
+        mocker.patch(
+            "servicex_app.cli.user_commands.UserModel"
+        ).find_by_email.return_value = None
+        set_user_admin("nobody@example.com", value=True)
+        assert "not found" in capsys.readouterr().out
+
+
+class TestApproveUser:
+    def test_approves_pending_user(self, mocker, capsys):
+        user = _make_user(pending=True)
+        mocker.patch(
+            "servicex_app.cli.user_commands.UserModel"
+        ).find_by_email.return_value = user
+        approve_user(user.email)
+        assert user.pending is False
+        user.save_to_db.assert_called_once()
+        assert "approved" in capsys.readouterr().out
+
+    def test_already_approved_skips_save(self, mocker, capsys):
+        user = _make_user(pending=False)
+        mocker.patch(
+            "servicex_app.cli.user_commands.UserModel"
+        ).find_by_email.return_value = user
+        approve_user(user.email)
+        user.save_to_db.assert_not_called()
+        assert "already approved" in capsys.readouterr().out
+
+    def test_user_not_found(self, mocker, capsys):
+        mocker.patch(
+            "servicex_app.cli.user_commands.UserModel"
+        ).find_by_email.return_value = None
+        approve_user("nobody@example.com")
+        assert "not found" in capsys.readouterr().out

--- a/servicex_app/servicex_app_test/test_cli_user_commands.py
+++ b/servicex_app/servicex_app_test/test_cli_user_commands.py
@@ -91,8 +91,8 @@ class TestSetUserAdmin:
         user = _make_user(admin=False)
         mocker.patch(
             "servicex_app.cli.user_commands.UserModel"
-        ).find_by_sub.return_value = user
-        set_user_admin("sub1", value=True)
+        ).find_by_email.return_value = user
+        set_user_admin(user.email, value=True)
         assert user.admin is True
         user.save_to_db.assert_called_once()
         assert "made admin" in capsys.readouterr().out
@@ -101,8 +101,8 @@ class TestSetUserAdmin:
         user = _make_user(admin=True)
         mocker.patch(
             "servicex_app.cli.user_commands.UserModel"
-        ).find_by_sub.return_value = user
-        set_user_admin("sub1", value=False)
+        ).find_by_email.return_value = user
+        set_user_admin(user.email, value=False)
         assert user.admin is False
         user.save_to_db.assert_called_once()
         assert "revoked" in capsys.readouterr().out
@@ -111,8 +111,8 @@ class TestSetUserAdmin:
         user = _make_user(admin=True)
         mocker.patch(
             "servicex_app.cli.user_commands.UserModel"
-        ).find_by_sub.return_value = user
-        set_user_admin("sub1", value=True)
+        ).find_by_email.return_value = user
+        set_user_admin(user.email, value=True)
         user.save_to_db.assert_not_called()
         assert "already admin" in capsys.readouterr().out
 
@@ -120,7 +120,7 @@ class TestSetUserAdmin:
         user = _make_user(admin=False)
         mocker.patch(
             "servicex_app.cli.user_commands.UserModel"
-        ).find_by_sub.return_value = user
-        set_user_admin("sub1", value=False)
+        ).find_by_email.return_value = user
+        set_user_admin(user.email, value=False)
         user.save_to_db.assert_not_called()
         assert "already not admin" in capsys.readouterr().out

--- a/servicex_app/servicex_app_test/web/admin/test_admin_auth_mixin.py
+++ b/servicex_app/servicex_app_test/web/admin/test_admin_auth_mixin.py
@@ -19,16 +19,18 @@ class TestAdminAuthMixin(WebTestBase):
         with client.application.test_request_context():
             assert mixin.is_accessible() is False
 
-    def test_is_admin_true_with_session_admin(self, auth_client, mixin):
+    def test_is_admin_true_with_session_admin(self, auth_client, mixin, user):
+        user.admin = True
         with auth_client.application.test_request_context():
             session["is_authenticated"] = True
-            session["admin"] = True
+            session["email"] = user.email
             assert mixin.is_accessible() is True
 
-    def test_is_admin_false_with_session_not_admin(self, auth_client, mixin):
+    def test_is_admin_false_with_session_not_admin(self, auth_client, mixin, user):
+        user.admin = False
         with auth_client.application.test_request_context():
             session["is_authenticated"] = True
-            session["admin"] = False
+            session["email"] = user.email
             assert mixin.is_accessible() is False
 
     def test_is_admin_false_with_session_authenticated_but_no_admin_key(
@@ -36,22 +38,6 @@ class TestAdminAuthMixin(WebTestBase):
     ):
         with auth_client.application.test_request_context():
             session["is_authenticated"] = True
-            assert mixin.is_accessible() is False
-
-    def test_is_admin_true_with_jwt_admin_user(self, auth_client, mixin, mocker):
-        mock_user = mocker.MagicMock()
-        mock_user.admin = True
-        mocker.patch("servicex_app.decorators.verify_jwt_in_request")
-        mocker.patch("servicex_app.decorators.get_jwt_user", return_value=mock_user)
-        with auth_client.application.test_request_context():
-            assert mixin.is_accessible() is True
-
-    def test_is_admin_false_with_jwt_non_admin_user(self, auth_client, mixin, mocker):
-        mock_user = mocker.MagicMock()
-        mock_user.admin = False
-        mocker.patch("servicex_app.decorators.verify_jwt_in_request")
-        mocker.patch("servicex_app.decorators.get_jwt_user", return_value=mock_user)
-        with auth_client.application.test_request_context():
             assert mixin.is_accessible() is False
 
     def test_is_admin_false_on_no_authorization_error(self, auth_client, mixin, mocker):

--- a/servicex_app/servicex_app_test/web/admin/test_admin_index.py
+++ b/servicex_app/servicex_app_test/web/admin/test_admin_index.py
@@ -6,11 +6,12 @@ from servicex_app_test.web.web_test_base import WebTestBase
 
 class TestSecureAdminIndexView(WebTestBase):
     @pytest.fixture
-    def admin_client(self):
+    def admin_client(self, user):
+        user.admin = True
         client = self._test_client(extra_config={"ENABLE_AUTH": True})
         with client.session_transaction() as sess:
             sess["is_authenticated"] = True
-            sess["admin"] = True
+            sess["email"] = user.email
         return client
 
     @pytest.fixture

--- a/servicex_app/servicex_app_test/web/admin/test_report_views.py
+++ b/servicex_app/servicex_app_test/web/admin/test_report_views.py
@@ -123,11 +123,12 @@ class TestUserTransformationCountReportView:
 
 class TestReportViewHttp(WebTestBase):
     @pytest.fixture
-    def admin_client(self):
+    def admin_client(self, user):
+        user.admin = True
         client = self._test_client(extra_config={"ENABLE_AUTH": True})
         with client.session_transaction() as sess:
             sess["is_authenticated"] = True
-            sess["admin"] = True
+            sess["email"] = user.email
         return client
 
     def test_report_index_renders_for_admin(self, admin_client):


### PR DESCRIPTION
Makes the following changes:

1. Change user CLI commands to use email instead of sub.
2. Make `AdminAuthMixin` lookup the `user.admin` value in the db instead of session.
3. Add a line to the `make-admin` CLI output instructing the user to log out and back in.