### PR TITLE
hide INFO, DEBUG logs from kibana by default

### DIFF
--- a/helm/servicex/values.yaml
+++ b/helm/servicex/values.yaml
@@ -32,7 +32,7 @@ app:
       clusterIssuer: null
       enabled: false
       secretName: "{{.Release.Name}}-app-tls"
-  logLevel: INFO
+  logLevel: DEBUG
   mailgunApiKey: null
   mailgunDomain: null
   pullPolicy: Always
@@ -307,8 +307,7 @@ logging:
     port: 5959
     protocol: TCP
     monitor: "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards?auth_provider_hint=anonymous1#/view/c2cc1f30-4a5b-11ed-afcf-d91dad577662?embed=true&_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-24h%2Fh%2Cto%3Anow))&show-time-filter=true"
-    # This URL format is tied to a parser in servicex_app/servicex_app/web/kibana_url_filter.py
-    logs: "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards?auth_provider_hint=anonymous1#/view/bb682100-5558-11ed-afcf-d91dad577662?embed=true&_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-24h%2Fh,to:now))&_a=(filters:!((query:(match_phrase:(instance:{{.Release.Name}})))),index:'923eaa00-45b9-11ed-afcf-d91dad577662')"
+    logs: "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards?auth_provider_hint=anonymous1#/view/bb682100-5558-11ed-afcf-d91dad577662?embed=true&_g=(filters:!(),refreshInterval:(pause:!t,value:1000),time:(from:now-24h%2Fh,to:now))&_a=(filters:!((query:(match_phrase:(instance:{{.Release.Name}}))),(meta:(index:'923eaa00-45b9-11ed-afcf-d91dad577662',key:level,negate:!t,params:(query:INFO),type:phrase),query:(match_phrase:(level:INFO))),(meta:(index:'923eaa00-45b9-11ed-afcf-d91dad577662',key:level,negate:!t,params:(query:DEBUG),type:phrase),query:(match_phrase:(level:DEBUG)))),index:'923eaa00-45b9-11ed-afcf-d91dad577662')"
 minio:
   image:
     repository: bitnamilegacy/minio

--- a/servicex_app/servicex_app/__init__.py
+++ b/servicex_app/servicex_app/__init__.py
@@ -236,9 +236,7 @@ def create_app(
     logstash_host = os.environ.get("LOGSTASH_HOST")
     logstash_port = os.environ.get("LOGSTASH_PORT")
 
-    level = os.environ.get("LOG_LEVEL", "INFO").upper()
-    if app.debug:
-        level = "DEBUG"
+    level = os.environ.get("LOG_LEVEL", "DEBUG").upper()
     app.logger.level = getattr(logging, level, None)
 
     # remove current handlers

--- a/servicex_app/servicex_app/resources/internal/fileset_error.py
+++ b/servicex_app/servicex_app/resources/internal/fileset_error.py
@@ -52,7 +52,7 @@ class FilesetError(ServiceXResource):
         dataset = Dataset.find_by_id(int(dataset_id))
 
         if dataset is None:
-            current_app.logger.info(
+            current_app.logger.warning(
                 "Dataset lookup error received for unknown dataset",
                 extra={
                     "dataset_id": dataset_id,
@@ -63,7 +63,7 @@ class FilesetError(ServiceXResource):
             )
             return "", 422
 
-        current_app.logger.info(
+        current_app.logger.warning(
             "Error in file lookup",
             extra={
                 "dataset_id": dataset_id,

--- a/servicex_app/servicex_app/resources/servicex_resource.py
+++ b/servicex_app/servicex_app/resources/servicex_resource.py
@@ -91,7 +91,7 @@ class ServiceXResource(Resource):
         request_rec.workers = min(max(1, request_rec.files), request_rec.workers)
 
         current_app.logger.info(
-            f"Lunching {request_rec.workers} transformers.",
+            f"Launching {request_rec.workers} transformers.",
             extra={"request_id": request_rec.request_id},
         )
 

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -240,7 +240,7 @@ class TransformerManager:
         # provide pods with level and logging server info
         env += [
             client.V1EnvVar(
-                "LOG_LEVEL", value=os.environ.get("LOG_LEVEL", "INFO").upper()
+                "LOG_LEVEL", value=os.environ.get("LOG_LEVEL", "DEBUG").upper()
             ),
             client.V1EnvVar("LOGSTASH_HOST", value=os.environ.get("LOGSTASH_HOST")),
             client.V1EnvVar("LOGSTASH_PORT", value=os.environ.get("LOGSTASH_PORT")),


### PR DESCRIPTION
1. Update default log level to send to ES to DEBUG.
2. Update Kibana log url to hide INFO, DEBUG by default

<img width="1173" height="322" alt="Screenshot 2026-08-03 at 4 25 02 PM" src="https://github.com/user-attachments/assets/12f72921-3e55-4ddf-be3e-96bf1f87b770" />
