### PR TITLE
fix(app): repair API code paths that cannot execute

### DIFF
--- a/servicex_app/servicex_app/__init__.py
+++ b/servicex_app/servicex_app/__init__.py
@@ -374,7 +374,7 @@ def create_app(
             )
             sys.exit(-1)
 
-        api = Api(app, errors=Flask.errorhandler)
+        api = Api(app)
 
         # ensure the instance folder exists
         try:

--- a/servicex_app/servicex_app/__init__.py
+++ b/servicex_app/servicex_app/__init__.py
@@ -237,7 +237,10 @@ def create_app(
     logstash_port = os.environ.get("LOGSTASH_PORT")
 
     level = os.environ.get("LOG_LEVEL", "DEBUG").upper()
-    app.logger.level = getattr(logging, level, None)
+    numeric_level = getattr(logging, level, None)
+    if not isinstance(numeric_level, int):
+        raise ValueError(f"Unknown LOG_LEVEL: {level}")
+    app.logger.setLevel(numeric_level)
 
     # remove current handlers
     for h in app.logger.handlers:

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -530,7 +530,11 @@ class Dataset(db.Model):
             "size": self.size,
             "events": self.events,
             "last_used": str(self.last_used.strftime(iso_fmt)),
-            "last_updated": str(self.last_updated.strftime(iso_fmt)),
+            "last_updated": (
+                str(self.last_updated.strftime(iso_fmt))
+                if self.last_updated is not None
+                else None
+            ),
             "lookup_status": self.lookup_status,
             "is_stale": self.stale,
         }

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -130,7 +130,7 @@ class UserModel(db.Model):
 
     @classmethod
     def delete_all_pending(cls):
-        num_rows_deleted = db.session.query.filter_by(pending=True).delete()
+        num_rows_deleted = db.session.query(cls).filter_by(pending=True).delete()
         db.session.commit()
         return {"message": "{} row(s) deleted".format(num_rows_deleted)}
 

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -240,10 +240,12 @@ class TransformRequest(db.Model):
             "files-failed": self.files_failed,
             "files-remaining": self.files_remaining,
             "submit-time": str(self.submit_time.strftime(iso_fmt)),
-            "finish-time": str(self.finish_time),
+            "finish-time": (
+                str(self.finish_time.strftime(iso_fmt))
+                if self.finish_time is not None
+                else None
+            ),
         }
-        if self.finish_time is not None:
-            result_obj["finish-time"] = str(self.finish_time.strftime(iso_fmt))
         return result_obj
 
     @classmethod
