### PR TITLE
ci: trim the test matrix and fix package metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,20 @@ updates:
 
   # Maintain dependencies for poetry
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/"
+      - "/code_generator_TopCPToolkit"
+      - "/code_generator_funcadl_uproot"
+      - "/code_generator_funcadl_xAOD"
+      - "/code_generator_python"
+      - "/code_generator_raw_uproot"
+      - "/did_finder_atlasopenmagic"
+      - "/did_finder_cernopendata"
+      - "/did_finder_rucio"
+      - "/did_finder_xrootd"
+      - "/servicex_app"
+      - "/transformer_sidecar"
+      - "/x509_secrets"
     schedule:
       interval: "weekly"
     groups:

--- a/.github/workflows/ci_servicex.yaml
+++ b/.github/workflows/ci_servicex.yaml
@@ -120,6 +120,7 @@ jobs:
           context: ${{ matrix.app.dir_name }}
           push: true
           tags: ${{ steps.extract_tag_name.outputs.imagetag }}
+          build-args: ${{ matrix.app.build_args }}
           cache-from: type=${{ format('registry,ref={0}',steps.extract_cache_name.outputs.cachetag) }}
           cache-to: type=${{ format('registry,ref={0}',steps.extract_cache_name.outputs.cachetag) }},mode=max
           file: ${{ matrix.app.dockerfile }}
@@ -130,6 +131,7 @@ jobs:
         with:
           context: ${{ matrix.app.dir_name }}
           tags: ${{ steps.extract_tag_name.outputs.imagetag }}
+          build-args: ${{ matrix.app.build_args }}
           cache-from: type=${{ format('registry,ref={0}',steps.extract_cache_name.outputs.cachetag) }}
           file: ${{ matrix.app.dockerfile }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/ci_servicex.yaml
+++ b/.github/workflows/ci_servicex.yaml
@@ -32,28 +32,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
         app: "${{fromJson(needs.build-matrix.outputs.matrix)}}"
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout to repository
         uses: actions/checkout@v7.0.1
 
-      - name: Set up Python versions
-        uses: actions/setup-python@v7.0.0
-        with:
-          python-version: |
-            3.14
-            3.10
-            3.11
-        if: ${{ matrix.app.test_required }}
-
       - name: Install poetry
         uses: abatilo/actions-poetry@v4.0.0
+        if: ${{ matrix.app.test_required }}
         with:
           poetry-version: 2.2.1
+
+      - name: Set up Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: ${{ matrix.app.python_version }}
+          cache: poetry
+          cache-dependency-path: ${{ matrix.app.dir_name }}/poetry.lock
+        if: ${{ matrix.app.test_required }}
 
       - name: Install dependencies
         working-directory: ${{ matrix.app.dir_name }}
@@ -61,7 +58,6 @@ jobs:
         run: |
           echo "${{ matrix.app }}"
           poetry install --no-root --with=test
-          pip list
       - name: Lint with Flake8
         working-directory: ${{ matrix.app.dir_name }}
         if: ${{ matrix.app.test_required }}

--- a/.github/workflows/deploy-config.json
+++ b/.github/workflows/deploy-config.json
@@ -2,68 +2,81 @@
   {
     "dir_name": "servicex_app",
     "image_name": "servicex_app",
+    "python_version": "3.10",
     "test_required": true
   },
   {
     "dir_name": "code_generator_python",
     "image_name": "servicex_code_gen_python",
+    "python_version": "3.10",
     "test_required": true
   },
   {
     "dir_name": "did_finder_cernopendata",
     "image_name": "servicex-did-finder-cernopendata",
+    "python_version": "3.10",
     "test_required": true
   },
   {
     "dir_name": "did_finder_atlasopenmagic",
     "image_name": "servicex-did-finder-atlasopenmagic",
+    "python_version": "3.14",
     "test_required": true
   },
   {
     "dir_name": "did_finder_rucio",
     "image_name": "servicex-did-finder",
+    "python_version": "3.11",
     "test_required": true
   },
   {
     "dir_name": "did_finder_xrootd",
     "image_name": "servicex-did-finder-xrootd",
+    "python_version": "3.10",
     "test_required": true
   },
   {
     "dir_name": "code_generator_funcadl_uproot",
     "image_name": "servicex_code_gen_func_adl_uproot",
+    "python_version": "3.10",
     "test_required": true
   },
   {
     "dir_name": "code_generator_raw_uproot",
     "image_name": "servicex_code_gen_raw_uproot",
+    "python_version": "3.10",
     "test_required": true
   },
   {
     "image_name": "servicex_sidecar_transformer",
     "dir_name": "transformer_sidecar",
+    "python_version": "3.10",
     "test_required": true
   },
   {
     "dir_name": "x509_secrets",
     "image_name": "x509-secrets",
+    "python_version": "3.11",
     "test_required": false
   },
   {
     "dir_name": "code_generator_funcadl_xAOD",
     "image_name": "servicex_code_gen_cms_aod",
+    "python_version": "3.10",
     "build_args": "APP_CONFIG_FILE=app.cms.aod.conf",
     "test_required": true
   },
   {
     "dir_name": "code_generator_funcadl_xAOD",
     "image_name": "servicex_code_gen_atlas_xaod",
+    "python_version": "3.10",
     "build_args": "APP_CONFIG_FILE=app.atlas.xaod.conf",
     "test_required": false
   },
   {
     "dir_name": "code_generator_TopCPToolkit",
     "image_name": "servicex_code_gen_topcp",
+    "python_version": "3.10",
     "test_required": true
   }
 ]

--- a/.github/workflows/deploy-config.json
+++ b/.github/workflows/deploy-config.json
@@ -52,12 +52,14 @@
   {
     "dir_name": "code_generator_funcadl_xAOD",
     "image_name": "servicex_code_gen_cms_aod",
+    "build_args": "APP_CONFIG_FILE=app.cms.aod.conf",
     "test_required": true
   },
   {
     "dir_name": "code_generator_funcadl_xAOD",
     "image_name": "servicex_code_gen_atlas_xaod",
-    "test_required": true
+    "build_args": "APP_CONFIG_FILE=app.atlas.xaod.conf",
+    "test_required": false
   },
   {
     "dir_name": "code_generator_TopCPToolkit",

--- a/code_generator_TopCPToolkit/Dockerfile
+++ b/code_generator_TopCPToolkit/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /home/servicex
 RUN mkdir ./servicex
 
 ENV  POETRY_VERSION=2.1.1
-RUN pip install poetry==$POETRY_VERSION
+RUN pip install --no-cache-dir poetry==$POETRY_VERSION
 
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock

--- a/code_generator_TopCPToolkit/pyproject.toml
+++ b/code_generator_TopCPToolkit/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.poetry]
-name = "code-generator-funcadl-uproot-raw"
+name = "code-generator-topcptoolkit"
 version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
