### PR TITLE
Fix requests table horizontal scrolling and truncate long titles

### DIFF
--- a/servicex_app/servicex_app/templates/global_dashboard.html
+++ b/servicex_app/servicex_app/templates/global_dashboard.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-  <div>
+  <div class="col-12">
     <div class="content-section">
       <div class="row justify-content-between align-items-center">
         <h4 class="mb-3 col-auto">Transformation Requests</h4>

--- a/servicex_app/servicex_app/templates/requests_table.html
+++ b/servicex_app/servicex_app/templates/requests_table.html
@@ -3,81 +3,83 @@
 {% from 'bootstrap5/pagination.html' import render_pagination %}
 
 {% macro requests_table(pagination, humanize) %}
-<table class="table table-sm table-bordered table-striped">
-  <caption>All times in timezone: <span class="tz"></span>.</caption>
-  <thead class="thead-dark">
-    <tr>
-      <th scope="col">Title</th>
-      {% if config['ENABLE_AUTH'] %}<th scope="col">Submitted by</th>{% endif %}
-      <th scope="col">Start time</th>
-      <th scope="col">Finish time</th>
-      <th scope="col">Status</th>
-      <th scope="col">Files completed</th>
-      <th scope="col">Workers</th>
-      <th scope="col">Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for req in pagination.items %}
-    <tr>
-      <th scope="row" style="word-break: break-all">
-        <a href="{{ create_kibana_link(req.request_id, "ERROR") }}" target="_blank">
-        <img src="{{ url_for('static', filename='logs.svg') }}" height="25" alt="Get Logs" />
-        </a>
-        <a href="/transformation-request/{{ req.id }}">{{ req.title or "Untitled" }}</a>
-      </th>
+<div class="table-responsive">
+  <table class="table table-sm table-bordered table-striped">
+      <caption>All times in timezone: <span class="tz"></span>.</caption>
+      <thead class="thead-dark">
+        <tr>
+          <th scope="col">Title</th>
+          {% if config['ENABLE_AUTH'] %}<th scope="col">Submitted by</th>{% endif %}
+          <th scope="col">Start time</th>
+          <th scope="col">Finish time</th>
+          <th scope="col">Status</th>
+          <th scope="col">Files completed</th>
+          <th scope="col">Workers</th>
+          <th scope="col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for req in pagination.items %}
+        <tr>
+          <th scope="row" style="max-width: 250px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+            <a href="{{ create_kibana_link(req.request_id, "ERROR") }}" target="_blank">
+            <img src="{{ url_for('static', filename='logs.svg') }}" height="25" alt="Get Logs" />
+            </a>
+            <a href="/transformation-request/{{ req.id }}" title="{{ req.title or 'Untitled' }}">{{ req.title or "Untitled" }}</a>
+          </th>
 
-      {% if config['ENABLE_AUTH'] %}<td>{{ req.submitter_name }}</td>{% endif %}
-      <td>{{ moment(req.submit_time).format("YYYY-MM-DD HH:mm:ss") }}</td>
+          {% if config['ENABLE_AUTH'] %}<td>{{ req.submitter_name }}</td>{% endif %}
+          <td>{{ moment(req.submit_time).format("YYYY-MM-DD HH:mm:ss") }}</td>
 
-      <td id="finish-time-{{ req.request_id }}">
-        {{ moment(req.finish_time).format("YYYY-MM-DD HH:mm:ss") if req.finish_time else "-" }}
-      </td>
+          <td id="finish-time-{{ req.request_id }}">
+            {{ moment(req.finish_time).format("YYYY-MM-DD HH:mm:ss") if req.finish_time else "-" }}
+          </td>
 
