### PR TITLE
Make configured Celery app the process-wide default

### DIFF
--- a/servicex_app/servicex_app/__init__.py
+++ b/servicex_app/servicex_app/__init__.py
@@ -331,6 +331,12 @@ def create_app(
 
             celery_app = Celery("ServiceX-App", broker=app.config["RABBIT_MQ_URL"])
             celery_app.conf.task_routes = (route_task,)
+            # Register as the process-wide default app so that @shared_task
+            # invocations (e.g. add_files_to_processing_queue.delay) resolve to
+            # this configured app from any thread — not just the thread that ran
+            # create_app. Without this, Flask request worker threads fall back to
+            # Celery's built-in default app and its default broker.
+            celery_app.set_default()
         else:
             celery_app = provided_celery_app
 


### PR DESCRIPTION
# Problem:
The app can't submit transform requests when run outside of the docker container since 
we don't have the external server_tasks worker running. 
  
The LookupResultProcessor enqueues work via add_files_to_processing_queue,
  a @shared_task whose target app is resolved at call time from Celery's
  "current app". 

Celery(set_as_current=True) only sets the current app on
  the thread that ran create_app (startup thread). The actual .delay()
  call happens on a Flask request worker thread, where no current app is
  set, so the shared task falls back to Celery's built-in default app and
  its default broker (amqp://guest@localhost//) — ignoring RABBIT_MQ_URL
  and the configured task_routes.

  Call celery_app.set_default() to register the configured app as the
  process-wide default so shared-task sends resolve to it from any thread.