### PR TITLE
add basic usage report

### DIFF
--- a/servicex_app/migrations/versions/1.8.4.py
+++ b/servicex_app/migrations/versions/1.8.4.py
@@ -16,15 +16,9 @@ depends_on = None
 
 def upgrade():
     op.create_index(
-        op.f("ix_requests_submit_time"),
-        "requests",
-        ["submit_time"],
-        unique=False
+        op.f("ix_requests_submit_time"), "requests", ["submit_time"], unique=False
     )
 
 
 def downgrade():
-    op.drop_index(
-        op.f("ix_requests_submit_time"),
-        table_name="requests"
-    )
+    op.drop_index(op.f("ix_requests_submit_time"), table_name="requests")

--- a/servicex_app/migrations/versions/1.8.4.py
+++ b/servicex_app/migrations/versions/1.8.4.py
@@ -1,0 +1,30 @@
+"""
+add index to TransformRequest.submit_time
+
+Revision ID: v1_8_4
+Revises: v1_8_3a
+Create Date: 2026-07-30 20:52:15.921295
+"""
+
+from alembic import op
+
+revision = "v1_8_4"
+down_revision = "v1_8_3a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        op.f("ix_requests_submit_time"),
+        "requests",
+        ["submit_time"],
+        unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f("ix_requests_submit_time"),
+        table_name="requests"
+    )

--- a/servicex_app/servicex_app/web/admin/admin.py
+++ b/servicex_app/servicex_app/web/admin/admin.py
@@ -13,7 +13,7 @@ from servicex_app.web.admin.reports import ReportView
 from servicex_app.web.admin.reports.user_transformation_count import (  # noqa: F401
     UserTransformationCountReportView,
 )
-from servicex_app.web.admin.reports.usage_report import UsageReportView # noqa: F401
+from servicex_app.web.admin.reports.usage_report import UsageReportView  # noqa: F401
 
 Unique.field_flags = {"unique": True}
 FieldListInputRequired.field_flags = {"required": True}

--- a/servicex_app/servicex_app/web/admin/admin.py
+++ b/servicex_app/servicex_app/web/admin/admin.py
@@ -13,6 +13,7 @@ from servicex_app.web.admin.reports import ReportView
 from servicex_app.web.admin.reports.user_transformation_count import (  # noqa: F401
     UserTransformationCountReportView,
 )
+from servicex_app.web.admin.reports.usage_report import UsageReportView # noqa: F401
 
 Unique.field_flags = {"unique": True}
 FieldListInputRequired.field_flags = {"required": True}

--- a/servicex_app/servicex_app/web/admin/reports/__init__.py
+++ b/servicex_app/servicex_app/web/admin/reports/__init__.py
@@ -26,7 +26,7 @@ class ReportView(AdminAuthMixin, BaseView):
         if "abstract" not in cls.__dict__:
             cls.abstract = False
 
-    def write_output(self, output: TextIO, **kwargs):
+    def write_output(self, output: io.StringIO, **kwargs):
         raise NotImplementedError
 
     @expose("/")
@@ -58,15 +58,27 @@ class SqlCsvReportView(ReportView):
     filename = "report.csv"
     mimetype = "text/csv"
     abstract = True
+    max_download_size: int | None = None # kilobytes
 
     def get_query(self, **kwargs) -> Select:
         raise NotImplementedError
 
-    def write_output(self, output: TextIO, **kwargs) -> None:
+    def write_output(self, output: io.StringIO, **kwargs) -> None:
         from servicex_app.models import db
 
         writer = csv.writer(output)
         results: CursorResult = db.session.execute(self.get_query(**kwargs))
         writer.writerow(results.keys())
+
+        limit = self.max_download_size * 1024 if self.max_download_size else None
+        written = len(output.getvalue().encode("utf-8")) if limit is not None else 0
+
         for row in results:
+            if limit is not None:
+                probe = io.StringIO()
+                csv.writer(probe).writerow(row)
+                row_bytes = len(probe.getvalue().encode("utf-8"))
+                if written + row_bytes > limit:
+                    break
+                written += row_bytes
             writer.writerow(row)

