### PR TITLE
add datasets page to dashboard

### DIFF
--- a/servicex_app/servicex_app/dataset_manager.py
+++ b/servicex_app/servicex_app/dataset_manager.py
@@ -123,6 +123,7 @@ class DatasetManager:
                 DatasetFile(paths=file, adler32="xxx", file_events=0, file_size=0)
                 for file in file_list
             ]
+            dataset.n_files = len(file_list)
 
             logger.info(
                 f"Upserted dataset for file list. Dataset Id is {dataset.id}",

--- a/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
+++ b/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
@@ -46,6 +46,8 @@ from tenacity import (
 
 from servicex_app import TransformerManager
 from servicex_app.models import (
+    Dataset,
+    DatasetFile,
     TransformRequest,
     TransformStatus,
     TransformationResult,
@@ -117,6 +119,10 @@ class TransformerFileComplete(ServiceXResource):
                     f"Duplicate result report - new_info: {info}, old_info: {orig_counts}",
                     extra=log_extra,
                 )
+
+            # Backfill per-file and per-dataset stats from the transformer's report
+            # if the DID finder never populated them (e.g., user file-list datasets).
+            self.backfill_dataset_stats(session, info)
 
             # Lookup the transformation request and increment either the successful
             # or failed file count
@@ -249,6 +255,49 @@ class TransformerFileComplete(ServiceXResource):
                 )
             session.add(result)
         return orig_counts
+
+    @staticmethod
+    @file_complete_ops_retry
+    def backfill_dataset_stats(session: Session, info: dict):
+        if info.get("status") != "success":
+            return
+        events = info.get("total-events") or 0
+        size = info.get("total-bytes") or 0
+        if not events and not size:
+            return
+
+        with session.begin():
+            file_row = (
+                session.query(DatasetFile)
+                .filter_by(id=info["file-id"])
+                .with_for_update()
+                .one_or_none()
+            )
+            if file_row is None:
+                return
+
+            events_delta = 0
+            size_delta = 0
+            if not file_row.file_events and events:
+                file_row.file_events = events
+                events_delta = events
+            if not file_row.file_size and size:
+                file_row.file_size = size
+                size_delta = size
+
+            if events_delta == 0 and size_delta == 0:
+                return
+
+            dataset = (
+                session.query(Dataset)
+                .filter_by(id=file_row.dataset_id)
+                .with_for_update()
+                .one_or_none()
+            )
+            if dataset is None:
+                return
+            dataset.events = (dataset.events or 0) + events_delta
+            dataset.size = (dataset.size or 0) + size_delta
 
     @staticmethod
     @file_complete_ops_retry

--- a/servicex_app/servicex_app/routes.py
+++ b/servicex_app/servicex_app/routes.py
@@ -94,6 +94,8 @@ def add_routes(
     from servicex_app.web.transformation_request import transformation_request
     from servicex_app.web.transformation_results import transformation_results
     from servicex_app.web.multiple_codegen_list import multiple_codegen_list
+    from servicex_app.web.datasets import datasets as datasets_page
+    from servicex_app.web.dataset import dataset as dataset_page
 
     # Must be its own module to allow patching
     from servicex_app.web.create_profile import create_profile
@@ -140,6 +142,8 @@ def add_routes(
     app.add_url_rule(
         "/multiple-codegen-list", "multiple_codegen_list", multiple_codegen_list
     )
+    app.add_url_rule("/datasets", "datasets", datasets_page)
+    app.add_url_rule("/datasets/<int:id_>", "dataset", dataset_page)
 
     # User management and Authentication Endpoints
     api.add_resource(TokenRefresh, "/token/refresh")

--- a/servicex_app/servicex_app/templates/base.html
+++ b/servicex_app/servicex_app/templates/base.html
@@ -44,6 +44,11 @@
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('home') }}">Dashboard</a>
             </li>
+            {% if not config["ENABLE_AUTH"] or session['is_authenticated'] %}
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('datasets') }}">Datasets</a>
+            </li>
+            {% endif %}
             <li class="nav-item">
               <a class="nav-link" href="{{ config['DOCS_BASE_URL'] }}" target="_blank">Docs</a>
             </li>

