### PR TITLE
Make the Dashboard the home page of the flask app

### DIFF
--- a/servicex_app/servicex_app/templates/base.html
+++ b/servicex_app/servicex_app/templates/base.html
@@ -31,7 +31,16 @@
   <header class="site-header">
     <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
       <div class="container">
-        <a class="navbar-brand mr-4" href="/">ServiceX</a>
+          {% if config["ENABLE_AUTH"] %}
+            {% if session['is_authenticated'] %}
+            <a class="navbar-brand mr-4" href="{{ url_for('user-dashboard') }}" >ServiceX</a>
+            {% else %}
+            <a class="navbar-brand mr-4" href="{{ url_for('home') }}" >ServiceX</a>
+            {% endif %}
+          {%  else %}
+          <a class="navbar-brand mr-4" href="{{ url_for('global-dashboard') }}" >ServiceX</a>
+          {% endif %}
+
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggle"
           aria-controls="navbarToggle" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
@@ -43,11 +52,6 @@
             <li class="nav-item">
               <a class="nav-link" href="{{ config['DOCS_BASE_URL'] }}" target="_blank">Docs</a>
             </li>
-            {% if not config['ENABLE_AUTH'] %}
-            <li class="nav-item">
-              <a href="{{ url_for('global-dashboard') }}" class="nav-link">Dashboard</a>
-            </li>
-            {% endif %}
           </ul>
 
 
@@ -67,9 +71,6 @@
               <a class="nav-link" href="{{ url_for('sign_in') }}">Sign In</a>
             </li>
             {% else %}
-            <li class="nav-item">
-              <a class="nav-link" href="{{ url_for('user-dashboard') }}">Dashboard</a>
-            </li>
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('monitor') }}">Monitor</a>
             </li>


### PR DESCRIPTION
Resolves #1301 

# Problem
The "Home" page of the web app is a static page that just says "Welcome to ServiceX" - not very useful. The dashboard is where the action is.

# Approach
Made the "ServiceX" menu item take you to the dashboard. Removed the link to the dashboard.

If there is Auth enabled, but you aren't logged in, we show the "Welcome to ServiceX" page

Updated the link from "Docs" to the new docs.

# Testing 
This is deployed to testing 1

## Not logged in:
<img width="1201" height="176" alt="image" src="https://github.com/user-attachments/assets/aabbdefd-0be2-455a-946f-ce9a91f7ed57" />


## Logged in
<img width="1223" height="650" alt="image" src="https://github.com/user-attachments/assets/60a11f1c-0fdb-46b6-a28b-d02d79390785" />


## No Auth (on my laptop)
<img width="1254" height="551" alt="image" src="https://github.com/user-attachments/assets/89682ee7-0739-4b0e-99cb-4b94c9458838" />