-      <td>
-        <div id="status-{{ req.request_id }}">
-          {{ req.status.string_name }}
-        </div>
-        {% if req.status.string_name == 'Running' %}
-        <div class="progress" id="progress-{{ req.request_id }}">
-          <div class="progress-bar progress-bar-striped progress-bar-animated" id="progress-bar-{{ req.request_id }}">
-          </div>
-        </div>
-        {% endif %}
-      </td>
+          <td>
+            <div id="status-{{ req.request_id }}">
+              {{ req.status.string_name }}
+            </div>
+            {% if req.status.string_name == 'Running' %}
+            <div class="progress" id="progress-{{ req.request_id }}">
+              <div class="progress-bar progress-bar-striped progress-bar-animated" id="progress-bar-{{ req.request_id }}">
+              </div>
+            </div>
+            {% endif %}
+          </td>
 
-      <td>
-        <div>
-          <a id="files-completed-{{ req.request_id }}"
-            href="/transformation-request/{{ req.id }}/results?status=success">
-            {{ humanize.intcomma(req.files_completed) }}
-          </a> of
-          <span id="files-total-{{ req.request_id }}">
-            {{ humanize.intcomma(req.files or "Unknown") }}
-          </span>
-        </div>
+          <td>
+            <div>
+              <a id="files-completed-{{ req.request_id }}"
+                href="/transformation-request/{{ req.id }}/results?status=success">
+                {{ humanize.intcomma(req.files_completed) }}
+              </a> of
+              <span id="files-total-{{ req.request_id }}">
+                {{ humanize.intcomma(req.files or "Unknown") }}
+              </span>
+            </div>
 
-        <div {% if not req.files_failed %}style="display: none" {% endif %}
-          id="files-failed-wrapper-{{ req.request_id }}">
-          (<a id="files-failed-{{ req.request_id }}"
-            href="/transformation-request/{{ req.id }}/results?status=failure">{{ req.files_failed }}</a> failed)
-        </div>
+            <div {% if not req.files_failed %}style="display: none" {% endif %}
+              id="files-failed-wrapper-{{ req.request_id }}">
+              (<a id="files-failed-{{ req.request_id }}"
+                href="/transformation-request/{{ req.id }}/results?status=failure">{{ req.files_failed }}</a> failed)
+            </div>
 
-      </td>
-      <td id="replicas-{{ req.request_id }}">-</td>
-      <td>
-        {% if not req.status.is_complete %}
-        <button id="cancel-{{ req.request_id }}"
-          onclick="fetch('/servicex/transformation/{{ req.request_id }}/cancel').then((res) => location.reload())"
-          type="button" class="btn btn-danger btn-sm">
-          Cancel
-        </button>
-        {% endif %}
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+          </td>
+          <td id="replicas-{{ req.request_id }}">-</td>
+          <td>
+            {% if not req.status.is_complete %}
+            <button id="cancel-{{ req.request_id }}"
+              onclick="fetch('/servicex/transformation/{{ req.request_id }}/cancel').then((res) => location.reload())"
+              type="button" class="btn btn-danger btn-sm">
+              Cancel
+            </button>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+</div>
 {% if pagination.items %}
 {{ render_pagination(pagination, align='center') }}
 {% else %}

--- a/servicex_app/servicex_app/templates/user_dashboard.html
+++ b/servicex_app/servicex_app/templates/user_dashboard.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-<div>
+<div class="col-12">
   <div class="content-section">
     <div class="row justify-content-between align-items-center">
       <h4 class="mb-3 col-auto">Transformation Requests</h4>


### PR DESCRIPTION
Resolves #1299 

# Problem 
This isn't really a safari issue, but an issue with how the dashboard scales when the window is resized.

# Approach
Switch the table wrapper to table-responsive so a horizontal scrollbar appears whenever the table overflows (the old table-responsive-xxl class does not exist in Bootstrap 4.5 and was a no-op). Constrain the Title column with text-overflow: ellipsis instead of word-break: break-all, and add a hover tooltip showing the full title.

Bound the dashboard content wrappers with col-12 so the table-responsive container is capped at the page width; previously the unbounded flex child grew to the table's full width, defeating overflow-x and clipping the right-most columns off-screen.

Resizes nicely now and puts a horizontal scroller if we get too skinny

<img width="716" height="1125" alt="image" src="https://github.com/user-attachments/assets/93a302f7-6a7f-4d3f-8c4e-d9afb3e0b6fb" />