@@ -468,7 +470,7 @@ class TransformationResult(db.Model):
         return {
             "id": x.id,
             "request-id": x.request_id,
-            "file-id": x.id,
+            "file-id": x.file_id,
             "file-path": x.file_path,
             "s3-object-name": x.s3_object_name,
             "transform_status": x.transform_status,

--- a/servicex_app/servicex_app/resources/datasets/get_all.py
+++ b/servicex_app/servicex_app/resources/datasets/get_all.py
@@ -25,7 +25,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from flask_restful import reqparse
+from flask_restful import inputs, reqparse
 
 from servicex_app.decorators import auth_required
 from servicex_app.models import Dataset
@@ -33,15 +33,17 @@ from servicex_app.resources.servicex_resource import ServiceXResource
 
 parser = reqparse.RequestParser()
 parser.add_argument("did-finder", type=str, location="args", required=False)
-parser.add_argument("show-deleted", type=bool, location="args", required=False)
+parser.add_argument(
+    "show-deleted", type=inputs.boolean, default=False, location="args", required=False
+)
 
 
 class AllDatasets(ServiceXResource):
     @auth_required
     def get(self):
         args = parser.parse_args()
-        show_deleted = args["show-deleted"] if "show-deleted" in args else False
-        if "did-finder" in args and args["did-finder"]:
+        show_deleted = args["show-deleted"]
+        if args["did-finder"]:
             did_finder = args["did-finder"]
             datasets = Dataset.get_by_did_finder(did_finder, show_deleted)
         else:

--- a/servicex_app/servicex_app/resources/datasets/get_one.py
+++ b/servicex_app/servicex_app/resources/datasets/get_one.py
@@ -34,6 +34,9 @@ class OneDataset(ServiceXResource):
     @auth_required
     def get(self, dataset_id):
         dataset = Dataset.find_by_id(dataset_id)
+        if dataset is None:
+            return {"message": f"Dataset {dataset_id} not found"}, 404
+
         result = dataset.to_json()
         result["files"] = [f.to_json() for f in dataset.files]
         return result

--- a/servicex_app/servicex_app/resources/internal/fileset_complete.py
+++ b/servicex_app/servicex_app/resources/internal/fileset_complete.py
@@ -51,6 +51,13 @@ class FilesetComplete(ServiceXResource):
         summary = request.get_json()
         dataset = Dataset.find_by_id(int(dataset_id))
 
+        if dataset is None:
+            current_app.logger.warning(
+                "Fileset complete received for unknown dataset",
+                extra={"dataset_id": dataset_id, "elapsed": summary["elapsed-time"]},
+            )
+            return "", 422
+
         current_app.logger.info(
             "Completed fileset for datasetID",
             extra={"dataset_id": dataset_id, "elapsed": summary["elapsed-time"]},

--- a/servicex_app/servicex_app/resources/internal/transform_status.py
+++ b/servicex_app/servicex_app/resources/internal/transform_status.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 from flask import current_app, request
-from servicex_app.models import TransformRequest, db
+from servicex_app.models import TransformRequest, TransformStatus
 from servicex_app.resources.servicex_resource import ServiceXResource
 
 
@@ -23,11 +23,15 @@ class TransformationStatusInternal(ServiceXResource):
             )
 
             submitted_request = TransformRequest.lookup(request_id)
-            submitted_request.status = "Fatal"
+            if not submitted_request:
+                msg = f"Transformation request not found with id: {request_id}"
+                current_app.logger.error(msg, extra={"request_id": request_id})
+                return {"message": msg}, 404
+
+            submitted_request.status = TransformStatus.fatal
             submitted_request.finish_time = datetime.now(tz=timezone.utc)
             submitted_request.failure_description = status["info"]
             submitted_request.save_to_db()
-            db.session.commit()
         else:
             current_app.logger.info(
                 "Transformation Status Update",

--- a/servicex_app/servicex_app/resources/transformation/status.py
+++ b/servicex_app/servicex_app/resources/transformation/status.py
@@ -25,7 +25,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from flask_restful import reqparse
+from flask_restful import inputs, reqparse
 from flask import jsonify, current_app
 
 from servicex_app.decorators import auth_required
@@ -34,7 +34,7 @@ from servicex_app.resources.servicex_resource import ServiceXResource
 
 status_request_parser = reqparse.RequestParser()
 status_request_parser.add_argument(
-    "details", type=bool, default=False, required=False, location="args"
+    "details", type=inputs.boolean, default=False, required=False, location="args"
 )
 
 

--- a/servicex_app/servicex_app/resources/users/token_refresh.py
+++ b/servicex_app/servicex_app/resources/users/token_refresh.py
@@ -47,6 +47,9 @@ class TokenRefresh(Resource):
         claims = get_jwt()
 
         user = UserModel.find_by_email(claims["sub"])
+        if not user or not user.refresh_token:
+            return {"message": "Invalid or outdated refresh token"}, 401
+
         decoded = decode_token(user.refresh_token)
         if not claims["jti"] == decoded["jti"]:
             return {"message": "Invalid or outdated refresh token"}, 401

--- a/servicex_app/servicex_app_test/resources/datasets/test_get_all.py
+++ b/servicex_app/servicex_app_test/resources/datasets/test_get_all.py
@@ -55,7 +55,7 @@ class TestDatasetsGetAll(ResourceTestBase):
         mock_get_by_did_finder.return_value = datasets
         client = self._test_client()
         response = client.get("/servicex/datasets?did-finder=rucio")
-        mock_get_by_did_finder.assert_called_with("rucio", None)
+        mock_get_by_did_finder.assert_called_with("rucio", False)
         assert response.status_code == 200
 
         assert response.json == {
@@ -80,5 +80,18 @@ class TestDatasetsGetAll(ResourceTestBase):
         mock_get.return_value = datasets
         client = self._test_client()
         response = client.get("/servicex/datasets")
-        mock_get.assert_called()
+        mock_get.assert_called_with(False)
+        assert response.status_code == 200
+
+    @patch("servicex_app.models.Dataset.get_all")
+    def test_get_all_show_deleted(self, mock_get, datasets):
+        mock_get.return_value = datasets
+        client = self._test_client()
+
+        response = client.get("/servicex/datasets?show-deleted=false")
+        mock_get.assert_called_with(False)
+        assert response.status_code == 200
+
+        response = client.get("/servicex/datasets?show-deleted=true")
+        mock_get.assert_called_with(True)
         assert response.status_code == 200

--- a/servicex_app/servicex_app_test/resources/datasets/test_get_one.py
+++ b/servicex_app/servicex_app_test/resources/datasets/test_get_one.py
@@ -65,3 +65,11 @@ class TestDatasetsGetOne(ResourceTestBase):
         response = client.get("/servicex/datasets/123")
         mock_get.assert_called()
         assert response.status_code == 200
+
+    @patch("servicex_app.models.Dataset.find_by_id")
+    def test_get_one_not_found(self, mock_get):
+        mock_get.return_value = None
+        client = self._test_client()
+        response = client.get("/servicex/datasets/123")
+        mock_get.assert_called()
+        assert response.status_code == 404

--- a/servicex_app/servicex_app_test/resources/internal/test_fileset_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_fileset_complete.py
@@ -148,3 +148,32 @@ class TestFilesetComplete(ResourceTestBase):
         assert running_request.finish_time is not None
         assert pending_request.status == TransformStatus.complete
         assert pending_request.finish_time is not None
+
+    def test_put_fileset_complete_unknown_dataset(self, mocker):
+        mock_lookup_pending = mocker.patch.object(
+            TransformRequest, "lookup_pending_on_dataset", return_value=[]
+        )
+        mock_lookup_running = mocker.patch.object(
+            TransformRequest, "lookup_running_by_dataset_id", return_value=[]
+        )
+        mock_find_dataset_by_id = mocker.patch.object(
+            Dataset, "find_by_id", return_value=None
+        )
+        mock_processor = mocker.MagicMock(LookupResultProcessor)
+
+        client = self._test_client(lookup_result_processor=mock_processor)
+
+        response = client.put(
+            "/servicex/internal/transformation/1234/complete",
+            json={
+                "files": 17,
+                "total-events": 1024,
+                "total-bytes": 2046,
+                "elapsed-time": 42,
+            },
+        )
+
+        assert response.status_code == 422
+        mock_find_dataset_by_id.assert_called_once_with(1234)
+        mock_lookup_pending.assert_not_called()
+        mock_lookup_running.assert_not_called()

--- a/servicex_app/servicex_app_test/resources/internal/test_transform_status.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_transform_status.py
@@ -49,21 +49,39 @@ class TestTransformStatusInternal(ResourceTestBase):
         assert response.status_code == 200
         mock_request.save_to_db.assert_not_called()
 
-    def test_post_status_fatal(self, mocker, client):
+    def test_post_status_fatal(self, client):
+        from servicex_app.models import TransformRequest, TransformStatus
+
+        with client.application.app_context():
+            transform_request = self._generate_transform_request()
+            transform_request.save_to_db()
+
+            response = client.post(
+                "/servicex/internal/transformation/BR549/status",
+                json={
+                    "severity": "fatal",
+                    "info": "Just testing",
+                    "source": "test source",
+                },
+            )
+
+            assert response.status_code == 200
+            saved = TransformRequest.lookup("BR549")
+            assert saved.status == TransformStatus.fatal
+            assert saved.finish_time is not None
+            assert saved.failure_description == "Just testing"
+
+    def test_post_status_fatal_unknown_request(self, mocker, client):
         from servicex_app.models import TransformRequest
 
-        mock_request = self._generate_transform_request()
-        mock_request.save_to_db = mocker.Mock()
-        mocker.patch.object(TransformRequest, "lookup", return_value=mock_request)
+        mocker.patch.object(TransformRequest, "lookup", return_value=None)
 
         response = client.post(
             "/servicex/internal/transformation/1234/status",
             json={"severity": "fatal", "info": "Just testing", "source": "test source"},
         )
 
-        assert response.status_code == 200
-        assert mock_request.finish_time is not None
-        mock_request.save_to_db.assert_called()
+        assert response.status_code == 404
 
     def test_post_status_bad_data(self, client):
         response = client.post(

--- a/servicex_app/servicex_app_test/resources/users/test_pending_users.py
+++ b/servicex_app/servicex_app_test/resources/users/test_pending_users.py
@@ -14,12 +14,24 @@ class TestPendingUsers(WebTestBase):
         mock.assert_called_once()
         assert response.json == resp_json
 
-    def test_delete_pending_users(self, client, mocker):
-        resp_json = {"message": "0 row(s) deleted"}
-        mock = mocker.patch(
-            "servicex_app.models.UserModel.delete_all_pending", return_value=resp_json
-        )
-        response: Response = client.delete("/pending")
-        assert response.status_code == 200
-        mock.assert_called_once()
-        assert response.json == resp_json
+    def test_delete_pending_users(self, client):
+        from servicex_app.models import UserModel
+
+        with client.application.app_context():
+            pending_user = self._test_user()
+            pending_user.pending = True
+            pending_user.save_to_db()
+
+            accepted_user = self._test_user()
+            accepted_user.email = "john@example.com"
+            accepted_user.sub = "johndoe"
+            accepted_user.refresh_token = "fedcba"
+            accepted_user.pending = False
+            accepted_user.save_to_db()
+
+            response: Response = client.delete("/pending")
+            assert response.status_code == 200
+            assert response.json == {"message": "1 row(s) deleted"}
+            assert [user.email for user in UserModel.query.all()] == [
+                accepted_user.email
+            ]

--- a/servicex_app/servicex_app_test/resources/users/test_token_refresh.py
+++ b/servicex_app/servicex_app_test/resources/users/test_token_refresh.py
@@ -62,6 +62,45 @@ class TestTokenRefresh(ResourceTestBase):
             assert "auth_disabled" in response.json
             assert response.json["auth_disabled"] is False
 
+    def test_token_refresh_with_deleted_user(self, mocker):
+        """Test that token refresh fails when the user no longer exists."""
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+
+        with client.application.app_context():
+            mocker.patch(
+                "servicex_app.resources.users.token_refresh.UserModel.find_by_email",
+                return_value=None,
+            )
+
+            refresh_token = create_refresh_token(identity="testuser@example.com")
+            headers = {"Authorization": f"Bearer {refresh_token}"}
+            response: Response = client.post("/token/refresh", headers=headers)
+
+            assert response.status_code == 401
+
+    def test_token_refresh_without_stored_refresh_token(self, mocker):
+        """Test that token refresh fails when the user has no stored refresh token."""
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+
+        with client.application.app_context():
+            test_user = UserModel()
+            test_user.email = "testuser@example.com"
+            test_user.sub = "test-sub-123"
+            test_user.name = "Test User"
+            test_user.institution = "Test Institution"
+            test_user.refresh_token = None
+
+            mocker.patch(
+                "servicex_app.resources.users.token_refresh.UserModel.find_by_email",
+                return_value=test_user,
+            )
+
+            refresh_token = create_refresh_token(identity=test_user.email)
+            headers = {"Authorization": f"Bearer {refresh_token}"}
+            response: Response = client.post("/token/refresh", headers=headers)
+
+            assert response.status_code == 401
+
     def test_token_refresh_with_mismatched_jti(self, mocker):
         """Test that token refresh fails when JTI doesn't match stored token."""
         client = self._test_client(extra_config={"ENABLE_AUTH": True})


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This fixes a group of Flask app code paths that could never succeed: endpoints that dereference `None` or write invalid values into enum columns and always return 500, a query argument that parsed as `True` for every value including `"false"`, and two JSON fields serialized from the wrong source. Tests that mocked away the broken model calls now exercise the real methods against the sqlite test database.

**How to review.** Each finding is one commit; the Commits tab shows them in severity order. Each entry below links to its commit; tick approve or reject under it. To ask for a change instead, leave a review comment on the commit. Rejected commits will be dropped from the branch and this list will be updated to match.

- **B4** · high · [`14bb71cd`](https://github.com/ssl-hep/ServiceX/pull/1540/commits/14bb71cd9061e20ce93897a67bf1121350153dac) · Assign `TransformStatus.fatal` instead of the string `"Fatal"`, return 404 for an unknown request, drop the redundant commit
  - [ ] approve
  - [ ] reject
- **B5** · high · [`793e66ab`](https://github.com/ssl-hep/ServiceX/pull/1540/commits/793e66abe77bc5d6ab9f93d06d6ca77f522b9fba) · `UserModel.delete_all_pending` builds a real query with `db.session.query(cls)`
  - [ ] approve
  - [ ] reject
- **B6** · high · [`0c3b1cba`](https://github.com/ssl-hep/ServiceX/pull/1540/commits/0c3b1cba717f29c3b248403567e1bd488b5fa1b6) · `Api(app)` instead of `Api(app, errors=Flask.errorhandler)`, so resource `HTTPException`s return JSON
  - [ ] approve
  - [ ] reject
- **B51** · medium · [`4621062b`](https://github.com/ssl-hep/ServiceX/pull/1540/commits/4621062bdbfed0e2ddd3f6354233d4926e956c1d) · 404 for an unknown dataset id, 422 for an unknown dataset on fileset completion, `null` for a missing `last_updated`
  - [ ] approve
  - [ ] reject
- **B52** · medium · [`d049c69c`](https://github.com/ssl-hep/ServiceX/pull/1540/commits/d049c69c829d82cc5fd1d2d938d5346c7a6293f5) · Return 401 when the user record is gone or has no stored refresh token
  - [ ] approve
  - [ ] reject
- **B53** · medium · [`9085871e`](https://github.com/ssl-hep/ServiceX/pull/1540/commits/9085871e468d2804640c1859edd60196d4f21599) · Use `flask_restful.inputs.boolean` for boolean query arguments and a parser default for `show-deleted`
  - [ ] approve
  - [ ] reject
- **B56** · medium · [`21c691b6`](https://github.com/ssl-hep/ServiceX/pull/1540/commits/21c691b690d7c8c911fe7d3d51b85ce195bd1f0d) · Emit `null` for a missing `finish-time` and report `x.file_id` as `"file-id"`
  - [ ] approve
  - [ ] reject
- **B63** · medium · [`aa38435a`](https://github.com/ssl-hep/ServiceX/pull/1540/commits/aa38435a01b391baaca3f2104b555c428c31fd7f) · Resolve `LOG_LEVEL`, raise `ValueError` on an unknown name, and apply it through `setLevel`
  - [ ] approve
  - [ ] reject

Part of #1539.