-packages = [{include = "code_generator_funcadl_uproot_raw"}]
+packages = [{include = "servicex"}]
 
 [tool.poetry.dependencies]
 python = "~3.10"

--- a/code_generator_funcadl_uproot/Dockerfile
+++ b/code_generator_funcadl_uproot/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /home/servicex
 RUN mkdir ./uproot_code_generator
 
 ENV  POETRY_VERSION=2.1.1
-RUN pip install poetry==$POETRY_VERSION
+RUN pip install --no-cache-dir poetry==$POETRY_VERSION
 
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock

--- a/code_generator_funcadl_uproot/pyproject.toml
+++ b/code_generator_funcadl_uproot/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
-packages = [{include = "code_generator_funcadl_uproot"}]
+packages = [{include = "uproot_code_generator"}]
 
 [tool.poetry.dependencies]
 python = "~3.10"

--- a/code_generator_funcadl_xAOD/Dockerfile
+++ b/code_generator_funcadl_xAOD/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.10
 ARG APP_CONFIG_FILE="app.atlas.xaod.conf"
 
 ENV  POETRY_VERSION=2.1.1
-RUN pip install poetry==$POETRY_VERSION
+RUN pip install --no-cache-dir poetry==$POETRY_VERSION
 
 RUN useradd -ms /bin/bash -g 0 servicex && chmod 0750 /home/servicex
 

--- a/code_generator_funcadl_xAOD/pyproject.toml
+++ b/code_generator_funcadl_xAOD/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
-packages = [{ include = "code_generator_funcadl_xaod" }]
+packages = [{ include = "xaod_code_generator" }]
 
 [tool.poetry.dependencies]
 python = "~3.10"

--- a/code_generator_python/Dockerfile
+++ b/code_generator_python/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /home/servicex
 RUN mkdir ./python_code_generator
 
 ENV  POETRY_VERSION=2.1.1
-RUN pip install poetry==$POETRY_VERSION
+RUN pip install --no-cache-dir poetry==$POETRY_VERSION
 
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock

--- a/code_generator_python/pyproject.toml
+++ b/code_generator_python/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = ""
 authors = []
 readme = "README.md"
-packages = [{include = "code_generator_python"}]
+packages = [{include = "python_code_generator"}]
 
 [tool.poetry.dependencies]
 python = "~3.10"

--- a/code_generator_raw_uproot/Dockerfile
+++ b/code_generator_raw_uproot/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /home/servicex
 RUN mkdir ./servicex
 
 ENV  POETRY_VERSION=2.1.1
-RUN pip install poetry==$POETRY_VERSION
+RUN pip install --no-cache-dir poetry==$POETRY_VERSION
 
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock

--- a/code_generator_raw_uproot/pyproject.toml
+++ b/code_generator_raw_uproot/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
-packages = [{include = "code_generator_funcadl_uproot_raw"}]
+packages = [{include = "servicex"}]
 
 [tool.poetry.dependencies]
 python = "~3.10"

--- a/did_finder_atlasopenmagic/Dockerfile
+++ b/did_finder_atlasopenmagic/Dockerfile
@@ -12,17 +12,17 @@ RUN useradd -g 0 -ms /bin/bash celery
 
 ENV  POETRY_VERSION=2.3
 
-RUN pip install poetry==$POETRY_VERSION
+RUN pip install --no-cache-dir poetry==$POETRY_VERSION
 
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock
 
-# Bring over the main scripts
-COPY . .
-
 ENV XDG_CONFIG_HOME=/opt/servicex
 RUN poetry config virtualenvs.in-project true
 RUN poetry install --no-root --no-interaction --no-ansi
+
+# Bring over the main scripts
+COPY . .
 
 # Change ownership of the app directory to celery user. Also set the group to zero since
 # that is the group OpenShift will run the container as

--- a/did_finder_cernopendata/Dockerfile
+++ b/did_finder_cernopendata/Dockerfile
@@ -12,17 +12,17 @@ RUN useradd -g 0 -ms /bin/bash celery
 
 ENV  POETRY_VERSION=2.1.1
 
-RUN pip install poetry==$POETRY_VERSION
+RUN pip install --no-cache-dir poetry==$POETRY_VERSION
 
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock
 
-# Bring over the main scripts
-COPY . .
-
 ENV XDG_CONFIG_HOME=/opt/servicex
 RUN poetry config virtualenvs.in-project true
 RUN poetry install --no-root --no-interaction --no-ansi
+
+# Bring over the main scripts
+COPY . .
 
 # Change ownership of the app directory to celery user. Also set the group to zero since
 # that is the group OpenShift will run the container as

--- a/did_finder_rucio/Dockerfile
+++ b/did_finder_rucio/Dockerfile
@@ -21,7 +21,7 @@ RUN yum -y update
 ENV POETRY_VERSION=2.1.1
 RUN python3 -m pip install --upgrade pip
 
-RUN pip install poetry==$POETRY_VERSION
+RUN pip install --no-cache-dir poetry==$POETRY_VERSION
 RUN mkdir -p /opt/servicex/pypoetry
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,7 @@ description = "Happy Eyeballs for asyncio"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8"},
     {file = "aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558"},
@@ -19,6 +20,7 @@ description = "Async http client/server framework (asyncio)"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "aiohttp-3.14.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:eb0495d778817619273c108784292be161a924b9f5ae5cbbc70a2caa6838250b"},
     {file = "aiohttp-3.14.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c3c200cf9757edd785051dc699c7ecbec22110dbfcb3fefc7a9f9695eda8ea7a"},