--- a/servicex_app/servicex_app/web/admin/reports/__init__.py
+++ b/servicex_app/servicex_app/web/admin/reports/__init__.py
@@ -58,6 +58,7 @@ class SqlCsvReportView(ReportView):
     mimetype = "text/csv"
     abstract = True
     max_download_size: int | None = None  # kilobytes
+    stream_batch_size = 1000
 
     def get_query(self, **kwargs) -> Select:
         raise NotImplementedError
@@ -66,7 +67,10 @@ class SqlCsvReportView(ReportView):
         from servicex_app.models import db
 
         writer = csv.writer(output)
-        results: CursorResult = db.session.execute(self.get_query(**kwargs))
+        results: CursorResult = db.session.execute(
+            self.get_query(**kwargs),
+            execution_options={"yield_per": self.stream_batch_size},
+        )
         writer.writerow(results.keys())
 
         limit = self.max_download_size * 1024 if self.max_download_size else None

--- a/servicex_app/servicex_app/web/admin/reports/__init__.py
+++ b/servicex_app/servicex_app/web/admin/reports/__init__.py
@@ -1,6 +1,5 @@
 import csv
 import io
-from typing import TextIO
 
 from sqlalchemy import Select
 from sqlalchemy.engine import CursorResult

--- a/servicex_app/servicex_app/web/admin/reports/__init__.py
+++ b/servicex_app/servicex_app/web/admin/reports/__init__.py
@@ -58,7 +58,7 @@ class SqlCsvReportView(ReportView):
     filename = "report.csv"
     mimetype = "text/csv"
     abstract = True
-    max_download_size: int | None = None # kilobytes
+    max_download_size: int | None = None  # kilobytes
 
     def get_query(self, **kwargs) -> Select:
         raise NotImplementedError

--- a/servicex_app/servicex_app/web/admin/reports/usage_report.py
+++ b/servicex_app/servicex_app/web/admin/reports/usage_report.py
@@ -1,6 +1,3 @@
-from datetime import datetime, timedelta
-
-import click
 from sqlalchemy import Select, desc, select
 
 from servicex_app.models import TransformRequest, UserModel
@@ -13,16 +10,10 @@ class UsageReportView(SqlCsvReportView):
     endpoint = "usage-report"
     filename = "usage_report.csv"
     description = (
-        "CSV of all users who have submitted at least one transform in the last N days."
+        "List of transforms executed"
     )
-    params = [
-        click.Option(
-            ["--days"], default=30, type=int, help="Number of days to look back"
-        ),
-    ]
 
-    def get_query(self, days: int = 30) -> Select:
-        cutoff = datetime.utcnow() - timedelta(days=days)
+    def get_query(self) -> Select:
         return (
             select(
                 UserModel.name.label("Name"),
@@ -31,6 +22,5 @@ class UsageReportView(SqlCsvReportView):
                 UserModel.created_at.label("Run Time"),
             )
             .join(TransformRequest, TransformRequest.submitted_by == UserModel.id)
-            .filter(TransformRequest.submit_time >= cutoff)
             .order_by(desc(UserModel.created_at))
         )

--- a/servicex_app/servicex_app/web/admin/reports/usage_report.py
+++ b/servicex_app/servicex_app/web/admin/reports/usage_report.py
@@ -9,9 +9,7 @@ class UsageReportView(SqlCsvReportView):
     report_name = "Usage"
     endpoint = "usage-report"
     filename = "usage_report.csv"
-    description = (
-        "List of transforms executed"
-    )
+    description = "List of transforms executed"
 
     def get_query(self) -> Select:
         return (

--- a/servicex_app/servicex_app/web/admin/reports/usage_report.py
+++ b/servicex_app/servicex_app/web/admin/reports/usage_report.py
@@ -17,8 +17,8 @@ class UsageReportView(SqlCsvReportView):
                 UserModel.name.label("Name"),
                 UserModel.email.label("Email"),
                 UserModel.institution.label("Institution"),
-                UserModel.created_at.label("Run Time"),
+                TransformRequest.submit_time.label("Run Time"),
             )
             .join(TransformRequest, TransformRequest.submitted_by == UserModel.id)
-            .order_by(desc(UserModel.created_at))
+            .order_by(desc(TransformRequest.submit_time))
         )

--- a/servicex_app/servicex_app/web/admin/reports/usage_report.py
+++ b/servicex_app/servicex_app/web/admin/reports/usage_report.py
@@ -8,6 +8,7 @@ from servicex_app.web.admin.reports import SqlCsvReportView
 
 
 class UsageReportView(SqlCsvReportView):
