### PR TITLE
fix(app): build valid transformer manifests and surface deployment failures

### DIFF
--- a/servicex_app/servicex_app/resources/servicex_resource.py
+++ b/servicex_app/servicex_app/resources/servicex_resource.py
@@ -31,9 +31,7 @@ from importlib.metadata import version, PackageNotFoundError
 from flask import current_app
 from flask_jwt_extended import get_jwt_identity
 from flask_restful import Resource
-from servicex_app.models import UserModel, TransformRequest, TransformStatus
-
-from servicex_app.transformer_manager import TransformerManager
+from servicex_app.models import UserModel
 
 from servicex_app.decorators import jwt_required_if_auth_enabled
 
@@ -72,44 +70,3 @@ class ServiceXResource(Resource):
             return version("servicex_app")
         except PackageNotFoundError:
             return "develop"
-
-    @classmethod
-    def start_transformers(
-        cls,
-        transformer_manager: TransformerManager,
-        config: dict,
-        request_rec: TransformRequest,
-    ):
-        """
-        Start the transformers for a given request
-        """
-        rabbitmq_uri = config["TRANSFORMER_RABBIT_MQ_URL"]
-        namespace = config["TRANSFORMER_NAMESPACE"]
-        x509_secret = config["TRANSFORMER_X509_SECRET"]
-        generated_code_cm = request_rec.generated_code_cm
-
-        request_rec.workers = min(max(1, request_rec.files), request_rec.workers)
-
-        current_app.logger.info(
-            f"Launching {request_rec.workers} transformers.",
-            extra={"request_id": request_rec.request_id},
-        )
-
-        transformer_manager.launch_transformer_jobs(
-            image=request_rec.image,
-            request_id=request_rec.request_id,
-            workers=request_rec.workers,
-            max_workers=(
-                max(1, request_rec.files)
-                if request_rec.status == TransformStatus.running
-                else config["TRANSFORMER_MAX_REPLICAS"]
-            ),
-            rabbitmq_uri=rabbitmq_uri,
-            namespace=namespace,
-            x509_secret=x509_secret,
-            generated_code_cm=generated_code_cm,
-            result_destination=request_rec.result_destination,
-            result_format=request_rec.result_format,
-            transformer_language=request_rec.transformer_language,
-            transformer_command=request_rec.transformer_command,
-        )

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -36,13 +36,18 @@ import time
 import urllib3
 from tenacity import (
     Retrying,
-    RetryError,
     stop_after_attempt,
     wait_random_exponential,
-    retry_if_exception_type,
+    retry_if_exception,
 )
 
 from servicex_app.models import TransformRequest, TransformStatus
+
+
+def _is_retryable_api_error(exc: BaseException) -> bool:
+    if isinstance(exc, ApiException):
+        return exc.status is not None and exc.status >= 500
+    return isinstance(exc, urllib3.exceptions.HTTPError)
 
 
 class TransformerManager:
@@ -562,74 +567,62 @@ class TransformerManager:
             hpa = self.create_hpa_object(request_id, max_workers)
             self._create_hpa(autoscaler_api, hpa, namespace, request_id)
 
+    @staticmethod
+    def _delete_with_retries(delete, description, request_id, quiet_errors):
+        try:
+            for attempt in Retrying(
+                wait=wait_random_exponential(max=60),
+                stop=stop_after_attempt(3),
+                retry=retry_if_exception(_is_retryable_api_error),
+                reraise=True,
+            ):
+                with attempt:
+                    delete()
+        except ApiException as e:
+            # the resource is already gone, which is all we wanted
+            if e.status == 404:
+                return
+            if not quiet_errors:
+                current_app.logger.exception(
+                    description,
+                    extra={"request_id": request_id, "retry_status": e.status},
+                )
+
     @classmethod
     def shutdown_transformer_job(cls, request_id, namespace, quiet_errors=False):
         # quiet_errors is intended to be used for reaper jobs where components of the transform
         # may be missing