@@ -144,7 +146,6 @@ files = [
 [package.dependencies]
 aiohappyeyeballs = ">=2.5.0"
 aiosignal = ">=1.4.0"
-async-timeout = {version = ">=4.0,<6.0", markers = "python_version < \"3.11\""}
 attrs = ">=17.3.0"
 frozenlist = ">=1.1.1"
 multidict = ">=4.5,<7.0"
@@ -162,6 +163,7 @@ description = "aiosignal: a list of registered asynchronous callbacks"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e"},
     {file = "aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7"},
@@ -178,6 +180,7 @@ description = "A database migration tool for SQLAlchemy."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "alembic-1.13.3-py3-none-any.whl", hash = "sha256:908e905976d15235fae59c9ac42c4c5b75cfcefe3d27c0fbf7ae15a37715d80e"},
     {file = "alembic-1.13.3.tar.gz", hash = "sha256:203503117415561e203aa14541740643a611f641517f0209fcae63e9fa09f1a2"},
@@ -213,6 +216,7 @@ description = "A library for parsing ISO 8601 strings."
 optional = false
 python-versions = "*"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "aniso8601-9.0.1-py2.py3-none-any.whl", hash = "sha256:1d2b7ef82963909e93c4f24ce48d4de9e66009a21bf1c1e1c85bdd0812fe412f"},
     {file = "aniso8601-9.0.1.tar.gz", hash = "sha256:72e3117667eedf66951bb2d93f4296a56b94b078a8a95905a052611fb3f1b973"},
@@ -228,6 +232,7 @@ description = "Argon2 for Python"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "argon2_cffi-23.1.0-py3-none-any.whl", hash = "sha256:c670642b78ba29641818ab2e68bd4e6a78ba53b7eff7b4c3815ae16abf91c7ea"},
     {file = "argon2_cffi-23.1.0.tar.gz", hash = "sha256:879c3e79a2729ce768ebb7d36d4609e3a78a4ca2ec3a9f12286ca057e3d0db08"},
@@ -249,6 +254,7 @@ description = "Low-level CFFI bindings for Argon2"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "argon2-cffi-bindings-21.2.0.tar.gz", hash = "sha256:bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3"},
     {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ccb949252cb2ab3a08c02024acb77cfb179492d5701c7cbdbfd776124d4d2367"},
@@ -281,24 +287,13 @@ dev = ["cogapp", "pre-commit", "pytest", "wheel"]
 tests = ["pytest"]
 
 [[package]]
-name = "async-timeout"
-version = "5.0.1"
-description = "Timeout context manager for asyncio programs"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
-    {file = "async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3"},
-]
-
-[[package]]
 name = "attrs"
 version = "24.2.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "attrs-24.2.0-py3-none-any.whl", hash = "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"},
     {file = "attrs-24.2.0.tar.gz", hash = "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346"},
@@ -319,6 +314,7 @@ description = "The ultimate Python library in building OAuth and OpenID Connect 
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "authlib-1.6.12-py2.py3-none-any.whl", hash = "sha256:e9229ad7fde610b139dd12f5edbe97eab9ee78bfb85691247e767727850b99ab"},
     {file = "authlib-1.6.12.tar.gz", hash = "sha256:0656d8482f28fc8221929d5f35b2bde5d13e10555ebc06b4561b0d622e83b1bd"},
@@ -334,6 +330,7 @@ description = "Backport of asyncio.Runner, a context manager that controls event
 optional = false
 python-versions = "<3.11,>=3.8"
 groups = ["test"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5"},
     {file = "backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162"},
@@ -362,6 +359,7 @@ files = [
     {file = "blinker-1.8.2-py3-none-any.whl", hash = "sha256:1779309f71bf239144b9399d06ae925637cf6634cf6bd131104184531bf67c01"},
     {file = "blinker-1.8.2.tar.gz", hash = "sha256:8f77b09d3bf7c795e969e9486f39c2c5e9c39d4ee07424be2bc594ece9642d83"},
 ]
+markers = {main = "python_version == \"3.10\""}
 
 [[package]]
 name = "bootstrap-flask"
@@ -370,6 +368,7 @@ description = "Bootstrap 4 & 5 helper for your Flask projects."
 optional = false
 python-versions = "*"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "Bootstrap_Flask-2.4.1-py3-none-any.whl", hash = "sha256:222df5b42c7795b121ed4709c534466c892e04ee31bfac7234de3ea64c106c27"},
     {file = "bootstrap_flask-2.4.1.tar.gz", hash = "sha256:cc25c59495f150550ea41d0e8079689de4250fe45445e158abdc111f8fe883e2"},
@@ -386,6 +385,7 @@ description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "boto3-1.43.63-py3-none-any.whl", hash = "sha256:859a8d1c50505a5cefb8629790dd34602ddb85bfd7ea5d34a362ab1793513636"},
     {file = "boto3-1.43.63.tar.gz", hash = "sha256:647c0f0b59710ce12a49323382bb5ece1b4e02199c736d19d555330dca7e947f"},
@@ -406,6 +406,7 @@ description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "botocore-1.43.63-py3-none-any.whl", hash = "sha256:8deed86feacc8f8d2491f1d170562af191f8b33924052d834f4217d5d797e5a9"},
     {file = "botocore-1.43.63.tar.gz", hash = "sha256:854e45247f00b0732496ea1f0c5d0cf3c31d58b48eb052c31c27ab1087dfddf1"},
@@ -426,6 +427,7 @@ description = "Extensible memoizing collections and decorators"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292"},
     {file = "cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a"},
@@ -495,6 +497,7 @@ description = "cernopendata-client."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "cernopendata_client-1.0.0.tar.gz", hash = "sha256:b336e42b7447270d15faa7a05f43fc6d3064664afa181a1777e246aa2997091d"},
 ]
@@ -529,6 +532,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -925,6 +929,7 @@ description = "cryptography is a package which provides cryptographic recipes an
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1"},
     {file = "cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225"},