--- a/servicex_app/servicex_app/templates/dataset.html
+++ b/servicex_app/servicex_app/templates/dataset.html
@@ -1,0 +1,135 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="content-section col-12">
+  <div class="row justify-content-between align-items-center">
+    <h4 class="mb-3 col-auto">Dataset</h4>
+    <div class="col-auto">
+      {% if not ds.stale %}
+      <button id="delete-{{ ds.id }}"
+        onclick="deleteDataset({{ ds.id }})"
+        type="button" class="btn btn-danger btn-sm">
+        Flush
+      </button>
+      {% elif ds.lookup_status and ds.lookup_status.value in ('bad_name', 'does_not_exist', 'internal_failure') %}
+      <span class="badge badge-danger">{{ ds.lookup_status.value }}</span>
+      {% else %}
+      <span class="badge badge-secondary">Flushed</span>
+      {% endif %}
+    </div>
+  </div>
+
+  <dl class="row">
+    <dt class="col-sm-3">ID</dt>
+    <dd class="col-sm-9">{{ ds.id }}</dd>
+
+    <dt class="col-sm-3">Name</dt>
+    <dd class="col-sm-9" style="word-break: break-all">
+      {% if ds.did_finder == "user" %}
+        (file list)
+        <div class="text-muted small">{{ ds.name }}</div>
+      {% else %}
+        {{ ds.name }}
+      {% endif %}
+    </dd>
+
+    <dt class="col-sm-3">DID Finder</dt>
+    <dd class="col-sm-9">{{ ds.did_finder }}</dd>
+
+    <dt class="col-sm-3">Lookup Status</dt>
+    <dd class="col-sm-9">{{ ds.lookup_status.value if ds.lookup_status else '-' }}</dd>
+
+    <dt class="col-sm-3">Files</dt>
+    <dd class="col-sm-9">{{ humanize.intcomma(ds.n_files or 0) }}</dd>
+
+    <dt class="col-sm-3">Total Events</dt>
+    <dd class="col-sm-9">{{ humanize.intcomma(ds.events or 0) }}</dd>
+
+    <dt class="col-sm-3">Total Size</dt>
+    <dd class="col-sm-9">{{ humanize.naturalsize(ds.size or 0) }}</dd>
+
+    <dt class="col-sm-3">Last Used</dt>
+    <dd class="col-sm-9">
+      {{ moment(ds.last_used).format("YYYY-MM-DD HH:mm:ss") if ds.last_used else "-" }}
+      <span class="tz"></span>
+    </dd>
+
+    <dt class="col-sm-3">Last Updated</dt>
+    <dd class="col-sm-9">
+      {{ moment(ds.last_updated).format("YYYY-MM-DD HH:mm:ss") if ds.last_updated else "-" }}
+      <span class="tz"></span>
+    </dd>
+
+    <dt class="col-sm-3">Transform Requests</dt>
+    <dd class="col-sm-9">
+      {% if ds.transform_requests %}
+        <ul class="list-unstyled mb-0">
+          {% for req in ds.transform_requests %}
+          <li>
+            <a href="{{ url_for('transformation_request', id_=req.id) }}">
+              {{ req.title or "Untitled" }}
+            </a>
+            <span class="text-muted small">({{ req.request_id }})</span>
+          </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        -
+      {% endif %}
+    </dd>
+  </dl>
+
+  <h5 class="mt-4">Files ({{ humanize.intcomma(ds.files|length) }})</h5>
+  {% if ds.files %}
+  <div class="table-responsive">
+    <table class="table table-sm table-bordered table-striped">
+      <thead class="thead-dark">
+        <tr>
+          <th scope="col">ID</th>
+          <th scope="col">Path(s)</th>
+          <th scope="col">Events</th>
+          <th scope="col">Size</th>
+          <th scope="col">adler32</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for f in ds.files %}
+        <tr>
+          <th scope="row">{{ f.id }}</th>
+          <td style="word-break: break-all">{{ f.paths }}</td>
+          <td>{{ humanize.intcomma(f.file_events or 0) }}</td>
+          <td>{{ humanize.naturalsize(f.file_size or 0) }}</td>
+          <td><code>{{ f.adler32 or '-' }}</code></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+    <p class="text-muted">No files.</p>
+  {% endif %}
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  function deleteDataset(datasetId) {
+    if (!confirm(`Flush dataset ${datasetId}?\n\nThis marks it stale so a future request will refetch the file list.`)) {
+      return;
+    }
+    fetch(`/servicex/datasets/${datasetId}`, { method: 'DELETE' })
+      .then(async (res) => {
+        if (res.ok) {
+          location.reload();
+        } else {
+          const body = await res.json().catch(() => ({}));
+          alert(body.message || `Failed to flush dataset ${datasetId}`);
+        }
+      })
+      .catch((err) => alert(`Failed to flush dataset ${datasetId}: ${err}`));
+  }
+
+  $(document).ready(function () {
+    $(".tz").text(moment.tz(moment.tz.guess()).format("z"));
+  });
+</script>
+{% endblock %}