-        try:
-            if current_app.config["TRANSFORMER_AUTOSCALE_ENABLED"]:
-                autoscaler_api = kubernetes.client.AutoscalingV1Api()
-                try:
-                    for attempt in Retrying(
-                        wait=wait_random_exponential(max=60),
-                        stop=stop_after_attempt(3),
-                        retry=retry_if_exception_type(ApiException),
-                    ):
-                        with attempt:
-                            autoscaler_api.delete_namespaced_horizontal_pod_autoscaler(
-                                name="transformer-" + request_id, namespace=namespace
-                            )
-                except RetryError as e:
-                    e.reraise()
-        except ApiException as e:
-            if not quiet_errors:
-                current_app.logger.exception(
-                    "Exception during Job HPA Shut Down",
-                    extra={"request_id": request_id, "retry_status": e.status},
-                )
+        if current_app.config["TRANSFORMER_AUTOSCALE_ENABLED"]:
+            autoscaler_api = kubernetes.client.AutoscalingV1Api()
+            cls._delete_with_retries(
+                lambda: autoscaler_api.delete_namespaced_horizontal_pod_autoscaler(
+                    name="transformer-" + request_id, namespace=namespace
+                ),
+                "Exception during Job HPA Shut Down",
+                request_id,
+                quiet_errors,
+            )
 
-        try:
-            api_v1 = client.AppsV1Api()
-            try:
-                for attempt in Retrying(
-                    wait=wait_random_exponential(max=60),
-                    stop=stop_after_attempt(3),
-                    retry=retry_if_exception_type(ApiException),
-                ):
-                    with attempt:
-                        api_v1.delete_namespaced_deployment(
-                            name="transformer-" + request_id, namespace=namespace
-                        )
-            except RetryError as e:
-                e.reraise()
-        except ApiException as e:
-            if not quiet_errors:
-                current_app.logger.exception(
-                    "Exception during Job Deployment Shut Down",
-                    extra={"request_id": request_id, "retry_status": e.status},
-                )
+        api_v1 = client.AppsV1Api()
+        cls._delete_with_retries(
+            lambda: api_v1.delete_namespaced_deployment(
+                name="transformer-" + request_id, namespace=namespace
+            ),
+            "Exception during Job Deployment Shut Down",
+            request_id,
+            quiet_errors,
+        )
 
-        try:
-            api_core = client.CoreV1Api()
-            configmap_name = "{}-generated-source".format(request_id)
-            try:
-                for attempt in Retrying(
-                    wait=wait_random_exponential(max=60),
-                    stop=stop_after_attempt(3),
-                    retry=retry_if_exception_type(ApiException),
-                ):
-                    with attempt:
-                        api_core.delete_namespaced_config_map(
-                            name=configmap_name, namespace=namespace
-                        )
-            except RetryError as e:
-                e.reraise()
-        except ApiException as e:
-            if not quiet_errors:
-                current_app.logger.exception(
-                    "Exception during Job ConfigMap cleanup",
-                    extra={"request_id": request_id, "retry_status": e.status},
-                )
+        api_core = client.CoreV1Api()
+        configmap_name = "{}-generated-source".format(request_id)
+        cls._delete_with_retries(
+            lambda: api_core.delete_namespaced_config_map(
+                name=configmap_name, namespace=namespace
+            ),
+            "Exception during Job ConfigMap cleanup",
+            request_id,
+            quiet_errors,
+        )
 
         # delete RabbitMQ queue
         try:

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -386,18 +386,8 @@ class TransformerManager:
         # Create and Configure a spec section
         pod_annotations = current_app.config.get("TRANSFORMER_POD_ANNOTATIONS", {})
         node_selector = current_app.config.get("TRANSFORMER_NODE_SELECTOR", {})