@@ -1031,6 +1036,7 @@ description = "Decorators for Humans"
 optional = false
 python-versions = ">=3.5"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
     {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
@@ -1043,12 +1049,13 @@ description = ""
 optional = false
 python-versions = "~3.10"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = []
 develop = true
 
 [package.dependencies]
 cernopendata-client = "1.0.0"
-servicex-did-finder-lib = "^3.1.1"
+servicex-did-finder-lib = "^3.2.0-rc.1"
 
 [package.source]
 type = "directory"
@@ -1059,16 +1066,17 @@ name = "did-finder-rucio"
 version = "0.1.0"
 description = ""
 optional = false
-python-versions = "^3.9"
+python-versions = "^3.11"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = []
 develop = true
 
 [package.dependencies]
 geoip2 = "^4.7.0"
-requests = ">=2.25.0,<3.0.0"
+requests = ">=2.33.0,<3.0.0"
 rucio-clients = "^37.7.0"
-servicex-did-finder-lib = "^3.1.1"
+servicex-did-finder-lib = "^3.2.0-rc.1"
 xmltodict = "^0.13.0"
 
 [package.source]
@@ -1086,7 +1094,7 @@ files = []
 develop = true
 
 [package.dependencies]
-servicex-did-finder-lib = "^3.1.1"
+servicex-did-finder-lib = "^3.2.0-rc.1"
 xrootd = ">=5.8.3"
 
 [package.source]
@@ -1100,6 +1108,7 @@ description = "DNS toolkit"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86"},
     {file = "dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1"},
@@ -1144,6 +1153,7 @@ description = "A caching front-end based on the Dogpile lock."
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "dogpile.cache-1.2.2-py3-none-any.whl", hash = "sha256:f6c2c6ff3a3dc7dc0d662b3f30983f684502fd7a91a45be680879d7d8cc177d7"},
     {file = "dogpile.cache-1.2.2.tar.gz", hash = "sha256:fd9022c0d9cbadadf20942391a95adaf296be80b42daa8e202f8de1c21f198b2"},
@@ -1152,7 +1162,6 @@ files = [
 [package.dependencies]
 decorator = ">=4.0.0"
 stevedore = ">=3.0.0"
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "email-validator"
@@ -1161,6 +1170,7 @@ description = "A robust email address syntax and deliverability validation libra
 optional = false
 python-versions = ">=3.5"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "email_validator-1.3.1-py2.py3-none-any.whl", hash = "sha256:49a72f5fa6ed26be1c964f0567d931d10bf3fdeeacdf97bc26ef1cd2a44e0bda"},
     {file = "email_validator-1.3.1.tar.gz", hash = "sha256:d178c5c6fa6c6824e9b04f199cf23e79ac15756786573c190d2ad13089411ad2"},
@@ -1177,6 +1187,7 @@ description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 groups = ["test"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
     {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
@@ -1213,6 +1224,7 @@ files = [
     {file = "flask-2.3.3-py3-none-any.whl", hash = "sha256:f69fcd559dc907ed196ab9df0e48471709175e696d6e698dd4dbe940f96ce66b"},
     {file = "flask-2.3.3.tar.gz", hash = "sha256:09c347a92aa7ff4a8e7f3206795f30d826654baf38b873d0744cd571ca609efc"},
 ]
+markers = {main = "python_version == \"3.10\""}
 
 [package.dependencies]
 blinker = ">=1.6.2"
@@ -1232,6 +1244,7 @@ description = "Simple and extensible admin interface framework for Flask"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "flask_admin-2.2.0-py3-none-any.whl", hash = "sha256:a8cb0f484eefb60b1ed345105ebb7199664ff910c52f02081b7881c390f643d3"},
     {file = "flask_admin-2.2.0.tar.gz", hash = "sha256:4a5b844789c10076da89320563600a7addf781e73ab315ae800521b3ec018509"},
@@ -1268,6 +1281,7 @@ description = "A Flask extension simplifying CORS support"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "flask_cors-6.0.0-py3-none-any.whl", hash = "sha256:6332073356452343a8ccddbfec7befdc3fdd040141fe776ec9b94c262f058657"},
     {file = "flask_cors-6.0.0.tar.gz", hash = "sha256:4592c1570246bf7beee96b74bc0adbbfcb1b0318f6ba05c412e8909eceec3393"},
@@ -1284,6 +1298,7 @@ description = "Extended JWT integration with Flask"
 optional = false
 python-versions = ">=3.7,<4"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "Flask-JWT-Extended-4.6.0.tar.gz", hash = "sha256:9215d05a9413d3855764bcd67035e75819d23af2fafb6b55197eb5a3313fdfb2"},
     {file = "Flask_JWT_Extended-4.6.0-py2.py3-none-any.whl", hash = "sha256:63a28fc9731bcc6c4b8815b6f954b5904caa534fc2ae9b93b1d3ef12930dca95"},
@@ -1304,6 +1319,7 @@ description = "SQLAlchemy database migrations for Flask applications using Alemb
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "Flask-Migrate-3.1.0.tar.gz", hash = "sha256:57d6060839e3a7f150eaab6fe4e726d9e3e7cffe2150fb223d73f92421c6d1d9"},
     {file = "Flask_Migrate-3.1.0-py3-none-any.whl", hash = "sha256:a6498706241aba6be7a251078de9cf166d74307bca41a4ca3e403c9d39e2f897"},
@@ -1321,6 +1337,7 @@ description = "Formatting of dates and times in Flask templates using moment.js.
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "Flask_Moment-1.0.6-py3-none-any.whl", hash = "sha256:3ae8baea20a41e99f457b9710ecd1368911dd5133f09a27583eb0dcb3491e31d"},
     {file = "flask_moment-1.0.6.tar.gz", hash = "sha256:2f8969907cbacde4a88319792e8f920ba5c9dd9d99ced2346cad563795302b88"},
@@ -1340,6 +1357,7 @@ description = "Simple framework for creating REST APIs"
 optional = false
 python-versions = "*"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "Flask-RESTful-0.3.10.tar.gz", hash = "sha256:fe4af2ef0027df8f9b4f797aba20c5566801b6ade995ac63b588abf1a59cec37"},
     {file = "Flask_RESTful-0.3.10-py2.py3-none-any.whl", hash = "sha256:1cf93c535172f112e080b0d4503a8d15f93a48c88bdd36dd87269bdaf405051b"},
@@ -1361,6 +1379,7 @@ description = "Add SQLAlchemy support to your Flask application."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "flask_sqlalchemy-3.1.1-py3-none-any.whl", hash = "sha256:4ba4be7f419dc72f4efd8802d69974803c37259dd42f3913b0dcf75c9447e0a0"},
     {file = "flask_sqlalchemy-3.1.1.tar.gz", hash = "sha256:e4b68bb881802dda1a7d878b2fc84c06d1ee57fb40b874d3dc97dabfa36b8312"},