--- a/servicex_app/servicex_app/templates/dataset_table.html
+++ b/servicex_app/servicex_app/templates/dataset_table.html
@@ -1,0 +1,87 @@
+{% from 'bootstrap5/pagination.html' import render_pagination %}
+
+{% macro datasets_table(pagination, humanize) %}
+<div class="table-responsive">
+  <table class="table table-sm table-bordered table-striped">
+    <caption>All times in timezone: <span class="tz"></span>.</caption>
+    <thead class="thead-dark">
+      <tr>
+        <th scope="col">ID</th>
+        <th scope="col">Name</th>
+        <th scope="col">DID Finder</th>
+        <th scope="col">Lookup Status</th>
+        <th scope="col">Files</th>
+        <th scope="col">Events</th>
+        <th scope="col">Size</th>
+        <th scope="col">Last Used</th>
+        <th scope="col">Last Updated</th>
+        <th scope="col">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for ds in pagination.items %}
+      <tr id="dataset-row-{{ ds.id }}">
+        <th scope="row">{{ ds.id }}</th>
+        <td style="max-width: 400px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"
+            title="{{ ds.name }}">
+          <a href="{{ url_for('dataset', id_=ds.id) }}">
+            {% if ds.did_finder == "user" %}(file list){% else %}{{ ds.name }}{% endif %}
+          </a>
+        </td>
+        <td>{{ ds.did_finder }}</td>
+        <td>{{ ds.lookup_status.value if ds.lookup_status else '-' }}</td>
+        <td>{{ humanize.intcomma(ds.n_files or 0) }}</td>
+        <td>{{ humanize.intcomma(ds.events or 0) }}</td>
+        <td>{{ humanize.naturalsize(ds.size or 0) }}</td>
+        <td>{{ moment(ds.last_used).format("YYYY-MM-DD HH:mm") if ds.last_used else "-" }}</td>
+        <td>{{ moment(ds.last_updated).format("YYYY-MM-DD HH:mm") if ds.last_updated else "-" }}</td>
+        <td>
+          {% if not ds.stale %}
+          <button id="delete-{{ ds.id }}"
+            onclick="deleteDataset({{ ds.id }}, '{{ ds.name|e }}')"
+            type="button" class="btn btn-danger btn-sm">
+            Flush
+          </button>
+          {% elif ds.lookup_status and ds.lookup_status.value in ('bad_name', 'does_not_exist', 'internal_failure') %}
+          <span class="badge badge-danger">{{ ds.lookup_status.value }}</span>
+          {% else %}
+          <span class="badge badge-secondary">Flushed</span>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% if pagination.items %}
+    {{ render_pagination(pagination, align='center') }}
+  {% else %}
+    <div class="text-center text-muted p-4">
+      No datasets found.
+    </div>
+  {% endif %}
+</div>
+{% endmacro %}
+
+{% macro datasets_table_scripts() %}
+<script>
+  function deleteDataset(datasetId, datasetName) {
+    if (!confirm(`Flush dataset "${datasetName}" (id ${datasetId})?\n\nThis marks it stale so a future request will refetch the file list.`)) {
+      return;
+    }
+    fetch(`/servicex/datasets/${datasetId}`, { method: 'DELETE' })
+      .then(async (res) => {
+        if (res.ok) {
+          location.reload();
+        } else {
+          const body = await res.json().catch(() => ({}));
+          alert(body.message || `Failed to flush dataset ${datasetId}`);
+        }
+      })
+      .catch((err) => alert(`Failed to flush dataset ${datasetId}: ${err}`));
+  }
+
+  $(document).ready(function () {
+    $(".tz").text(moment.tz(moment.tz.guess()).format("z"));
+  });
+</script>
+{% endmacro %}

--- a/servicex_app/servicex_app/templates/datasets.html
+++ b/servicex_app/servicex_app/templates/datasets.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% from 'dataset_table.html' import datasets_table, datasets_table_scripts with context %}
+{% from 'sort_dropdown.html' import sort_dropdown %}
+
+{% block content %}
+
+  <div class="col-12">
+    <div class="content-section">
+      <div class="row justify-content-between align-items-center">
+        <h4 class="mb-3 col-auto">Datasets</h4>
+        <div class="col-auto d-flex align-items-center">
+          <form method="get" class="form-inline mr-3">
+            <input type="hidden" name="sort" value="{{ active_sort }}">
+            <input type="hidden" name="order" value="{{ active_order }}">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" name="show_deleted" value="true"
+                     id="show_deleted" {% if show_deleted %}checked{% endif %}
+                     onchange="this.form.submit()">
+              <label class="form-check-label" for="show_deleted">
+                Show flushed
+              </label>
+            </div>
+          </form>
+          {{ sort_dropdown(dropdown_options, active_sort, active_order) }}
+        </div>
+      </div>
+      {{ datasets_table(pagination, humanize) }}
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {{ datasets_table_scripts() }}
+{% endblock %}

