### PR TITLE
save output path on transform model

### DIFF
--- a/servicex_app/migrations/versions/1.9.0.py
+++ b/servicex_app/migrations/versions/1.9.0.py
@@ -1,0 +1,31 @@
+"""
+add output_path column to TransformRequest
+
+Revision ID: v1_9_0
+Revises: v1_8_4
+Create Date: 2026-08-20 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "v1_9_0"
+down_revision = "v1_8_4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "requests",
+        sa.Column("output_path", sa.String(length=1024), nullable=True),
+    )
+
+    op.execute(
+        "UPDATE requests SET output_path = request_id "
+        "WHERE output_path IS NULL AND result_destination = 'object-store'"
+    )
+
+
+def downgrade():
+    op.drop_column("requests", "output_path")

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -194,6 +194,7 @@ class TransformRequest(db.Model):
     workers = db.Column(db.Integer, nullable=True)
     result_destination = db.Column(db.String(32), nullable=False)
     result_format = db.Column(db.String(32), nullable=False)
+    output_path = db.Column(db.String(1024), nullable=True)
     submitted_by = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
 
     files = db.Column(db.Integer, default=0, nullable=False)
@@ -230,6 +231,7 @@ class TransformRequest(db.Model):
             "workers": self.workers,
             "result-destination": self.result_destination,
             "result-format": self.result_format,
+            "output-path": self.output_path,
             "generated-code-cm": self.generated_code_cm,
             "status": self.status.string_name,
             "failure-info": self.failure_description,

--- a/servicex_app/servicex_app/resources/internal/data_lifecycle_ops.py
+++ b/servicex_app/servicex_app/resources/internal/data_lifecycle_ops.py
@@ -69,8 +69,18 @@ class DataLifecycleOps(ServiceXResource):
                 ).delete()
 
                 # Delete the transformed files out of object store along with the bucket
-                if object_store:
-                    object_store.delete_bucket_and_contents(transform.request_id)
+                if (
+                    object_store
+                    and transform.result_destination
+                    == TransformRequest.OBJECT_STORE_DEST
+                ):
+                    if transform.output_path:
+                        object_store.delete_bucket_and_contents(transform.output_path)
+                    else:
+                        current_app.logger.warning(
+                            "Skipping bucket cleanup: transform has no output_path recorded",
+                            extra={"request_id": transform.request_id},
+                        )
 
                 # Delete the transform request
                 session.delete(transform)

--- a/servicex_app/servicex_app/resources/transformation/delete.py
+++ b/servicex_app/servicex_app/resources/transformation/delete.py
@@ -68,7 +68,7 @@ class DeleteTransform(ServiceXResource):
                     "recorded; refusing to delete to avoid leaking the bucket."
                 )
                 current_app.logger.error(msg, extra={"request_id": request_id})
-                return {"message": msg}, 409
+                return {"message": msg}, 400
 
             # Delete all the results for this transform
             session.query(TransformationResult).filter_by(

--- a/servicex_app/servicex_app/resources/transformation/delete.py
+++ b/servicex_app/servicex_app/resources/transformation/delete.py
@@ -57,14 +57,27 @@ class DeleteTransform(ServiceXResource):
             if user and (not user.admin and user.id != transform_req.submitted_by):
                 return {"message": "You are not authorized to delete this request"}, 403
 
+            needs_bucket_cleanup = (
+                self.object_store
+                and transform_req.result_destination
+                == TransformRequest.OBJECT_STORE_DEST
+            )
+            if needs_bucket_cleanup and not transform_req.output_path:
+                msg = (
+                    f"Transform request {request_id} has no output_path "
+                    "recorded; refusing to delete to avoid leaking the bucket."
+                )
+                current_app.logger.error(msg, extra={"request_id": request_id})
+                return {"message": msg}, 409
+
             # Delete all the results for this transform
             session.query(TransformationResult).filter_by(
                 request_id=transform_req.request_id
             ).delete()
 
             # Delete the transformed files out of object store along with the bucket
-            if self.object_store:
-                self.object_store.delete_bucket_and_contents(transform_req.request_id)
+            if needs_bucket_cleanup:
+                self.object_store.delete_bucket_and_contents(transform_req.output_path)
 
             # Delete the transform request
             session.delete(transform_req)

--- a/servicex_app/servicex_app/resources/transformation/file_urls.py
+++ b/servicex_app/servicex_app/resources/transformation/file_urls.py
@@ -81,11 +81,28 @@ class FileURLGenerator(ServiceXResource):
         expiry = int(datetime.datetime.now().timestamp() + expirydelta)
 
         # Add branches for other backends when relevant
+        if transform.result_destination != TransformRequest.OBJECT_STORE_DEST:
+            msg = (
+                f"Transformation request {request_id} does not use object-store "
+                f"storage (result_destination={transform.result_destination}); "
+                "cannot generate presigned URLs."
+            )
+            current_app.logger.error(msg, extra={"request_id": request_id})
+            return {"message": msg}, 409
+
+        if not transform.output_path:
+            msg = (
+                f"Transformation request {request_id} has no output_path "
+                "recorded; cannot generate file URLs."
+            )
+            current_app.logger.error(msg, extra={"request_id": request_id})
+            return {"message": msg}, 409
+
         rv = {
             f: (
                 self.s3client.generate_presigned_url(
                     "get_object",
-                    Params={"Bucket": request_id, "Key": f},
+                    Params={"Bucket": transform.output_path, "Key": f},
                     ExpiresIn=expirydelta,
                 ),
                 {},

--- a/servicex_app/servicex_app/resources/transformation/file_urls.py
+++ b/servicex_app/servicex_app/resources/transformation/file_urls.py
@@ -88,7 +88,7 @@ class FileURLGenerator(ServiceXResource):
                 "cannot generate presigned URLs."
             )
             current_app.logger.error(msg, extra={"request_id": request_id})
-            return {"message": msg}, 409
+            return {"message": msg}, 400
 
         if not transform.output_path:
             msg = (
@@ -96,7 +96,7 @@ class FileURLGenerator(ServiceXResource):
                 "recorded; cannot generate file URLs."
             )
             current_app.logger.error(msg, extra={"request_id": request_id})
-            return {"message": msg}, 409
+            return {"message": msg}, 400
 
         rv = {
             f: (

--- a/servicex_app/servicex_app/resources/transformation/submit.py
+++ b/servicex_app/servicex_app/resources/transformation/submit.py
@@ -39,6 +39,7 @@ from servicex_app.decorators import auth_required
 from servicex_app.did_parser import DIDParser
 from servicex_app.models import TransformRequest, db, TransformStatus
 from servicex_app.resources.servicex_resource import ServiceXResource
+from servicex_app.transformer_manager import TransformerManager
 from werkzeug.exceptions import BadRequest
 
 
@@ -228,13 +229,17 @@ class SubmitTransformationRequest(ServiceXResource):
                     current_app.logger.error(msg, extra={"request_id": request_id})
                     return {"message": msg}, 500
 
+            output_path = TransformerManager.compute_output_path(
+                request_id, args["result-destination"]
+            )
+
             # If the user has requested an object store destination, now is the time
-            # to create a bucket named after the request id
+            # to create the bucket at the computed output path.
             if (
                 self.object_store
                 and args["result-destination"] == TransformRequest.OBJECT_STORE_DEST
             ):
-                self.object_store.create_bucket(request_id)
+                self.object_store.create_bucket(output_path)
                 # TODO: need to check to make sure bucket was created
                 # WHat happens if object-store and object_store is None?
 
@@ -271,6 +276,7 @@ class SubmitTransformationRequest(ServiceXResource):
                     tree_name=args["tree-name"],
                     result_destination=args["result-destination"],
                     result_format=args["result-format"],
+                    output_path=output_path,
                     workers=args["workers"],
                     status=TransformStatus.submitted,
                     app_version=self._get_app_version(),

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -79,6 +79,22 @@ class TransformerManager:
         cls.celery_app = celery_app
         return cls
 
+    @staticmethod
+    def compute_output_path(request_id: str, result_destination: str) -> str:
+        """Return the destination the transformer will write results to.
+
+        For ``object-store`` this is the S3 bucket name; for ``volume`` this
+        is the on-disk directory the sidecar writes files into.
+        """
+        if result_destination == TransformRequest.OBJECT_STORE_DEST:
+            return request_id
+        if result_destination == TransformRequest.VOLUME_DEST:
+            return os.path.join(
+                TransformerManager.POSIX_VOLUME_MOUNT,
+                current_app.config["TRANSFORMER_PERSISTENCE_SUBDIR"],
+            )
+        raise ValueError(f"Unknown result_destination: {result_destination}")
+
     def __init__(self, manager_mode):
         if manager_mode == "internal-kubernetes":
             kubernetes.config.load_incluster_config()
@@ -341,9 +357,8 @@ class TransformerManager:
         )
 
         if result_destination == "volume":
-            sidecar_command += " --output-dir " + os.path.join(
-                TransformerManager.POSIX_VOLUME_MOUNT,
-                current_app.config["TRANSFORMER_PERSISTENCE_SUBDIR"],
+            sidecar_command += " --output-dir " + TransformerManager.compute_output_path(
+                request_id, result_destination
             )
 
         resources = client.V1ResourceRequirements(

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -357,8 +357,9 @@ class TransformerManager:
         )
 
         if result_destination == "volume":
-            sidecar_command += " --output-dir " + TransformerManager.compute_output_path(
-                request_id, result_destination
+            sidecar_command += (
+                " --output-dir "
+                + TransformerManager.compute_output_path(request_id, result_destination)
             )
 
         resources = client.V1ResourceRequirements(

--- a/servicex_app/servicex_app_test/resource_test_base.py
+++ b/servicex_app/servicex_app_test/resource_test_base.py
@@ -163,6 +163,7 @@ class ResourceTestBase:
         transform_request.image = "sslhep/foo:latest"
         transform_request.result_format = "arrow"
         transform_request.result_destination = "object-store"
+        transform_request.output_path = "BR549"
         transform_request.total_events = 10000
         transform_request.total_bytes = 1203
         transform_request.files = 1

--- a/servicex_app/servicex_app_test/resources/internal/test_data_lifecycle_ops.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_data_lifecycle_ops.py
@@ -232,7 +232,9 @@ class TestDataLifecycleOps(ResourceTestBase):
         db_session.commit()
 
         mock_object_store = mocker.MagicMock()
-        mock_logger = mocker.patch(f"{self.module}.current_app")
+        mock_logger = mocker.patch(
+            f"{self.module}.current_app", new=mocker.MagicMock()
+        )
 
         data_life_cycle_ops = DataLifecycleOps()
         response = data_life_cycle_ops.delete_expired_transforms(

--- a/servicex_app/servicex_app_test/resources/internal/test_data_lifecycle_ops.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_data_lifecycle_ops.py
@@ -232,9 +232,7 @@ class TestDataLifecycleOps(ResourceTestBase):
         db_session.commit()
 
         mock_object_store = mocker.MagicMock()
-        mock_logger = mocker.patch(
-            f"{self.module}.current_app", new=mocker.MagicMock()
-        )
+        mock_logger = mocker.patch(f"{self.module}.current_app", new=mocker.MagicMock())
 
         data_life_cycle_ops = DataLifecycleOps()
         response = data_life_cycle_ops.delete_expired_transforms(

--- a/servicex_app/servicex_app_test/resources/internal/test_data_lifecycle_ops.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_data_lifecycle_ops.py
@@ -219,6 +219,57 @@ class TestDataLifecycleOps(ResourceTestBase):
         if use_object_store:
             mock_object_store.delete_bucket_and_contents.assert_called_with("2")
 
+    def test_expired_transform_missing_output_path_skips_bucket_cleanup(
+        self, mocker, db_session
+    ):
+        stale_transform = self._generate_transform_request()
+        stale_transform.submit_time = datetime(2021, 1, 1, 0, 0)
+        stale_transform.request_id = "no-output-path"
+        stale_transform.output_path = None
+        stale_transform.did_id = 1
+        stale_transform.title = "stale-no-path"
+        db_session.add(stale_transform)
+        db_session.commit()
+
+        mock_object_store = mocker.MagicMock()
+        mock_logger = mocker.patch(f"{self.module}.current_app")
+
+        data_life_cycle_ops = DataLifecycleOps()
+        response = data_life_cycle_ops.delete_expired_transforms(
+            db_session,
+            mock_object_store,
+            cutoff_timestamp=datetime.fromisoformat("2021-01-02T00:00:00"),
+        )
+
+        assert len(response) == 1
+        mock_object_store.delete_bucket_and_contents.assert_not_called()
+        mock_logger.logger.warning.assert_called_once()
+        # Transform row is still gone
+        assert db_session.query(TransformRequest).all() == []
+
+    def test_expired_volume_transform_skips_object_store(self, mocker, db_session):
+        stale_transform = self._generate_transform_request()
+        stale_transform.submit_time = datetime(2021, 1, 1, 0, 0)
+        stale_transform.request_id = "volume-transform"
+        stale_transform.result_destination = TransformRequest.VOLUME_DEST
+        stale_transform.output_path = "/some/volume/path"
+        stale_transform.did_id = 1
+        stale_transform.title = "stale-volume"
+        db_session.add(stale_transform)
+        db_session.commit()
+
+        mock_object_store = mocker.MagicMock()
+
+        data_life_cycle_ops = DataLifecycleOps()
+        response = data_life_cycle_ops.delete_expired_transforms(
+            db_session,
+            mock_object_store,
+            cutoff_timestamp=datetime.fromisoformat("2021-01-02T00:00:00"),
+        )
+
+        assert len(response) == 1
+        mock_object_store.delete_bucket_and_contents.assert_not_called()
+
     def test_orphaned_datasets(self, insert_datasets, db_session):
         data_life_cycle_ops = DataLifecycleOps()
         response = data_life_cycle_ops.delete_orphaned_datasets(db_session)

--- a/servicex_app/servicex_app_test/resources/internal/test_data_lifecycle_ops.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_data_lifecycle_ops.py
@@ -130,6 +130,7 @@ class TestDataLifecycleOps(ResourceTestBase):
         active_transform = self._generate_transform_request()
         active_transform.submit_time = datetime(2022, 1, 1, 0, 0)
         active_transform.request_id = 1
+        active_transform.output_path = "1"
         active_transform.did_id = 1
         active_transform.title = "active"
         db_session.add(active_transform)
@@ -144,6 +145,7 @@ class TestDataLifecycleOps(ResourceTestBase):
         stale_transform = self._generate_transform_request()
         stale_transform.submit_time = datetime(2021, 1, 1, 0, 0)
         stale_transform.request_id = 2
+        stale_transform.output_path = "2"
         stale_transform.did_id = 1
         stale_transform.title = "stale"
         db_session.add(stale_transform)

--- a/servicex_app/servicex_app_test/resources/transformation/test_delete.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_delete.py
@@ -15,9 +15,8 @@ class TestTransformDelete(ResourceTestBase):
 
     @pytest.fixture
     def fake_transform(self, mocker) -> TransformRequest:
-        mock_transform_request_cls = mocker.patch(f"{self.module}.TransformRequest")
         transform = self._generate_transform_request()
-        mock_transform_request_cls.lookup.return_value = transform
+        mocker.patch(f"{self.module}.TransformRequest.lookup", return_value=transform)
         return transform
 
     @pytest.fixture

--- a/servicex_app/servicex_app_test/resources/transformation/test_delete.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_delete.py
@@ -48,6 +48,52 @@ class TestTransformDelete(ResourceTestBase):
             "BR549"
         )
 
+    def test_delete_missing_output_path(
+        self, fake_transform, db_session, mock_object_store_manager
+    ):
+        fake_transform.status = TransformStatus.complete
+        fake_transform.output_path = None
+
+        local_config = {
+            "OBJECT_STORE_ENABLED": True,
+            "MINIO_URL": "localhost:9000",
+            "MINIO_ACCESS_KEY": "miniouser",
+            "MINIO_SECRET_KEY": "leftfoot1",
+        }
+
+        client = self._test_client(
+            extra_config=local_config, object_store=mock_object_store_manager
+        )
+
+        resp = client.delete("/servicex/transformation/BR549")
+        assert resp.status_code == 400
+        assert "no output_path" in resp.json["message"]
+        assert not db_session.delete.called
+        mock_object_store_manager.delete_bucket_and_contents.assert_not_called()
+
+    def test_delete_volume_destination_no_object_store_call(
+        self, fake_transform, db_session, mock_object_store_manager
+    ):
+        fake_transform.status = TransformStatus.complete
+        fake_transform.result_destination = TransformRequest.VOLUME_DEST
+        fake_transform.output_path = "/some/volume/path"
+
+        local_config = {
+            "OBJECT_STORE_ENABLED": True,
+            "MINIO_URL": "localhost:9000",
+            "MINIO_ACCESS_KEY": "miniouser",
+            "MINIO_SECRET_KEY": "leftfoot1",
+        }
+
+        client = self._test_client(
+            extra_config=local_config, object_store=mock_object_store_manager
+        )
+
+        resp = client.delete("/servicex/transformation/BR549")
+        assert resp.status_code == 200
+        db_session.delete.assert_called_once_with(fake_transform)
+        mock_object_store_manager.delete_bucket_and_contents.assert_not_called()
+
     def test_running(self, fake_transform, db_session):
         fake_transform.status = TransformStatus.running
 

--- a/servicex_app/servicex_app_test/resources/transformation/test_file_urls.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_file_urls.py
@@ -46,6 +46,7 @@ class TestFileURLGenerator(ResourceTestBase):
                 fake_transform_request = self._generate_transform_request()
                 fake_transform_request.submit_time = datetime(2021, 1, 1, 12, 0, 0)
                 fake_transform_request.finish_time = datetime(2021, 1, 1, 12, 30, 0)
+                fake_transform_request.output_path = "1234"
                 fake_transform_request.files = 32
                 fake_transform_request.files_completed = 15
                 fake_transform_request.files_failed = 2

--- a/servicex_app/servicex_app_test/resources/transformation/test_file_urls.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_file_urls.py
@@ -89,3 +89,42 @@ class TestFileURLGenerator(ResourceTestBase):
         )
         assert response.status_code == 404
         mock_transform_request_read.assert_called_with("1234")
+
+    def test_non_object_store_destination(self, mocker, client):
+        import servicex_app
+
+        fake_transform_request = self._generate_transform_request()
+        fake_transform_request.result_destination = "volume"
+        fake_transform_request.output_path = "/some/path"
+
+        mocker.patch.object(
+            servicex_app.models.TransformRequest,
+            "lookup",
+            return_value=fake_transform_request,
+        )
+
+        response = client.post(
+            "/servicex/transformation/file-urls",
+            json={"request_id": 1234, "file_list": ["abc"]},
+        )
+        assert response.status_code == 400
+        assert "does not use object-store" in response.json["message"]
+
+    def test_missing_output_path(self, mocker, client):
+        import servicex_app
+
+        fake_transform_request = self._generate_transform_request()
+        fake_transform_request.output_path = None
+
+        mocker.patch.object(
+            servicex_app.models.TransformRequest,
+            "lookup",
+            return_value=fake_transform_request,
+        )
+
+        response = client.post(
+            "/servicex/transformation/file-urls",
+            json={"request_id": 1234, "file_list": ["abc"]},
+        )
+        assert response.status_code == 400
+        assert "no output_path" in response.json["message"]

--- a/servicex_app/servicex_app_test/test_transformer_manager.py
+++ b/servicex_app/servicex_app_test/test_transformer_manager.py
@@ -122,6 +122,30 @@ class TestTransformerManager(ResourceTestBase):
             mock_kubernetes.config.load_incluster_config.assert_not_called()
             mock_kubernetes.config.load_kube_config.assert_not_called()
 
+    def test_compute_output_path_object_store(self):
+        assert (
+            TransformerManager.compute_output_path(
+                "req-123", TransformRequest.OBJECT_STORE_DEST
+            )
+            == "req-123"
+        )
+
+    def test_compute_output_path_volume(self):
+        client = self._test_client(
+            extra_config={"TRANSFORMER_PERSISTENCE_SUBDIR": "out-dir"}
+        )
+        with client.application.app_context():
+            result = TransformerManager.compute_output_path(
+                "req-123", TransformRequest.VOLUME_DEST
+            )
+            assert result == os.path.join(
+                TransformerManager.POSIX_VOLUME_MOUNT, "out-dir"
+            )
+
+    def test_compute_output_path_unknown(self):
+        with pytest.raises(ValueError, match="Unknown result_destination"):
+            TransformerManager.compute_output_path("req-123", "s3-bucket")
+
     @pytest.mark.skip(reason="Needs to be updated to work with sidecar")
     def test_launch_transformer_jobs(self, mocker):
         import kubernetes


### PR DESCRIPTION
Adds `output_path` to `requests` table as well as `TransformerManager.compute_output_path` for distinguishing between object store and volume destinations.