@@ -1377,6 +1396,7 @@ description = "Form rendering, validation, and CSRF protection for Flask with WT
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "flask_wtf-1.2.1-py3-none-any.whl", hash = "sha256:fa6793f2fb7e812e0fe9743b282118e581fb1b6c45d414b8af05e659bd653287"},
     {file = "flask_wtf-1.2.1.tar.gz", hash = "sha256:8bb269eb9bb46b87e7c8233d7e7debdf1f8b74bf90cc1789988c29b37a97b695"},
@@ -1397,6 +1417,7 @@ description = "A list-like structure which implements collections.abc.MutableSeq
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "frozenlist-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5b6a66c18b5b9dd261ca98dffcb826a525334b2f29e7caa54e182255c5f6a65a"},
     {file = "frozenlist-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d1b3eb7b05ea246510b43a7e53ed1653e55c2121019a97e60cad7efb881a97bb"},
@@ -1499,6 +1520,7 @@ description = "MaxMind GeoIP2 API"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "geoip2-4.8.0-py2.py3-none-any.whl", hash = "sha256:39b38ec703575355d10475c0e6aa981827a2b4b5471d308c4ecb5e79cbe366ce"},
     {file = "geoip2-4.8.0.tar.gz", hash = "sha256:dd9cc180b7d41724240ea481d5d539149e65b234f64282b231b9170794a9ac35"},
@@ -1520,6 +1542,7 @@ description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "google_auth-2.35.0-py2.py3-none-any.whl", hash = "sha256:25df55f327ef021de8be50bad0dfd4a916ad0de96da86cd05661c9297723ad3f"},
     {file = "google_auth-2.35.0.tar.gz", hash = "sha256:f4c64ed4e01e8e8b646ef34c018f8bf3338df0c8e37d8b3bba40e7f574a3278a"},
@@ -1544,7 +1567,7 @@ description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""
+markers = "python_version == \"3.10\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
 files = [
     {file = "greenlet-3.1.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:0bbae94a29c9e5c7e4a2b7f0aae5c17e8e90acbfd3bf6270eeba60c39fce3563"},
     {file = "greenlet-3.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fde093fb93f35ca72a556cf72c92ea3ebfda3d79fc35bb19fbe685853869a83"},
@@ -1632,6 +1655,7 @@ description = "WSGI HTTP Server for UNIX"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d"},
     {file = "gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec"},
@@ -1654,6 +1678,7 @@ description = "Python humanize utilities"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "humanize-4.11.0-py3-none-any.whl", hash = "sha256:b53caaec8532bcb2fff70c8826f904c35943f8cecaca29d272d9df38092736c0"},
     {file = "humanize-4.11.0.tar.gz", hash = "sha256:e66f36020a2d5a974c504bd2555cf770621dbdbb6d82f94a6857c0b1ea2608be"},
@@ -1700,6 +1725,7 @@ files = [
     {file = "itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef"},
     {file = "itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"},
 ]
+markers = {main = "python_version == \"3.10\""}
 
 [[package]]
 name = "jinja2"
@@ -1712,6 +1738,7 @@ files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
 ]
+markers = {main = "python_version == \"3.10\""}
 
 [package.dependencies]
 MarkupSafe = ">=2.0"
@@ -1726,6 +1753,7 @@ description = "JSON Matching Expressions"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"},
     {file = "jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d"},
@@ -1738,6 +1766,7 @@ description = "An implementation of JSON Schema validation for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "jsonschema-4.20.0-py3-none-any.whl", hash = "sha256:ed6231f0429ecf966f5bc8dfef245998220549cbbcf140f913b7464c52c3b6b3"},
     {file = "jsonschema-4.20.0.tar.gz", hash = "sha256:4f614fd46d8d61258610998997743ec5492a648b33cf478c1ddc23ed4598a5fa"},
@@ -1760,6 +1789,7 @@ description = "The JSON Schema meta-schemas and vocabularies, exposed as a Regis
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "jsonschema_specifications-2024.10.1-py3-none-any.whl", hash = "sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf"},
     {file = "jsonschema_specifications-2024.10.1.tar.gz", hash = "sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272"},
@@ -1809,6 +1839,7 @@ description = "Kubernetes python client"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "kubernetes-25.3.0-py2.py3-none-any.whl", hash = "sha256:eb42333dad0bb5caf4e66460c6a4a1a36f0f057a040f35018f6c05a699baed86"},
     {file = "kubernetes-25.3.0.tar.gz", hash = "sha256:213befbb4e5aed95f94950c7eed0c2322fc5a2f8f40932e58d28fdd42d90836c"},
@@ -1851,6 +1882,7 @@ description = "A super-fast templating language that borrows the best ideas from
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9"},
     {file = "mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a"},
@@ -1871,6 +1903,7 @@ description = "Python port of markdown-it. Markdown parsing, done right!"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
     {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
@@ -1958,6 +1991,7 @@ files = [
     {file = "MarkupSafe-2.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5"},
     {file = "MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"},
 ]
+markers = {main = "python_version == \"3.10\""}
 
 [[package]]
 name = "maxminddb"
@@ -1966,6 +2000,7 @@ description = "Reader for the MaxMind DB format"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "maxminddb-2.6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7cfdf5c29a2739610700b9fea7f8d68ce81dcf30bb8016f1a1853ef889a2624b"},
     {file = "maxminddb-2.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:05e873eb82281cef6e787bd40bd1d58b2e496a21b3689346f0d0420988b3cbb1"},
@@ -2057,6 +2092,7 @@ description = "Markdown URL utilities"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
@@ -2069,6 +2105,7 @@ description = "MinIO Python SDK for Amazon S3 Compatible Cloud Storage"
 optional = false
 python-versions = ">3.8"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "minio-7.2.10-py3-none-any.whl", hash = "sha256:5961c58192b1d70d3a2a362064b8e027b8232688998a6d1251dadbb02ab57a7d"},
     {file = "minio-7.2.10.tar.gz", hash = "sha256:418c31ac79346a580df04a0e14db1becbc548a6e7cca61f9bc4ef3bcd336c449"},