+    max_download_size = 200 * 1024
     report_name = "Usage"
     endpoint = "usage-report"
     filename = "usage_report.csv"

--- a/servicex_app/servicex_app/web/admin/reports/usage_report.py
+++ b/servicex_app/servicex_app/web/admin/reports/usage_report.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Select, desc, select
+from sqlalchemy import Select, desc, select, cast, String
 
 from servicex_app.models import TransformRequest, UserModel
 from servicex_app.web.admin.reports import SqlCsvReportView
@@ -17,7 +17,24 @@ class UsageReportView(SqlCsvReportView):
                 UserModel.name.label("Name"),
                 UserModel.email.label("Email"),
                 UserModel.institution.label("Institution"),
+                TransformRequest.title.label("Title"),
+                cast(TransformRequest.status, String).label("Status"),
                 TransformRequest.submit_time.label("Run Time"),
+                TransformRequest.finish_time.label("Finish Time"),
+                TransformRequest.did.label("Dataset Identifier (DID)"),
+                TransformRequest.image.label("Image"),
+                TransformRequest.workers.label("Workers"),
+                TransformRequest.result_destination.label("Result Destination"),
+                TransformRequest.result_format.label("Result Format"),
+                TransformRequest.files.label("File Count"),
+                TransformRequest.files_completed.label("Files Completed"),
+                TransformRequest.files_failed.label("Files Failed"),
+                TransformRequest.total_events.label("Total Events"),
+                TransformRequest.did_lookup_time.label("DID Lookup Time"),
+                TransformRequest.app_version.label("App Version"),
+                TransformRequest.code_gen_image.label("Code Gen Image"),
+                TransformRequest.transformer_language.label("Transformer Language"),
+                TransformRequest.transformer_command.label("Transformer Command"),
             )
             .join(TransformRequest, TransformRequest.submitted_by == UserModel.id)
             .order_by(desc(TransformRequest.submit_time))

--- a/servicex_app/servicex_app/web/admin/reports/usage_report.py
+++ b/servicex_app/servicex_app/web/admin/reports/usage_report.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timedelta
+
+import click
+from sqlalchemy import Select, desc, select
+
+from servicex_app.models import TransformRequest, UserModel
+from servicex_app.web.admin.reports import SqlCsvReportView
+
+
+class UsageReportView(SqlCsvReportView):
+    report_name = "Usage"
+    endpoint = "usage-report"
+    filename = "usage_report.csv"
+    description = (
+        "CSV of all users who have submitted at least one transform in the last N days."
+    )
+    params = [
+        click.Option(
+            ["--days"], default=30, type=int, help="Number of days to look back"
+        ),
+    ]
+
+    def get_query(self, days: int = 30) -> Select:
+        cutoff = datetime.utcnow() - timedelta(days=days)
+        return (
+            select(
+                UserModel.name.label("Name"),
+                UserModel.email.label("Email"),
+                UserModel.institution.label("Institution"),
+                UserModel.created_at.label("Run Time"),
+            )
+            .join(TransformRequest, TransformRequest.submitted_by == UserModel.id)
+            .filter(TransformRequest.submit_time >= cutoff)
+            .order_by(desc(UserModel.created_at))
+        )

--- a/servicex_app/servicex_app_test/web/admin/test_report_views.py
+++ b/servicex_app/servicex_app_test/web/admin/test_report_views.py
@@ -66,11 +66,11 @@ class TestSqlCsvReportView:
         mock_db_execute(["a", "b"], [("x" * 100, "y" * 100)] * 3)
         mocker.patch.object(SqlCsvReportView, "get_query", return_value=MagicMock())
 
-        class BoundedView(SqlCsvReportView):
+        class AllRowsBoundedView(SqlCsvReportView):
             max_download_size = 100  # 100 KB — well above the row total
 
         output = io.StringIO()
-        BoundedView().write_output(output)
+        AllRowsBoundedView().write_output(output)
         output.seek(0)
         rows = list(csv.reader(output))
         assert len(rows) == 4  # header + 3 data rows