--- a/servicex_app/servicex_app/templates/sort_dropdown.html
+++ b/servicex_app/servicex_app/templates/sort_dropdown.html
@@ -2,11 +2,11 @@
   <div class="dropdown col-auto">
     <button class="btn btn-sm btn-dark dropdown-toggle" type="button" id="dropdownMenuButton"
             data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      Sort: <b>{{ active_sort.title() }} ({{ active_order }})</b>
+      Sort: <b>{{ active_sort.replace('_', ' ').title() }} ({{ active_order }})</b>
     </button>
     <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
         {% for sort, order in options %}
-          <a href="?sort={{ sort }}&order={{ order }}" class="dropdown-item">{{ sort.title() }} ({{ order }})</a>
+          <a href="?sort={{ sort }}&order={{ order }}" class="dropdown-item">{{ sort.replace('_', ' ').title() }} ({{ order }})</a>
         {% endfor %}
     </div>
   </div>

--- a/servicex_app/servicex_app/web/dataset.py
+++ b/servicex_app/servicex_app/web/dataset.py
@@ -1,0 +1,12 @@
+from flask import render_template, abort
+
+from servicex_app.decorators import oauth_required
+from servicex_app.models import Dataset
+
+
+@oauth_required
+def dataset(id_: int):
+    ds = Dataset.find_by_id(id_)
+    if not ds:
+        abort(404)
+    return render_template("dataset.html", ds=ds)

--- a/servicex_app/servicex_app/web/datasets.py
+++ b/servicex_app/servicex_app/web/datasets.py
@@ -1,0 +1,63 @@
+import itertools
+
+from flask import render_template
+from flask_restful import reqparse
+
+from servicex_app.decorators import oauth_required
+from servicex_app.models import Dataset
+
+model_attributes = {
+    "last_used": Dataset.last_used,
+    "last_updated": Dataset.last_updated,
+    "name": Dataset.name,
+    "size": Dataset.size,
+    "events": Dataset.events,
+    "files": Dataset.n_files,
+}
+parser = reqparse.RequestParser()
+parser.add_argument("page", default=1, type=int, location="args")
+sort_choices = tuple(model_attributes.keys())
+parser.add_argument(
+    "sort",
+    choices=sort_choices,
+    default="last_used",
+    location="args",
+    help=f"Sort must be one of: {', '.join(map(repr, sort_choices))}.",
+)
+order_choices = ("asc", "desc")
+parser.add_argument(
+    "order",
+    choices=order_choices,
+    default="desc",
+    location="args",
+    help="Order must be 'asc' or 'desc'.",
+)
+parser.add_argument(
+    "show_deleted",
+    type=lambda v: str(v).lower() in ("1", "true", "yes", "on"),
+    default=False,
+    location="args",
+)
+
+
+@oauth_required
+def datasets():
+    args = parser.parse_args()
+    sort, order = args["sort"], args["order"]
+    query = Dataset.query
+    if not args["show_deleted"]:
+        query = query.filter_by(stale=False)
+
+    sort_column = model_attributes[sort]
+    sort_order = sort_column.asc() if order == "asc" else sort_column.desc()
+    pagination = query.order_by(sort_order).paginate(
+        page=args["page"], per_page=15, error_out=False
+    )
+    return render_template(
+        "datasets.html",
+        pagination=pagination,
+        dropdown_options=list(itertools.product(sort_choices, order_choices)),
+        active_sort=sort,
+        active_order=order,
+        show_deleted=args["show_deleted"],
+    )

--- a/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
@@ -29,7 +29,12 @@
 import psycopg2
 import pytest
 
-from servicex_app.models import TransformationResult, TransformRequest, TransformStatus
+from servicex_app.models import (
+    DatasetFile,
+    TransformationResult,
+    TransformRequest,
+    TransformStatus,
+)
 from servicex_app.transformer_manager import TransformerManager
 from servicex_app_test.resource_test_base import ResourceTestBase
 
@@ -75,10 +80,20 @@ class TestTransformFileComplete(ResourceTestBase):
         return rv
 
     @pytest.fixture
-    def mock_transform_request_lookup(self, db_session, trqmock, othermock):
+    def dsfilemock(self, mocker):
+        rv = mocker.Mock()
+        rv.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = (  # noqa: E501
+            None
+        )
+        return rv
+
+    @pytest.fixture
+    def mock_transform_request_lookup(self, db_session, trqmock, othermock, dsfilemock):
         def switcher(cls):
             if cls == TransformRequest:
                 return trqmock