@@ -2088,6 +2125,7 @@ description = "multidict implementation"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "multidict-6.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3380252550e372e8511d49481bd836264c009adb826b23fefcc5dd3c69692f60"},
     {file = "multidict-6.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:99f826cbf970077383d7de805c0681799491cb939c25450b9b5b3ced03ca99f1"},
@@ -2183,9 +2221,6 @@ files = [
     {file = "multidict-6.1.0.tar.gz", hash = "sha256:22ae2ebf9b0c69d206c003e2f6a914ea33f0a932d4aa16f236afc049d9958f4a"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.11\""}
-
 [[package]]
 name = "oauthlib"
 version = "3.2.2"
@@ -2193,6 +2228,7 @@ description = "A generic, spec-compliant, thorough implementation of the OAuth r
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca"},
     {file = "oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"},
@@ -2222,6 +2258,7 @@ description = "comprehensive password hashing framework supporting over 30 schem
 optional = false
 python-versions = "*"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1"},
     {file = "passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04"},
@@ -2240,6 +2277,7 @@ description = "Python Build Reasonableness"
 optional = false
 python-versions = ">=2.6"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "pbr-6.1.0-py2.py3-none-any.whl", hash = "sha256:a776ae228892d8013649c0aeccbb3d5f99ee15e005a4cbb7e61d55a067b28a2a"},
     {file = "pbr-6.1.0.tar.gz", hash = "sha256:788183e382e3d1d7707db08978239965e8b9e4e5ed42669bf4758186734d5f24"},
@@ -2252,6 +2290,7 @@ description = "Pika Python AMQP Client Library"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "pika-1.3.2-py3-none-any.whl", hash = "sha256:0779a7c1fafd805672796085560d290213a465e4f6f76a6fb19e378d8041a14f"},
     {file = "pika-1.3.2.tar.gz", hash = "sha256:b2a327ddddf8570b4965b3576ac77091b850262d34ce8c1d8cb4e4146aa4145f"},
@@ -2300,6 +2339,7 @@ description = "Accelerated property cache"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "propcache-0.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c5869b8fd70b81835a6f187c5fdbe67917a04d7e52b6e7cc4e5fe39d55c39d58"},
     {file = "propcache-0.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:952e0d9d07609d9c5be361f33b0d6d650cd2bae393aabb11d9b719364521984b"},
@@ -2443,6 +2483,7 @@ description = "psycopg2 - Python-PostgreSQL Database Adapter"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "psycopg2-2.9.12-cp310-cp310-win_amd64.whl", hash = "sha256:d5fbe092315fb007c03544704e6d1e678a6c0378139d01cea433dc59edf041b4"},
     {file = "psycopg2-2.9.12-cp311-cp311-win_amd64.whl", hash = "sha256:2532c0cdc6ad18c9c35cd935cc3159712e14f05276a6d29a6435c52d24b840c1"},
@@ -2460,6 +2501,7 @@ description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs 
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
     {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
@@ -2472,6 +2514,7 @@ description = "A collection of ASN.1-based protocols modules"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "pyasn1_modules-0.4.1-py3-none-any.whl", hash = "sha256:49bfa96b45a292b711e986f222502c1c9a5e1f4e568fc30e2574a6c7d07838fd"},
     {file = "pyasn1_modules-0.4.1.tar.gz", hash = "sha256:c28e2dbf9c06ad61c71a075c7e0f9fd0f1b0bb2d2ad4377f240d33ac2ab60a7c"},
@@ -2499,7 +2542,7 @@ description = "C parser in Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "implementation_name != \"PyPy\""
+markers = "python_version == \"3.10\" and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
@@ -2512,6 +2555,7 @@ description = "Cryptographic library for Python"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "pycryptodome-3.21.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:dad9bf36eda068e89059d1f07408e397856be9511d7113ea4b586642a429a4fd"},
     {file = "pycryptodome-3.21.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:a1752eca64c60852f38bb29e2c86fca30d7672c024128ef5d70cc15868fa10f4"},