-        tolerations_config = current_app.config.get("TRANSFORMER_TOLERATIONS", [])
-        affinity_config = current_app.config.get("TRANSFORMER_AFFINITY", {})
-
-        # Convert tolerations from config dicts to V1Toleration objects
-        tolerations = None
-        if tolerations_config:
-            tolerations = [client.V1Toleration(**t) for t in tolerations_config]
-
-        # Convert affinity from config dict to V1Affinity object
-        affinity = None
-        if affinity_config:
-            affinity = client.V1Affinity(**affinity_config)
+        tolerations = current_app.config.get("TRANSFORMER_TOLERATIONS", [])
+        affinity = current_app.config.get("TRANSFORMER_AFFINITY", {})
 
         template = client.V1PodTemplateSpec(
             metadata=client.V1ObjectMeta(
@@ -411,8 +401,8 @@ class TransformerManager:
                     "TRANSFORMER_PRIORITY_CLASS", None
                 ),
                 node_selector=node_selector if node_selector else None,
-                tolerations=tolerations,
-                affinity=affinity,
+                tolerations=tolerations if tolerations else None,
+                affinity=affinity if affinity else None,
                 containers=[
                     sidecar,
                     science_container,

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -509,8 +509,10 @@ class TransformerManager:
             )
         except ApiException as e:
             current_app.logger.exception(
-                f"Exception during HPA Creation: {e}", extra={"request_id": request_id}
+                f"Exception during Deployment Creation: {e}",
+                extra={"request_id": request_id},
             )
+            raise
 
     @staticmethod
     def _create_hpa(api_instance, hpa, namespace, request_id):

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -34,7 +34,6 @@ from kubernetes.client.rest import ApiException
 from typing import Optional
 import time
 import urllib3
-import re
 from tenacity import (
     Retrying,
     RetryError,
@@ -44,27 +43,6 @@ from tenacity import (
 )
 
 from servicex_app.models import TransformRequest, TransformStatus
-
-# these regexes are defined to help translate camelCase to snake_case
-# due to mismatch of Kubernetes yaml syntax and Python API
-UPPER_FOLLOWED_BY_LOWER_RE = re.compile("(.)([A-Z][a-z]+)")
-LOWER_OR_NUM_FOLLOWED_BY_UPPER_RE = re.compile("([a-z0-9])([A-Z])")
-
-
-def camel_to_snake_case(strin: str):
-    strout = UPPER_FOLLOWED_BY_LOWER_RE.sub(r"\1_\2", strin)
-    strout = LOWER_OR_NUM_FOLLOWED_BY_UPPER_RE.sub(r"\1_\2", strout).lower()
-    return strout
-
-
-def camel_to_snake_case_dict(dictin: dict):
-    dictout = {}
-    for key, value in dictin.items():
-        keyout = camel_to_snake_case(key)
-        dictout[keyout] = (
-            camel_to_snake_case_dict(value) if isinstance(value, dict) else value
-        )
-    return dictout
 
 
 class TransformerManager:
@@ -219,17 +197,16 @@ class TransformerManager:
             )
 
         if (cvmfs_volume := current_app.config["TRANSFORMER_CVMFS_VOLUME"]) is not None:
-            cvmfs_volume = camel_to_snake_case_dict(cvmfs_volume)
-            cvmfs_volume["name"] = "cvmfs"
+            cvmfs_volume = {**cvmfs_volume, "name": "cvmfs"}
             cvmfs_volume_mount = {
                 "name": "cvmfs",
                 "mount_path": "/cvmfs",
                 "read_only": True,
             }
-            if "host_path" in cvmfs_volume:
+            if "hostPath" in cvmfs_volume:
                 cvmfs_volume_mount["mount_propagation"] = "HostToContainer"
 
-            volumes.append(client.V1Volume(**cvmfs_volume))
+            volumes.append(cvmfs_volume)
             volume_mounts.append(client.V1VolumeMount(**cvmfs_volume_mount))
 
         # Compute Environment Vars

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -284,15 +284,15 @@ class TransformerManager:
         science_command = " "
         if x509_secret:
             science_command += (
-                "until [ -f /servicex/output/scripts/proxy-exporter.sh ];"
+                f"until [ -f {output_path}/scripts/proxy-exporter.sh ];"
                 "do sleep 5;done &&"
-                " /servicex/output/scripts/proxy-exporter.sh & sleep 5 && "
+                f" {output_path}/scripts/proxy-exporter.sh & sleep 5 && "
             )
 
         sidecar_command = (
             "PYTHONPATH=/servicex/transformer_sidecar:$PYTHONPATH "
             + "python /servicex/transformer_sidecar/transformer.py "
-            + " --shared-dir /servicex/output "
+            + f" --shared-dir {output_path} "
             + " --request-id "
             + request_id
             + " --rabbit-uri "

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -645,11 +645,11 @@ class TransformerManager:
         namespace = current_app.config["TRANSFORMER_NAMESPACE"]
         api = client.AppsV1Api()
         selector = f"metadata.name=transformer-{request_id}"
-        results: kubernetes.client.AppsV1beta1DeploymentList
+        results: client.V1DeploymentList
         results = api.list_namespaced_deployment(namespace, field_selector=selector)
         if not results.items:
             return None
-        deployment: kubernetes.client.AppsV1beta1Deployment = results.items[0]
+        deployment: client.V1Deployment = results.items[0]
         return deployment.status
 
     @staticmethod
@@ -668,7 +668,7 @@ class TransformerManager:
     def create_configmap_from_zip(zipfile, request_id, namespace):
         configmap_name = "{}-generated-source".format(request_id)
         data = {
-            file.filename: base64.b64encode(zipfile.open(file).read()).decode("ascii")
+            file.filename: base64.b64encode(zipfile.read(file)).decode("ascii")
             for file in zipfile.filelist
         }
 

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -75,8 +75,6 @@ class TransformerManager:
         x509_secret = config["TRANSFORMER_X509_SECRET"]
         generated_code_cm = request_rec.generated_code_cm
 
-        request_rec.workers = min(max(1, request_rec.files), request_rec.workers)
-
         current_app.logger.info(
             f"Launching {request_rec.workers} transformers.",
             extra={"request_id": request_rec.request_id},
@@ -397,7 +395,7 @@ class TransformerManager:
         if current_app.config["TRANSFORMER_AUTOSCALE_ENABLED"]:
             replicas = current_app.config.get("TRANSFORMER_MIN_REPLICAS", 1)
         else:
-            replicas = workers
+            replicas = max(1, workers)
         spec = client.V1DeploymentSpec(
             template=template, selector=selector, replicas=replicas
         )

--- a/servicex_app/servicex_app_test/test_transformer_manager.py
+++ b/servicex_app/servicex_app_test/test_transformer_manager.py
@@ -240,6 +240,48 @@ class TestTransformerManager(ResourceTestBase):
             assert requests["cpu"] == "500m"
             assert requests["memory"] == "512Mi"
 
+    def test_launch_transformer_jobs_custom_sidecar_volume_path(self, mocker):
+        import kubernetes
+
+        mocker.patch.object(kubernetes.config, "load_kube_config")
+        mock_api = mocker.patch.object(kubernetes.client, "AppsV1Api")
+
+        mocker.patch.object(kubernetes.client, "AutoscalingV1Api", mocker.Mock())
+
+        transformer = TransformerManager("external-kubernetes")
+        transformer.persistent_volume_claim_exists = mocker.Mock(return_value=True)
+
+        client = self._test_client(
+            extra_config=make_config(
+                TRANSFORMER_AUTOSCALE_ENABLED=False,
+                TRANSFORMER_SIDECAR_VOLUME_PATH="/shared/scratch",
+            ),
+            transformation_manager=transformer,
+        )
+
+        with client.application.app_context():
+            transformer.launch_transformer_jobs(
+                image="sslhep/servicex-transformer:pytest",
+                request_id="1234",
+                workers=17,
+                max_workers=17,
+                rabbitmq_uri="ampq://test.com",
+                namespace="my-ns",
+                result_destination="object-store",
+                result_format="arrow",
+                x509_secret="x509",
+                generated_code_cm=None,
+                transformer_language="scala",
+                transformer_command="echo",
+            )
+            called_deployment = mock_api.mock_calls[1][2]["body"]
+            sidecar, science = called_deployment.spec.template.spec.containers
+
+            assert _arg_value(sidecar.args, "--shared-dir") == "/shared/scratch"
+            assert "/shared/scratch/scripts/proxy-exporter.sh" in science.args[0]
+            assert "/servicex/output" not in sidecar.args[0]
+            assert "/servicex/output" not in science.args[0]
+
     def test_launch_transformer_jobs_deployment_failure(self, mocker):
         import kubernetes
 

--- a/servicex_app/servicex_app_test/test_transformer_manager.py
+++ b/servicex_app/servicex_app_test/test_transformer_manager.py
@@ -1174,15 +1174,15 @@ class TestTransformerManager(ResourceTestBase):
                 "key": "gpu",
                 "operator": "Exists",
                 "effect": "NoExecute",
-                "toleration_seconds": 3600,
+                "tolerationSeconds": 3600,
             },
         ]
         affinity = {
-            "node_affinity": {
-                "required_during_scheduling_ignored_during_execution": {
-                    "node_selector_terms": [
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
                         {
-                            "match_expressions": [
+                            "matchExpressions": [
                                 {
                                     "key": "topology.kubernetes.io/zone",
                                     "operator": "In",
@@ -1234,20 +1234,15 @@ class TestTransformerManager(ResourceTestBase):
             # Verify node selector
             assert template.spec.node_selector == node_selector
 
-            # Verify tolerations
-            assert len(template.spec.tolerations) == 2
-            assert template.spec.tolerations[0].key == "dedicated"
-            assert template.spec.tolerations[0].operator == "Equal"
-            assert template.spec.tolerations[0].value == "servicex"
-            assert template.spec.tolerations[0].effect == "NoSchedule"
-            assert template.spec.tolerations[1].key == "gpu"
-            assert template.spec.tolerations[1].operator == "Exists"
-            assert template.spec.tolerations[1].effect == "NoExecute"
-            assert template.spec.tolerations[1].toleration_seconds == 3600
-
-            # Verify affinity
-            assert template.spec.affinity is not None
-            assert template.spec.affinity.node_affinity is not None
+            # Verify the manifest which actually gets sent to Kubernetes keeps
+            # the standard camelCase spelling of these settings
+            manifest = kubernetes.client.ApiClient().sanitize_for_serialization(
+                called_deployment
+            )
+            pod_spec = manifest["spec"]["template"]["spec"]
+            assert pod_spec["tolerations"] == tolerations
+            assert pod_spec["affinity"] == affinity
+            assert pod_spec["nodeSelector"] == node_selector
 
     def test_launch_transformer_with_empty_pod_scheduling_options(self, mocker):
         import kubernetes

--- a/servicex_app/servicex_app_test/test_transformer_manager.py
+++ b/servicex_app/servicex_app_test/test_transformer_manager.py
@@ -240,6 +240,41 @@ class TestTransformerManager(ResourceTestBase):
             assert requests["cpu"] == "500m"
             assert requests["memory"] == "512Mi"
 
+    def test_launch_transformer_jobs_deployment_failure(self, mocker):
+        import kubernetes
+
+        mocker.patch.object(kubernetes.config, "load_kube_config")
+        mock_api = mocker.MagicMock(kubernetes.client.AppsV1Api)
+        mocker.patch.object(kubernetes.client, "AppsV1Api", return_value=mock_api)
+        mock_api.create_namespaced_deployment.side_effect = (
+            kubernetes.client.rest.ApiException(status=403)
+        )
+
+        transformer = TransformerManager("external-kubernetes")
+        transformer.persistent_volume_claim_exists = mocker.Mock(return_value=True)
+
+        client = self._test_client(
+            extra_config=make_config(TRANSFORMER_AUTOSCALE_ENABLED=False),
+            transformation_manager=transformer,
+        )
+
+        with client.application.app_context():
+            with pytest.raises(kubernetes.client.rest.ApiException):
+                transformer.launch_transformer_jobs(
+                    image="sslhep/servicex-transformer:pytest",
+                    request_id="1234",
+                    workers=17,
+                    max_workers=17,
+                    rabbitmq_uri="ampq://test.com",
+                    namespace="my-ns",
+                    result_destination="object-store",
+                    result_format="arrow",
+                    x509_secret="x509",
+                    generated_code_cm=None,
+                    transformer_language="scala",
+                    transformer_command="echo",
+                )
+
     def test_launch_transformer_with_hostpath(self, mocker):
         import kubernetes
 

--- a/servicex_app/servicex_app_test/test_transformer_manager.py
+++ b/servicex_app/servicex_app_test/test_transformer_manager.py
@@ -737,13 +737,13 @@ class TestTransformerManager(ResourceTestBase):
         mock_api = mocker.MagicMock(kubernetes.client.AppsV1Api)
         mocker.patch.object(kubernetes.client, "AppsV1Api", return_value=mock_api)
         mock_api.delete_namespaced_deployment.side_effect = (
-            kubernetes.client.rest.ApiException()
+            kubernetes.client.rest.ApiException(status=403)
         )
 
         mock_core_api = mocker.MagicMock(kubernetes.client.CoreV1Api)
         mocker.patch.object(kubernetes.client, "CoreV1Api", return_value=mock_core_api)
         mock_core_api.delete_namespaced_config_map.side_effect = (
-            kubernetes.client.rest.ApiException()
+            kubernetes.client.rest.ApiException(status=403)
         )
 
         mock_autoscaling = mocker.Mock()
@@ -751,7 +751,7 @@ class TestTransformerManager(ResourceTestBase):
             kubernetes.client, "AutoscalingV1Api", return_value=mock_autoscaling
         )
         mock_autoscaling.delete_namespaced_horizontal_pod_autoscaler.side_effect = (
-            kubernetes.client.rest.ApiException()
+            kubernetes.client.rest.ApiException(status=403)
         )
 
         transformer = TransformerManager("external-kubernetes")
@@ -778,6 +778,8 @@ class TestTransformerManager(ResourceTestBase):
             transformer.celery_app.control.cancel_consumer.assert_called_with(
                 "transformer-1234"
             )
+            # a 403 is not worth retrying
+            assert mock_api.delete_namespaced_deployment.call_count == 1
         assert client.application.logger.exception.call_count == 4
 
         # now check quiet mode
@@ -805,14 +807,14 @@ class TestTransformerManager(ResourceTestBase):
         mock_api = mocker.MagicMock(kubernetes.client.AppsV1Api)
         mocker.patch.object(kubernetes.client, "AppsV1Api", return_value=mock_api)
         mock_api.delete_namespaced_deployment.side_effect = (
-            kubernetes.client.rest.ApiException(),
+            kubernetes.client.rest.ApiException(status=500),
             None,
         )
 
         mock_core_api = mocker.MagicMock(kubernetes.client.CoreV1Api)
         mocker.patch.object(kubernetes.client, "CoreV1Api", return_value=mock_core_api)
         mock_core_api.delete_namespaced_config_map.side_effect = (
-            kubernetes.client.rest.ApiException(),
+            kubernetes.client.rest.ApiException(status=500),
             None,
         )
 
@@ -821,7 +823,7 @@ class TestTransformerManager(ResourceTestBase):
             kubernetes.client, "AutoscalingV1Api", return_value=mock_autoscaling
         )
         mock_autoscaling.delete_namespaced_horizontal_pod_autoscaler.side_effect = (
-            kubernetes.client.rest.ApiException(),
+            kubernetes.client.rest.ApiException(status=500),
             None,
         )
 

--- a/servicex_app/servicex_app_test/test_transformer_manager.py
+++ b/servicex_app/servicex_app_test/test_transformer_manager.py
@@ -894,9 +894,7 @@ class TestTransformerManager(ResourceTestBase):
         mock_zip_ext = mocker.Mock()
         mock_zip_ext.filename = "foo.sh"
         mock_zip.filelist = [mock_zip_ext]
-        mock_open = mocker.Mock()
-        mock_open.read = mocker.Mock(return_value=b"hi there")
-        mock_zip.open = mocker.Mock(return_value=mock_open)
+        mock_zip.read = mocker.Mock(return_value=b"hi there")
 
         transformer.create_configmap_from_zip(mock_zip, "my-request", "servicex")
 

--- a/servicex_app/servicex_app_test/test_transformer_manager.py
+++ b/servicex_app/servicex_app_test/test_transformer_manager.py
@@ -1336,29 +1336,17 @@ class TestTransformerManager(ResourceTestBase):
             called_job = mock_kubernetes.mock_calls[1][2]["body"]
             container = called_job.spec.template.spec.containers[0]
 
+            manifest = kubernetes.client.ApiClient().sanitize_for_serialization(
+                called_job
+            )
             cvmfs_vol = next(
                 filter(
-                    lambda v: v.name == "cvmfs",
-                    called_job.spec.template.spec.volumes,
+                    lambda v: v["name"] == "cvmfs",
+                    manifest["spec"]["template"]["spec"]["volumes"],
                 )
             )
-            # check that one volume type exists
-            assert (
-                len(
-                    [
-                        _
-                        for _ in cvmfs_vol.to_dict().items()
-                        if _[1] is not None and _[0] != "name"
-                    ]
-                )
-                == 1
-            )
-            # check that all the keys have been snake cased
-            for key, subdict in cvmfs_vol.to_dict().items():
-                if key == "name":
-                    continue
-                if subdict is not None:
-                    assert all(_.islower() for _ in subdict.keys())
+            # the volume definition is passed through verbatim, apart from the name
+            assert cvmfs_vol == {**volume, "name": "cvmfs"}
 
             cvmfs_vol_mount = next(
                 filter(lambda m: m.name == "cvmfs", container.volume_mounts)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The transformer Deployment manifest was being assembled in ways that either crashed or produced invalid Kubernetes objects, and a failed deployment creation was silently swallowed. This PR hands the configured Kubernetes fragments straight to the pod spec, propagates deployment failures to the caller, stops overwriting the requested worker count, and uses the configured sidecar volume path consistently. It also removes a dead duplicate of `start_transformers`, consolidates the shutdown retry logic, and refreshes two stale Kubernetes client usages.

**How to review.** Each finding is one commit; the Commits tab shows them in severity order. Each entry below links to its commit; tick approve or reject under it. To ask for a change instead, leave a review comment on the commit. Rejected commits will be dropped from the branch and this list will be updated to match.

- **B9** · high · [`8cdebd9`](https://github.com/ssl-hep/ServiceX/pull/1541/commits/8cdebd95812ade9a68a41194ec4e3d87d12f8c94) · `TRANSFORMER_AFFINITY` and `TRANSFORMER_TOLERATIONS` go to `V1PodSpec` as the plain camelCase dicts the helm chart and docs describe, instead of `V1Affinity(**cfg)` / `V1Toleration(**t)`, which raised `TypeError` on any real config
  - [ ] approve
  - [ ] reject
- **B10** · high · [`d941086`](https://github.com/ssl-hep/ServiceX/pull/1541/commits/d9410866f4c4ff6610e1a4ff967b7a030d840588) · `TRANSFORMER_CVMFS_VOLUME` is no longer run through `camel_to_snake_case_dict`, which corrupted nested keys such as `persistentVolumeClaim.claimName`; the volume is passed through verbatim apart from the injected `name`
  - [ ] approve
  - [ ] reject
- **B11** · high · [`4105c0f`](https://github.com/ssl-hep/ServiceX/pull/1541/commits/4105c0f171f2306e0f80c800e75938cb2cabca7d) · dropped the `min(max(1, files), workers)` clamp in `start_transformers`, which forced a single replica because transformers start at submit time while `files` is still 0, keeping a floor of one replica where the replica count is computed
  - [ ] approve
  - [ ] reject
- **B12** · high · [`3503c97`](https://github.com/ssl-hep/ServiceX/pull/1541/commits/3503c97e2bac5e6d8336b6b275fef973926537db) · `_create_job` logs the correct message and re-raises instead of logging "Exception during HPA Creation" and reporting success for a transform that has no pods
  - [ ] approve
  - [ ] reject
- **B31** · medium · [`f95ab04`](https://github.com/ssl-hep/ServiceX/pull/1541/commits/f95ab042dc13763e8c526ccbd5e2467bb08c80fd) · the proxy-exporter wait loop and the sidecar `--shared-dir` argument use the configured `TRANSFORMER_SIDECAR_VOLUME_PATH` instead of a hard-coded `/servicex/output`
  - [ ] approve
  - [ ] reject
- **S2** · simplification · [`61a34cf`](https://github.com/ssl-hep/ServiceX/pull/1541/commits/61a34cf5ae49250ea19c8bc63c74bbcc78300852) · removed `ServiceXResource.start_transformers`, an unused verbatim duplicate of `TransformerManager.start_transformers`, and the imports only it needed
  - [ ] approve
  - [ ] reject
- **S3** · simplification · [`40ca4d1`](https://github.com/ssl-hep/ServiceX/pull/1541/commits/40ca4d15dacb9555a7c85ffa1243ffe528a6e1de) · the three near identical `Retrying` blocks in `shutdown_transformer_job` become one `_delete_with_retries` helper that uses `reraise=True`, retries only on 5xx and connection failures, and treats 404 as success
  - [ ] approve
  - [ ] reject
- **M7** · modernization · [`e300ee7`](https://github.com/ssl-hep/ServiceX/pull/1541/commits/e300ee7de1aa6af7738aac0c9366eb24cd249413) · replaced the nonexistent `AppsV1beta1DeploymentList` / `AppsV1beta1Deployment` annotations with `client.V1DeploymentList` / `client.V1Deployment`, and `zipfile.open(file).read()` with `zipfile.read(file)`
  - [ ] approve
  - [ ] reject

**Skipped**

- `docs/deployment/reference.md` needed no change. It already documents `transformer.affinity`, `transformer.tolerations` and `transformer.cvmfsVolume` as standard Kubernetes fragments, which is what the code now accepts.

**Follow-ups noticed, out of scope**

- The sidecar hard-codes `--shared-dir` on its own side as well, so only the app side of B31 is fixed here.
- `resources/transformation/submit.py:316` still has a leftover debug `print(f"-----------> files: {request_rec.files}")`.
- `TestTransformerManager::test_init_invalid_config` and `TestTransformerManager::test_persistent_claim_exists` only pass because an earlier test leaks an application context into them, `web_test_base._test_client` pushes `app.test_request_context()` and never pops it. Run `servicex_app_test/test_transformer_manager.py` on its own and both fail with "Working outside of application context".

Part of #1539.