+            elif cls == DatasetFile:
+                return dsfilemock
             else:
                 return othermock
 

--- a/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
@@ -608,7 +608,9 @@ class TestBackfillDatasetStats:
         assert file_row.file_events == 999
         assert file_row.file_size == 999
         # Dataset should NOT be queried since deltas are both zero
-        queried_classes = [call.args[0] for call in session.query.mock_calls if call.args]
+        queried_classes = [
+            call.args[0] for call in session.query.mock_calls if call.args
+        ]
         assert Dataset not in queried_classes
 
     def test_backfills_file_row_and_dataset(self, mocker):

--- a/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
@@ -30,10 +30,14 @@ import psycopg2
 import pytest
 
 from servicex_app.models import (
+    Dataset,
     DatasetFile,
     TransformationResult,
     TransformRequest,
     TransformStatus,
+)
+from servicex_app.resources.internal.transformer_file_complete import (
+    TransformerFileComplete,
 )
 from servicex_app.transformer_manager import TransformerManager
 from servicex_app_test.resource_test_base import ResourceTestBase
@@ -535,3 +539,136 @@ class TestTransformFileComplete(ResourceTestBase):
         # add called once for the transform result and then once for the updated transform request
         # once with a failure and once successfully
         assert db_session.add.call_count == 3
+
+
+class TestBackfillDatasetStats:
+    """Direct unit tests for TransformerFileComplete.backfill_dataset_stats."""
+
+    @staticmethod
+    def _session(mocker, file_row=None, dataset_row=None):
+        session = mocker.Mock()
+        session.begin = mocker.MagicMock()
+
+        def switcher(cls):
+            chain = mocker.Mock()
+            if cls is DatasetFile:
+                chain.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = (  # noqa: E501
+                    file_row
+                )
+            elif cls is Dataset:
+                chain.filter_by.return_value.with_for_update.return_value.one_or_none.return_value = (  # noqa: E501
+                    dataset_row
+                )
+            return chain
+
+        session.query.side_effect = switcher
+        return session
+
+    @staticmethod
+    def _info(**overrides):
+        base = {
+            "file-id": 42,
+            "status": "success",
+            "total-events": 12345,
+            "total-bytes": 6789,
+        }
+        base.update(overrides)
+        return base
+
+    def test_skips_when_status_not_success(self, mocker):
+        session = self._session(mocker)
+        TransformerFileComplete.backfill_dataset_stats(
+            session, self._info(status="failure")
+        )
+        session.query.assert_not_called()
+
+    def test_skips_when_events_and_size_both_zero(self, mocker):
+        session = self._session(mocker)
+        TransformerFileComplete.backfill_dataset_stats(
+            session, self._info(**{"total-events": 0, "total-bytes": 0})
+        )
+        session.query.assert_not_called()
+
+    def test_skips_when_file_row_missing(self, mocker):
+        session = self._session(mocker, file_row=None)
+        TransformerFileComplete.backfill_dataset_stats(session, self._info())
+        # DatasetFile queried, but never reaches Dataset
+        assert Dataset not in [call.args[0] for call in session.query.mock_calls]
+
+    def test_skips_when_file_row_already_populated(self, mocker):
+        file_row = mocker.Mock()
+        file_row.file_events = 999
+        file_row.file_size = 999
+        file_row.dataset_id = 7
+        session = self._session(mocker, file_row=file_row)
+
+        TransformerFileComplete.backfill_dataset_stats(session, self._info())
+
+        # File row values not overwritten
+        assert file_row.file_events == 999
+        assert file_row.file_size == 999
+        # Dataset should NOT be queried since deltas are both zero
+        queried_classes = [call.args[0] for call in session.query.mock_calls if call.args]
+        assert Dataset not in queried_classes
+
+    def test_backfills_file_row_and_dataset(self, mocker):
+        file_row = mocker.Mock()
+        file_row.file_events = 0
+        file_row.file_size = 0
+        file_row.dataset_id = 7
+        dataset_row = mocker.Mock()
+        dataset_row.events = 100
+        dataset_row.size = 500
+        session = self._session(mocker, file_row=file_row, dataset_row=dataset_row)
+
+        TransformerFileComplete.backfill_dataset_stats(session, self._info())
+
+        assert file_row.file_events == 12345
+        assert file_row.file_size == 6789
+        assert dataset_row.events == 100 + 12345
+        assert dataset_row.size == 500 + 6789
+
+    def test_backfills_from_none_dataset_counters(self, mocker):
+        file_row = mocker.Mock()
+        file_row.file_events = 0
+        file_row.file_size = 0
+        file_row.dataset_id = 7
+        dataset_row = mocker.Mock()
+        dataset_row.events = None
+        dataset_row.size = None
+        session = self._session(mocker, file_row=file_row, dataset_row=dataset_row)
+
+        TransformerFileComplete.backfill_dataset_stats(session, self._info())
+
+        assert dataset_row.events == 12345
+        assert dataset_row.size == 6789
+
+    def test_backfills_only_events_when_size_already_set(self, mocker):
+        file_row = mocker.Mock()
+        file_row.file_events = 0
+        file_row.file_size = 999
+        file_row.dataset_id = 7
+        dataset_row = mocker.Mock()
+        dataset_row.events = 0
+        dataset_row.size = 0
+        session = self._session(mocker, file_row=file_row, dataset_row=dataset_row)
+
+        TransformerFileComplete.backfill_dataset_stats(session, self._info())
+
+        assert file_row.file_events == 12345
+        assert file_row.file_size == 999
+        assert dataset_row.events == 12345
+        assert dataset_row.size == 0
+
+    def test_skips_when_dataset_row_missing(self, mocker):
+        file_row = mocker.Mock()
+        file_row.file_events = 0
+        file_row.file_size = 0
+        file_row.dataset_id = 7
+        session = self._session(mocker, file_row=file_row, dataset_row=None)
+
+        TransformerFileComplete.backfill_dataset_stats(session, self._info())
+
+        # File row is still updated even though Dataset lookup returned None
+        assert file_row.file_events == 12345
+        assert file_row.file_size == 6789