@@ -2570,6 +2614,7 @@ files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
+markers = {main = "python_version >= \"3.11\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
@@ -2581,6 +2626,7 @@ description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728"},
     {file = "pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423"},
@@ -2751,6 +2797,7 @@ description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
     {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
@@ -2849,6 +2896,7 @@ files = [
     {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
     {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
 ]
+markers = {main = "python_version == \"3.10\""}
 
 [[package]]
 name = "referencing"
@@ -2857,6 +2905,7 @@ description = "JSON Referencing + Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "referencing-0.35.1-py3-none-any.whl", hash = "sha256:eda6d3234d62814d1c64e305c1331c9a3a6132da475ab6382eaa997b21ee75de"},
     {file = "referencing-0.35.1.tar.gz", hash = "sha256:25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c"},
@@ -2896,6 +2945,7 @@ description = "OAuthlib authentication support for Requests."
 optional = false
 python-versions = ">=3.4"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
     {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
@@ -2915,6 +2965,7 @@ description = "A utility belt for advanced users of python-requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"},
     {file = "requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"},
@@ -2950,6 +3001,7 @@ description = "Render rich text, tables, progress bars, syntax highlighting, mar
 optional = false
 python-versions = ">=3.8.0"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0"},
     {file = "rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725"},
@@ -2958,7 +3010,6 @@ files = [
 [package.dependencies]
 markdown-it-py = ">=2.2.0"
 pygments = ">=2.13.0,<3.0.0"
-typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
@@ -2970,6 +3021,7 @@ description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "rpds_py-0.20.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3ad0fda1635f8439cde85c700f964b23ed5fc2d28016b32b9ee5fe30da5c84e2"},
     {file = "rpds_py-0.20.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9bb4a0d90fdb03437c109a17eade42dfbf6190408f29b2744114d11586611d6f"},
@@ -3083,6 +3135,7 @@ description = "Pure-Python RSA implementation"
 optional = false
 python-versions = ">=3.6,<4"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
     {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
@@ -3098,6 +3151,7 @@ description = "Rucio Client Lite Package"
 optional = false
 python-versions = "<4,>=3.9"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "rucio_clients-37.7.0-py3-none-any.whl", hash = "sha256:090bd9870b9c485dadbed2c1fcbfa9b4660cfd0f0bd15da85eabe601c4fb6af5"},
     {file = "rucio_clients-37.7.0.tar.gz", hash = "sha256:b74471722d43458b3df8efde99f85acb995d2ce88bfd5d0d18e6617604d87f88"},
@@ -3129,6 +3183,7 @@ description = "An Amazon S3 Transfer Manager"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25"},
     {file = "s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993"},
@@ -3147,6 +3202,7 @@ description = "REST Frontend to ServiceX"
 optional = false
 python-versions = "~3.10"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = []
 develop = true
 
@@ -3156,7 +3212,7 @@ blinker = "^1.5"
 bootstrap-flask = "^2.1.0"
 boto3 = ">=1.42.94"
 Celery = "^5.2.0"
-cryptography = ">=46.0.7,<49.0.0"
+cryptography = ">=46.0.7,<51.0.0"
 email-validator = "^1.3.0"
 flask = "^2.3.3"
 flask-admin = "^2.0.2"
@@ -3190,19 +3246,20 @@ url = "servicex_app"
 
 [[package]]
 name = "servicex-did-finder-lib"
-version = "3.1.1"
+version = "3.2.0rc1"
 description = "ServiceX DID Library Routines"
 optional = false
-python-versions = "<4.0.0,>=3.8.1"
+python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "servicex_did_finder_lib-3.1.1-py3-none-any.whl", hash = "sha256:bf0788e6b3a27304675f8158c6ea0515fbb4a443afa37c0f7c5c61dfff15c7ea"},
-    {file = "servicex_did_finder_lib-3.1.1.tar.gz", hash = "sha256:2711decea834858503d99b7e623d3e3e045e7d8538b545b076983f3b1496bd18"},
+    {file = "servicex_did_finder_lib-3.2.0rc1-py3-none-any.whl", hash = "sha256:a4574dd26d1712a5cebb75a32eed3e6f4a5bae2f1ef2571a42a0061b1d8ac87a"},
+    {file = "servicex_did_finder_lib-3.2.0rc1.tar.gz", hash = "sha256:ee43cacedd784ed54002c246cbb5eceefd654a349bec8a4ac8976c5c866375dc"},
 ]
 
 [package.dependencies]
 Celery = ">=5.4,<6.0"
 make-it-sync = ">=1.0.0,<2.0.0"
+python-logstash = ">=0.4.8,<0.5.0"
 requests = ">=2.25.0,<3.0.0"
 
 [[package]]
@@ -3245,6 +3302,7 @@ description = "Database Abstraction Library"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "SQLAlchemy-2.0.35-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:67219632be22f14750f0d1c70e62f204ba69d28f62fd6432ba05ab295853de9b"},
     {file = "SQLAlchemy-2.0.35-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4668bd8faf7e5b71c0319407b608f278f279668f358857dbfd10ef1954ac9f90"},
@@ -3333,6 +3391,7 @@ description = "Manage dynamic plugins for Python applications"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "stevedore-5.3.0-py3-none-any.whl", hash = "sha256:1efd34ca08f474dad08d9b19e934a22c68bb6fe416926479ba29e5013bcc8f78"},
     {file = "stevedore-5.3.0.tar.gz", hash = "sha256:9a64265f4060312828151c204efbe9b7a9852a0d9228756344dbc7e4023e375a"},
