### PR TITLE
Quote the value for the CVMFS_AVAILABLE so Go Template parses it correctly

### DIFF
--- a/helm/servicex/templates/codegen/deployment.yaml
+++ b/helm/servicex/templates/codegen/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: COMPRESSION_LEVEL
           value: "{{ $compressionLevel }}"
         - name: CVMFS_AVAILABLE
-          value: {{ $.Values.transformer.cvmfsAvailable | ternary "1" "0" }}
+          value: "{{ $.Values.transformer.cvmfsAvailable | ternary "1" "0" }}"
         tty: true
         stdin: true
         imagePullPolicy: {{ .pullPolicy }}


### PR DESCRIPTION
# Problem
If `cvmfsAvailable` is false when you install the helm chart you get 

```
Error: server-side apply failed for object default/servicex-ben-code-gen-uproot-raw apps/v1, Kind=Deployment: failed to create typed patch object (default/servicex-ben-code-gen-uproot-raw; apps/v1, Kind=Deployment): .spec.template.spec.containers[name="servicex-ben-code-gen-uproot-raw"].env[name="CVMFS_AVAILABLE"].value: expected string, got &value.valueUnstructured{Value:0}
```

This error is telling us that Kubernetes expected the value field to be a string, but it received an integer 0 instead.

The ternary function returns "1" or "0" as strings, but YAML is interpreting the unquoted 0 as an integer when the template is rendered. 

Kubernetes requires env var value fields to always be strings.