--- a/servicex_app/servicex_app_test/web/test_dataset.py
+++ b/servicex_app/servicex_app_test/web/test_dataset.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timezone
+
+from flask import Response, url_for
+from pytest import fixture
+
+from servicex_app.models import Dataset, DatasetStatus
+
+from .web_test_base import WebTestBase
+
+
+class TestDatasetDetail(WebTestBase):
+
+    @staticmethod
+    def _fake_dataset(**overrides):
+        defaults = {
+            "id": 42,
+            "name": "rucio://data25/foo.bar",
+            "did_finder": "rucio",
+            "last_used": datetime.now(tz=timezone.utc),
+            "last_updated": datetime.now(tz=timezone.utc),
+            "n_files": 3,
+            "size": 1024,
+            "events": 100,
+            "lookup_status": DatasetStatus.complete,
+            "stale": False,
+        }
+        defaults.update(overrides)
+        ds = Dataset(**defaults)
+        ds.files = []
+        ds.transform_requests = []
+        return ds
+
+    @fixture
+    def mock_find_by_id(self, mocker):
+        return mocker.patch("servicex_app.web.dataset.Dataset.find_by_id")
+
+    def test_renders_existing_dataset(
+        self, client, user, mock_find_by_id, captured_templates
+    ):
+        ds = self._fake_dataset()
+        mock_find_by_id.return_value = ds
+        response: Response = client.get(
+            url_for("dataset", id_=42), headers=self.fake_header()
+        )
+        assert response.status_code == 200
+        mock_find_by_id.assert_called_once_with(42)
+        template, context = captured_templates[0]
+        assert template.name == "dataset.html"
+        assert context["ds"] is ds
+
+    def test_missing_dataset_returns_404(self, client, user, mock_find_by_id):
+        mock_find_by_id.return_value = None
+        response: Response = client.get(
+            url_for("dataset", id_=999), headers=self.fake_header()
+        )
+        assert response.status_code == 404

--- a/servicex_app/servicex_app_test/web/test_datasets.py
+++ b/servicex_app/servicex_app_test/web/test_datasets.py
@@ -16,14 +16,14 @@ class TestDatasets(WebTestBase):
             "filtered": filtered.order_by.return_value,
         }
 
-    def test_default_filters_out_stale(self, client, user, mock_query, captured_templates):
+    def test_default_filters_out_stale(
+        self, client, user, mock_query, captured_templates
+    ):
         pagination = mock_query["filtered"].paginate(
             page=1, per_page=15, total=0, items=[]
         )
         mock_query["filtered"].paginate.return_value = pagination
-        response: Response = client.get(
-            url_for("datasets"), headers=self.fake_header()
-        )
+        response: Response = client.get(url_for("datasets"), headers=self.fake_header())
         assert response.status_code == 200
         template, context = captured_templates[0]
         assert template.name == "datasets.html"
@@ -35,9 +35,7 @@ class TestDatasets(WebTestBase):
     def test_show_deleted_true_skips_stale_filter(
         self, client, user, mock_query, captured_templates
     ):