@@ -3348,6 +3407,7 @@ description = "Pretty-print tabular data"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"},
     {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
@@ -3367,6 +3427,7 @@ files = [
     {file = "tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539"},
     {file = "tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b"},
 ]
+markers = {main = "python_version == \"3.10\""}
 
 [package.extras]
 doc = ["reno", "sphinx"]
@@ -3379,6 +3440,7 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["test"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38"},
     {file = "tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed"},
@@ -3395,6 +3457,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
+markers = {test = "python_version < \"3.13\""}
 
 [[package]]
 name = "tzdata"
@@ -3457,6 +3520,7 @@ description = "WebSocket client for Python with low level API options"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526"},
     {file = "websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da"},
@@ -3478,6 +3542,7 @@ files = [
     {file = "werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131"},
     {file = "werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25"},
 ]
+markers = {main = "python_version == \"3.10\""}
 
 [package.dependencies]
 markupsafe = ">=2.1.1"
@@ -3492,6 +3557,7 @@ description = "Form validation and rendering for Python web development."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "wtforms-3.1.2-py3-none-any.whl", hash = "sha256:bf831c042829c8cdbad74c27575098d541d039b1faa74c771545ecac916f2c07"},
     {file = "wtforms-3.1.2.tar.gz", hash = "sha256:f8d76180d7239c94c6322f7990ae1216dae3659b7aa1cee94b6318bdffb474b9"},
@@ -3510,6 +3576,7 @@ description = "Makes working with XML feel like you are working with JSON"
 optional = false
 python-versions = ">=3.4"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
     {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},
@@ -3539,6 +3606,7 @@ description = "Yet another URL library"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version >= \"3.11\""
 files = [
     {file = "yarl-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:93771146ef048b34201bfa382c2bf74c524980870bb278e6df515efaf93699ff"},
     {file = "yarl-1.17.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8281db240a1616af2f9c5f71d355057e73a1409c4648c8949901396dc0a3c151"},
@@ -3631,5 +3699,5 @@ propcache = ">=0.2.0"
 
 [metadata]
 lock-version = "2.1"
-python-versions = "~3.10"
-content-hash = "ea9c41c40d523f878bb40fdba1dc5938b14968770cda6a74f097f08edcb1a428"
+python-versions = ">=3.10,<3.15"
+content-hash = "6c3ec8381695cac02dd7546c998ef70ea41cddd0cd23834c13f74c45fc1c0d64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,11 @@ authors = ["Ben Galewsky <ben@peartreestudio.net>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "~3.10"
-servicex-app = {path = "servicex_app", develop = true}
-did-finder-cernopendata = {path = "did_finder_cernopendata", develop = true}
+python = ">=3.10,<3.15"
+servicex-app = {path = "servicex_app", develop = true, python = "~3.10"}
+did-finder-cernopendata = {path = "did_finder_cernopendata", develop = true, python = "~3.10"}
 did-finder-xrootd = {path = "did_finder_xrootd", develop = true}
-did-finder-rucio = {path = "did_finder_rucio", develop = true}
+did-finder-rucio = {path = "did_finder_rucio", develop = true, python = "^3.11"}
 
 [tool.poetry.group.test.dependencies]
 pytest = "^9.1.1"

--- a/servicex_app/Dockerfile
+++ b/servicex_app/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /home/servicex
 RUN mkdir ./servicex
 
 ENV  POETRY_VERSION=2.1.1
-RUN pip install poetry==$POETRY_VERSION
+RUN pip install --no-cache-dir poetry==$POETRY_VERSION
 
 COPY README.rst README.rst
 COPY pyproject.toml pyproject.toml

--- a/transformer_sidecar/Dockerfile
+++ b/transformer_sidecar/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /servicex
 RUN python3 -m pip install --upgrade pip
 
 ENV  POETRY_VERSION=2.1.1
-RUN pip install poetry==$POETRY_VERSION
+RUN pip install --no-cache-dir poetry==$POETRY_VERSION
 
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock

--- a/transformer_sidecar/pyproject.toml
+++ b/transformer_sidecar/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
-packages = [{include = "transformer_sidecar"}]
+packages = [{include = "transformer_sidecar", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "~3.10"

--- a/x509_secrets/Dockerfile
+++ b/x509_secrets/Dockerfile
@@ -28,4 +28,4 @@ RUN echo "Timestamp:" `date --utc` | tee /image-build-info.txt
 
 ENV X509_USER_PROXY=/tmp/x509up
 
-CMD ["sh", "-c", "python3", "x509_updater.py", "--voms", "$VOMS"]
+CMD ["sh", "-c", "python3 x509_updater.py --voms \"$VOMS\""]

--- a/x509_secrets/Dockerfile
+++ b/x509_secrets/Dockerfile
@@ -14,7 +14,7 @@ RUN yum -y update
 ENV POETRY_VERSION=2.1.1
 RUN python3 -m pip install --upgrade pip
 
-RUN pip install poetry==$POETRY_VERSION
+RUN pip install --no-cache-dir poetry==$POETRY_VERSION
 COPY pyproject.toml pyproject.toml
 COPY poetry.lock poetry.lock
 

--- a/x509_secrets/pyproject.toml
+++ b/x509_secrets/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
-packages = [{include = "x509_secrets"}]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Cleans up the test and publish matrix in `ci_servicex.yaml`, makes the two `code_generator_funcadl_xAOD` images actually differ, and fixes a batch of poetry and Docker packaging metadata problems across the monorepo.

**How to review.** Each finding is one commit; the Commits tab shows them in severity order. Each entry below links to its commit; tick approve or reject under it. To ask for a change instead, leave a review comment on the commit. Rejected commits will be dropped from the branch and this list will be updated to match.

- **B40** · medium · [`ff7e676`](https://github.com/ssl-hep/ServiceX/pull/1543/commits/ff7e676266ae17f79b8797ba8c1ed483893a59a2) · Give each `code_generator_funcadl_xAOD` entry its own `build_args` so the CMS image stops shipping the ATLAS config, and stop the duplicate entry from repeating the same test suite.
  - [ ] approve
  - [ ] reject
- **B41** · medium · [`905e2c7`](https://github.com/ssl-hep/ServiceX/pull/1543/commits/905e2c7d80e6a433dac34fe4e4d88eaa6b36923f) · Widen the root python range to `>=3.10,<3.15` and put a `python` marker on each path dependency, since no single range satisfies all four, then regenerate `poetry.lock`.
  - [ ] approve
  - [ ] reject
- **B62** · medium · [`d628d8f`](https://github.com/ssl-hep/ServiceX/pull/1543/commits/d628d8fe8552a19eb3ffd07a84af05fb1a0f2e56) · Pass the whole x509 updater command as a single `sh -c` string so it actually runs, with `$VOMS` quoted.
  - [ ] approve
  - [ ] reject
- **P8** · perf · [`41ee179`](https://github.com/ssl-hep/ServiceX/pull/1543/commits/41ee179325f09cdb0a5deb8982a8376acc783678) · Drop the unused `platform` axis that ran every package's tests twice, install only the interpreter each app declares in `python_version`, cache poetry against the app's own lock file, and remove the misleading `pip list` step.
  - [ ] approve
  - [ ] reject
- **P9** · perf · [`6119a3e`](https://github.com/ssl-hep/ServiceX/pull/1543/commits/6119a3ef2927e59e9be6f579973561459a5862f9) · Add `--no-cache-dir` to every `pip install poetry`, and move `COPY . .` after `poetry install` in the atlasopenmagic and cernopendata finders so a source edit no longer busts the dependency layer.
  - [ ] approve
  - [ ] reject
- **S12** · simplification · [`a0b9151`](https://github.com/ssl-hep/ServiceX/pull/1543/commits/a0b9151625b353d33678a81c95356d244c74871f) · Point each `packages` include at the directory that actually exists, set `package-mode = false` for the single-script `x509_secrets`, and fix the copied project `name` in `code_generator_TopCPToolkit`.
  - [ ] approve
  - [ ] reject
- **M9** · modernization · [`603436e`](https://github.com/ssl-hep/ServiceX/pull/1543/commits/603436eff562912662e0216027f0d6602df5cab4) · List every directory with a `pyproject.toml` under the pip ecosystem in `dependabot.yml`, keeping the existing schedule, grouping and labels.
  - [ ] approve
  - [ ] reject

**Follow-ups noticed, out of scope**

- The root environment is still split after B41. Because `servicex_app` and `did_finder_cernopendata` require `~3.10` while `did_finder_rucio` requires `^3.11`, the markers make `poetry lock` succeed but no single interpreter installs all four path dependencies at once: a developer on 3.10 gets no rucio finder, one on 3.11 gets no app. Unifying the sub-package constraints would be the real fix.
- Both `docker/build-push-action` steps in `ci_servicex.yaml` pass `file: ${{ matrix.app.dockerfile }}`, but no entry in `deploy-config.json` sets `dockerfile`, so the input always expands to an empty string and the action falls back to its default. Either populate the field or drop the input.
- M9 in the issue also lists stale dependency pins (`flask ^2.3.3`, `email-validator ^1.3`, `fsspec ^2023.6.0`, `freezegun ^0.3.15`, `pre-commit ^2.20`, and the `flake8 ^5` / `coverage ^6` test groups that disagree with pre-commit). Only the dependabot coverage part is addressed here.
- P9 in the issue also notes that only 2 of 12 package directories have a `.dockerignore`. Not addressed here.

Part of #1539.