@@ -81,11 +81,11 @@ class TestSqlCsvReportView:
         mock_db_execute(["a", "b"], [("x" * 100, "y" * 100)] * 10)
         mocker.patch.object(SqlCsvReportView, "get_query", return_value=MagicMock())
 
-        class BoundedView(SqlCsvReportView):
+        class ExceedLimitBoundedView(SqlCsvReportView):
             max_download_size = 1  # 1 KB — only a handful of rows fit
 
         output = io.StringIO()
-        BoundedView().write_output(output)
+        ExceedLimitBoundedView().write_output(output)
         output.seek(0)
         rows = list(csv.reader(output))
         assert 1 < len(rows) < 11  # some data rows written, but truncated

--- a/servicex_app/servicex_app_test/web/admin/test_report_views.py
+++ b/servicex_app/servicex_app_test/web/admin/test_report_views.py
@@ -100,7 +100,29 @@ class TestUsageReportView:
     def test_get_query_column_labels(self):
         query = UsageReportView().get_query()
         keys = list(query.exported_columns.keys())
-        assert keys == ["Name", "Email", "Institution", "Run Time"]
+        assert keys == [
+            "Name",
+            "Email",
+            "Institution",
+            "Title",
+            "Status",
+            "Run Time",
+            "Finish Time",
+            "Dataset Identifier (DID)",
+            "Image",
+            "Workers",
+            "Result Destination",
+            "Result Format",
+            "File Count",
+            "Files Completed",
+            "Files Failed",
+            "Total Events",
+            "DID Lookup Time",
+            "App Version",
+            "Code Gen Image",
+            "Transformer Language",
+            "Transformer Command",
+        ]
 
 
 class TestUserTransformationCountReportView:

--- a/servicex_app/servicex_app_test/web/admin/test_report_views.py
+++ b/servicex_app/servicex_app_test/web/admin/test_report_views.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy import Select
 
 from servicex_app.web.admin.reports import SqlCsvReportView, ReportView
+from servicex_app.web.admin.reports.usage_report import UsageReportView
 from servicex_app.web.admin.reports.user_transformation_count import (
     UserTransformationCountReportView,
 )
@@ -58,6 +59,48 @@ class TestSqlCsvReportView:
         rows = list(csv.reader(output))
         assert rows[0] == ["col_a", "col_b"]
         assert rows[1] == ["val_1", "val_2"]
+
+    def test_write_output_within_max_download_size_writes_all_rows(
+        self, mocker, mock_db_execute
+    ):
+        mock_db_execute(["a", "b"], [("x" * 100, "y" * 100)] * 3)
+        mocker.patch.object(SqlCsvReportView, "get_query", return_value=MagicMock())
+
+        class BoundedView(SqlCsvReportView):
+            max_download_size = 100  # 100 KB — well above the row total
+
+        output = io.StringIO()
+        BoundedView().write_output(output)
+        output.seek(0)
+        rows = list(csv.reader(output))
+        assert len(rows) == 4  # header + 3 data rows
+
+    def test_write_output_truncates_when_row_would_exceed_limit(
+        self, mocker, mock_db_execute
+    ):
+        mock_db_execute(["a", "b"], [("x" * 100, "y" * 100)] * 10)
+        mocker.patch.object(SqlCsvReportView, "get_query", return_value=MagicMock())
+
+        class BoundedView(SqlCsvReportView):
+            max_download_size = 1  # 1 KB — only a handful of rows fit
+
+        output = io.StringIO()
+        BoundedView().write_output(output)
+        output.seek(0)
+        rows = list(csv.reader(output))
+        assert 1 < len(rows) < 11  # some data rows written, but truncated
+        assert len(output.getvalue().encode("utf-8")) <= 1024
+
+
+class TestUsageReportView:
+    def test_get_query_returns_select(self):
+        query = UsageReportView().get_query()
+        assert isinstance(query, Select)
+
+    def test_get_query_column_labels(self):
+        query = UsageReportView().get_query()
+        keys = list(query.exported_columns.keys())
+        assert keys == ["Name", "Email", "Institution", "Run Time"]
 
 
 class TestUserTransformationCountReportView:


### PR DESCRIPTION
Instead of limiting this report based on SQL rows as the Issue requested, I have added logic to `SqlCsvReportView` to allow a max size to be added to a report. Output will be truncated by row if the max download size is exceeded.