-        pagination = mock_query["raw"].paginate(
-            page=1, per_page=15, total=0, items=[]
-        )
+        pagination = mock_query["raw"].paginate(page=1, per_page=15, total=0, items=[])
         mock_query["raw"].paginate.return_value = pagination
         response: Response = client.get(
             url_for("datasets") + "?show_deleted=true",

--- a/servicex_app/servicex_app_test/web/test_datasets.py
+++ b/servicex_app/servicex_app_test/web/test_datasets.py
@@ -1,0 +1,72 @@
+from flask import Response, url_for
+from pytest import fixture
+
+from .web_test_base import WebTestBase
+
+
+class TestDatasets(WebTestBase):
+
+    @fixture
+    def mock_query(self, mocker):
+        mock_ds = mocker.patch("servicex_app.web.datasets.Dataset")
+        query = mock_ds.query
+        filtered = query.filter_by.return_value
+        return {
+            "raw": query.order_by.return_value,
+            "filtered": filtered.order_by.return_value,
+        }
+
+    def test_default_filters_out_stale(self, client, user, mock_query, captured_templates):
+        pagination = mock_query["filtered"].paginate(
+            page=1, per_page=15, total=0, items=[]
+        )
+        mock_query["filtered"].paginate.return_value = pagination
+        response: Response = client.get(
+            url_for("datasets"), headers=self.fake_header()
+        )
+        assert response.status_code == 200
+        template, context = captured_templates[0]
+        assert template.name == "datasets.html"
+        assert context["pagination"] == pagination
+        assert context["active_sort"] == "last_used"
+        assert context["active_order"] == "desc"
+        assert context["show_deleted"] is False
+
+    def test_show_deleted_true_skips_stale_filter(
+        self, client, user, mock_query, captured_templates
+    ):
+        pagination = mock_query["raw"].paginate(
+            page=1, per_page=15, total=0, items=[]
+        )
+        mock_query["raw"].paginate.return_value = pagination
+        response: Response = client.get(
+            url_for("datasets") + "?show_deleted=true",
+            headers=self.fake_header(),
+        )
+        assert response.status_code == 200
+        template, context = captured_templates[0]
+        assert template.name == "datasets.html"
+        assert context["show_deleted"] is True
+
+    def test_sort_and_order_are_applied(
+        self, client, user, mock_query, captured_templates
+    ):
+        pagination = mock_query["filtered"].paginate(
+            page=1, per_page=15, total=0, items=[]
+        )
+        mock_query["filtered"].paginate.return_value = pagination
+        response: Response = client.get(
+            url_for("datasets") + "?sort=events&order=asc",
+            headers=self.fake_header(),
+        )
+        assert response.status_code == 200
+        template, context = captured_templates[0]
+        assert context["active_sort"] == "events"
+        assert context["active_order"] == "asc"
+
+    def test_invalid_sort_choice_returns_400(self, client, user, mock_query):
+        response: Response = client.get(
+            url_for("datasets") + "?sort=bogus",
+            headers=self.fake_header(),
+        )
+        assert response.status_code == 400

--- a/transformer_sidecar/src/transformer_sidecar/transformer_stats/aod_stats.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer_stats/aod_stats.py
@@ -35,9 +35,19 @@ class AODStats(TransformerStats):
     def __init__(self, log_path: Path):
         super().__init__(log_path)
 
-        matches = re.findall(r"Processed (\d+) events", self.log_body)
-        if len(matches) == 1:
-            self.total_events = int(matches[0])
+        # First see if the total events processed is printed
+        range_matches = re.findall(
+            r"Processing events 0-(\d+) in file", self.log_body
+        )
+        if range_matches:
+            self.total_events = int(range_matches[-1])
+        else:
+            # Fallback: "Processed N events" is a periodic progress marker
+            progress_matches = re.findall(
+                r"Processed (\d+) events", self.log_body
+            )
+            if progress_matches:
+                self.total_events = max(int(m) for m in progress_matches)
 
         # Look for incorrect property names
         matches = re.findall(

--- a/transformer_sidecar/src/transformer_sidecar/transformer_stats/aod_stats.py
+++ b/transformer_sidecar/src/transformer_sidecar/transformer_stats/aod_stats.py
@@ -36,16 +36,12 @@ class AODStats(TransformerStats):
         super().__init__(log_path)
 
         # First see if the total events processed is printed
-        range_matches = re.findall(
-            r"Processing events 0-(\d+) in file", self.log_body
-        )
+        range_matches = re.findall(r"Processing events 0-(\d+) in file", self.log_body)
         if range_matches:
             self.total_events = int(range_matches[-1])
         else:
             # Fallback: "Processed N events" is a periodic progress marker
-            progress_matches = re.findall(
-                r"Processed (\d+) events", self.log_body
-            )
+            progress_matches = re.findall(r"Processed (\d+) events", self.log_body)
             if progress_matches:
                 self.total_events = max(int(m) for m in progress_matches)
 

--- a/transformer_sidecar/tests/transformer_stats/test_aod_stats.py
+++ b/transformer_sidecar/tests/transformer_stats/test_aod_stats.py
@@ -52,6 +52,68 @@ def test_aod_stats():
         os.remove(test_logfile_path)
 
 
+def test_aod_stats_large_file():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as fp:
+        test_logfile_path = Path(fp.name)
+        fp.write(
+            "Package.EventLoop        INFO    created submission directory "
+            "/home/atlas/rel/build/bogus\n"
+            "Package.EventLoop        INFO    submitting job in "
+            "/home/atlas/rel/build/bogus\n"
+            "Package.EventLoop        INFO    Running sample: ANALYSIS\n"
+            "Package.EventLoop        INFO    xAODInput = 1\n"
+            "Package.EventLoop        INFO    calling firstInitialize on all modules\n"
+            "Package.EventLoop        INFO    calling preFileInitialize on all modules\n"
+            "Package.EventLoop        INFO    Opening file "
+            "root://example/DAOD_PHYSLITE.pool.root.1\n"
+            "Package.EventLoop        INFO    Processing events 0-213934 in file "
+            "root://example/DAOD_PHYSLITE.pool.root.1\n"
+            "Package.EventLoop        INFO    Processed 10000 events\n"
+            "Package.EventLoop        INFO    Processed 20000 events\n"
+            "Package.EventLoop        INFO    Processed 100000 events\n"
+            "Package.EventLoop        INFO    Processed 200000 events\n"
+            "Package.EventLoop        INFO    Processed 210000 events\n"
+            "LeakCheckModule          INFO    Memory increase/change during the job:\n"
+            "Package.EventLoop        INFO    worker finished successfully\n"
+            "Package.EventLoop        INFO    done\n"
+        )
+        fp.close()
+        aod_stats = AODStats(test_logfile_path)
+        assert aod_stats.total_events == 213934
+        os.remove(test_logfile_path)
+
+
+def test_aod_stats_small_file():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as fp:
+        test_logfile_path = Path(fp.name)
+        fp.write(
+            "Package.EventLoop        INFO    Opening file "
+            "root://example/DAOD_PHYSLITE.pool.root.1\n"
+            "Package.EventLoop        INFO    Processing events 0-11860 in file "
+            "root://example/DAOD_PHYSLITE.pool.root.1\n"
+            "Package.EventLoop        INFO    Processed 10000 events\n"
+            "Package.EventLoop        INFO    worker finished successfully\n"
+        )
+        fp.close()
+        aod_stats = AODStats(test_logfile_path)
+        assert aod_stats.total_events == 11860
+        os.remove(test_logfile_path)
+
+
+def test_aod_stats_fallback_progress_markers_only():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as fp:
+        test_logfile_path = Path(fp.name)
+        fp.write(
+            "Package.EventLoop        INFO    Processed 10000 events\n"
+            "Package.EventLoop        INFO    Processed 20000 events\n"
+            "Package.EventLoop        INFO    Processed 30000 events\n"
+        )
+        fp.close()
+        aod_stats = AODStats(test_logfile_path)
+        assert aod_stats.total_events == 30000
+        os.remove(test_logfile_path)
+
+
 def test_bad_property():
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as fp:
         test_logfile_path = Path(fp.name)


### PR DESCRIPTION
Adds a datasets page to the nav bar.

To improve our reporting of a dataset/files event count and file size:

1. Add `TransformerFileComplete.backfill_dataset_stats` to catch info when the DID finder didn't run (user supplied file lists).
2. Update `AODStats` to catch total event counts when available in logs.

<img width="1185" height="841" alt="Screenshot 2026-08-13 at 1 17 54 PM" src="https://github.com/user-attachments/assets/d45ec830-71ac-45ed-9e72-edf208709610" />
<img width="1209" height="1200" alt="Screenshot 2026-08-13 at 1 17 45 PM" src="https://github.com/user-attachments/assets/4dc275af-e15c-4637-be13-62f7f66f697c" />
<img width="1163" height="420" alt="Screenshot 2026-08-13 at 1 17 36 PM" src="https://github.com/user-attachments/assets/f8cfb0bf-dca0-4e76-bb63-1433438f22a8" />
