### PR TITLE
fix(app): enforce request ownership and pending-user checks

### DIFF
--- a/servicex_app/servicex_app/decorators.py
+++ b/servicex_app/servicex_app/decorators.py
@@ -82,11 +82,27 @@ def auth_required(fn: Callable[..., Response]) -> Callable[..., Response]:
     Pending or deleted users will receive a 401: Unauthorized response.
     """
 
+    no_user_msg = (
+        "Not Authorized: No user found matching this API token. "
+        "Your account may have been deleted. "
+        "Please visit the ServiceX website to obtain a new API token."
+    )
+    pending_msg = (
+        "Not Authorized: Your account is still pending. "
+        "An administrator should approve it shortly. If not, "
+        "please contact the ServiceX admins via email or Slack."
+    )
+
     @wraps(fn)
     def inner(*args, **kwargs) -> Response:
         if not current_app.config.get("ENABLE_AUTH"):
             return fn(*args, **kwargs)
         elif session.get("is_authenticated"):
+            user = UserModel.find_by_id(session.get("user_id"))
+            if not user:
+                return make_response({"message": no_user_msg}, 401)
+            elif user.pending:
+                return make_response({"message": pending_msg}, 401)
             return fn(*args, **kwargs)
         try:
             verify_jwt_in_request(locations=["headers"])
@@ -100,19 +116,9 @@ def auth_required(fn: Callable[..., Response]) -> Callable[..., Response]:
             user = get_jwt_user()
 
             if not user:
-                msg = (
-                    "Not Authorized: No user found matching this API token. "
-                    "Your account may have been deleted. "
-                    "Please visit the ServiceX website to obtain a new API token."
-                )
-                return make_response({"message": msg}, 401)
+                return make_response({"message": no_user_msg}, 401)
             elif user.pending:
-                msg = (
-                    "Not Authorized: Your account is still pending. "
-                    "An administrator should approve it shortly. If not, "
-                    "please contact the ServiceX admins via email or Slack."
-                )
-                return make_response({"message": msg}, 401)
+                return make_response({"message": pending_msg}, 401)
 
         return fn(*args, **kwargs)
 

--- a/servicex_app/servicex_app/resources/servicex_resource.py
+++ b/servicex_app/servicex_app/resources/servicex_resource.py
@@ -25,10 +25,10 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from typing import Optional
+from typing import Any, Optional, Tuple
 
 from importlib.metadata import version, PackageNotFoundError
-from flask import current_app
+from flask import current_app, session
 from flask_jwt_extended import get_jwt_identity
 from flask_restful import Resource
 from servicex_app.models import UserModel, TransformRequest, TransformStatus
@@ -50,7 +50,7 @@ class ServiceXResource(Resource):
         return "http://" + current_app.config["ADVERTISED_HOSTNAME"] + "/" + endpoint
 
     @staticmethod
-    @jwt_required_if_auth_enabled
+    @jwt_required_if_auth_enabled(optional=True)
     def get_requesting_user() -> Optional[UserModel]:
         """
         :return: User who submitted request for resource.
@@ -59,8 +59,34 @@ class ServiceXResource(Resource):
         """
         user = None
         if current_app.config.get("ENABLE_AUTH"):
-            user = UserModel.find_by_email(get_jwt_identity())
+            if session.get("is_authenticated"):
+                user = UserModel.find_by_id(session.get("user_id"))
+            else:
+                user = UserModel.find_by_email(get_jwt_identity())
         return user
+
+    def _get_owned_request(self, request_id) -> Tuple[Optional[TransformRequest], Any]:
+        """
+        Look up a transform request and confirm that the requesting user is
+        allowed to act on it.
+        :return: A (transform request, error response) pair. The error response
+        is None if the lookup succeeded and the user is an admin or the
+        submitter, and is a 404 or 403 response otherwise.
+        """
+        transform_req = TransformRequest.lookup(request_id)
+        if not transform_req:
+            msg = f"Transformation request not found with id: {request_id}"
+            current_app.logger.warning(msg, extra={"request_id": request_id})
+            return None, ({"message": msg}, 404)
+
+        if current_app.config.get("ENABLE_AUTH"):
+            user = self.get_requesting_user()
+            if not user or (not user.admin and user.id != transform_req.submitted_by):
+                msg = "You are not authorized to access this request"
+                current_app.logger.warning(msg, extra={"request_id": request_id})
+                return None, ({"message": msg}, 403)
+
+        return transform_req, None
 
     @classmethod
     def _get_app_version(cls):

--- a/servicex_app/servicex_app/resources/transformation/cancel.py
+++ b/servicex_app/servicex_app/resources/transformation/cancel.py
@@ -31,7 +31,7 @@ import kubernetes
 from flask import current_app
 
 from servicex_app.decorators import auth_required
-from servicex_app.models import TransformRequest, db, TransformStatus
+from servicex_app.models import db, TransformStatus
 from servicex_app.resources.servicex_resource import ServiceXResource
 from servicex_app.transformer_manager import TransformerManager
 
@@ -56,12 +56,10 @@ class CancelTransform(ServiceXResource):
         return self._cancel_transform(request_id)
 
     def _cancel_transform(self, request_id: str):
-        transform_req = TransformRequest.lookup(request_id)
-        if not transform_req:
-            msg = f"Transformation request not found with id: {request_id}"
-            current_app.logger.warning(msg, extra={"request_id": request_id})
-            return {"message": msg}, 404
-        elif transform_req.status.is_complete:
+        transform_req, error = self._get_owned_request(request_id)
+        if error:
+            return error
+        if transform_req.status.is_complete:
             msg = f"Transform request with id {request_id} is not in progress."
             current_app.logger.warning(msg, extra={"request_id": request_id})
             return {"message": msg}, 400

--- a/servicex_app/servicex_app/resources/transformation/delete.py
+++ b/servicex_app/servicex_app/resources/transformation/delete.py
@@ -27,7 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from servicex_app import ObjectStoreManager
 from servicex_app.decorators import auth_required
-from servicex_app.models import TransformRequest, TransformationResult, db
+from servicex_app.models import TransformationResult, db
 from servicex_app.resources.servicex_resource import ServiceXResource
 from flask import current_app
 
@@ -42,20 +42,14 @@ class DeleteTransform(ServiceXResource):
         session = db.session
         with session.begin():
 
-            transform_req = TransformRequest.lookup(request_id)
-            if not transform_req:
-                msg = f"Transformation request not found with id: {request_id}"
-                current_app.logger.warning(msg, extra={"request_id": request_id})
-                return {"message": msg}, 404
+            transform_req, error = self._get_owned_request(request_id)
+            if error:
+                return error
 
             if not transform_req.status.is_complete:
                 msg = f"Transform request with id {request_id} is still in progress."
                 current_app.logger.warning(msg, extra={"request_id": request_id})
                 return {"message": msg}, 400
-
-            user = self.get_requesting_user()
-            if user and (not user.admin and user.id != transform_req.submitted_by):
-                return {"message": "You are not authorized to delete this request"}, 403
 
             # Delete all the results for this transform
             session.query(TransformationResult).filter_by(

--- a/servicex_app/servicex_app/resources/transformation/file_urls.py
+++ b/servicex_app/servicex_app/resources/transformation/file_urls.py
@@ -31,7 +31,6 @@ from flask import current_app
 from flask_restful import reqparse
 
 from servicex_app.decorators import auth_required
-from servicex_app.models import TransformRequest
 from servicex_app.resources.servicex_resource import ServiceXResource
 
 import boto3
@@ -70,12 +69,9 @@ class FileURLGenerator(ServiceXResource):
 
         args = parser.parse_args()
         request_id = args["request_id"]
-        # Validate that the user is an admin or submitted the request (not yet implemented)
-        transform = TransformRequest.lookup(request_id)
-        if not transform:
-            msg = f"Transformation request not found with id: {request_id}"
-            current_app.logger.error(msg, extra={"request_id": request_id})
-            return {"message": msg}, 404
+        _, error = self._get_owned_request(request_id)
+        if error:
+            return error
 
         expirydelta = 365 * 24 * 60 * 60
         expiry = int(datetime.datetime.now().timestamp() + expirydelta)

--- a/servicex_app/servicex_app/resources/transformation/get_all.py
+++ b/servicex_app/servicex_app/resources/transformation/get_all.py
@@ -44,8 +44,14 @@ class AllTransformationRequests(ServiceXResource):
     def get(self):
         args = parser.parse_args()
         query_id = args.get("submitted_by")
+        user = self.get_requesting_user()
         transforms: List[TransformRequest]
-        if query_id:
+        if user and not user.admin:
+            # Non-admin users may only see their own requests
+            if query_id is not None and query_id != user.id:
+                return {"message": "You are not authorized to view these requests"}, 403
+            query_id = user.id
+        if query_id is not None:
             current_app.logger.debug(f"Querying transform request by id: {query_id}")
             transforms = TransformRequest.query.filter_by(submitted_by=query_id)
         else:

--- a/servicex_app/servicex_app/resources/transformation/get_one.py
+++ b/servicex_app/servicex_app/resources/transformation/get_one.py
@@ -38,12 +38,9 @@ parser = reqparse.RequestParser()
 class TransformationRequest(ServiceXResource):
     @auth_required
     def get(self, request_id):
-        # Validate that the user is an admin or submitted the request
-        transform = TransformRequest.lookup(request_id)
-        if not transform:
-            msg = f"Transformation request not found with id: {request_id}"
-            current_app.logger.error(msg, extra={"request_id": request_id})
-            return {"message": msg}, 404
+        transform, error = self._get_owned_request(request_id)
+        if error:
+            return error
 
         transform_json = transform.to_json()
         if (

--- a/servicex_app/servicex_app/resources/transformation/results.py
+++ b/servicex_app/servicex_app/resources/transformation/results.py
@@ -13,6 +13,10 @@ class TransformationResults(ServiceXResource):
         if not request_id:
             return {"message": "Missing required transformation request_id"}, 400
 
+        _, error = self._get_owned_request(request_id)
+        if error:
+            return error
+
         parser = reqparse.RequestParser()
         parser.add_argument("later_than", type=str, required=False, location="args")
 

--- a/servicex_app/servicex_app/resources/transformation/status.py
+++ b/servicex_app/servicex_app/resources/transformation/status.py
@@ -29,7 +29,7 @@ from flask_restful import reqparse
 from flask import jsonify, current_app
 
 from servicex_app.decorators import auth_required
-from servicex_app.models import TransformationResult, TransformRequest
+from servicex_app.models import TransformationResult
 from servicex_app.resources.servicex_resource import ServiceXResource
 
 status_request_parser = reqparse.RequestParser()
@@ -41,11 +41,9 @@ status_request_parser.add_argument(
 class TransformationStatus(ServiceXResource):
     @auth_required
     def get(self, request_id):
-        transform = TransformRequest.lookup(request_id)
-        if not transform:
-            msg = f"Transformation request not found with id: {request_id}"
-            current_app.logger.error(msg, extra={"request_id": request_id})
-            return {"message": msg}, 404
+        transform, error = self._get_owned_request(request_id)
+        if error:
+            return error
 
         status_request = status_request_parser.parse_args()
 

--- a/servicex_app/servicex_app/resources/users/slack_interaction.py
+++ b/servicex_app/servicex_app/resources/users/slack_interaction.py
@@ -12,9 +12,8 @@ from servicex_app.reliable_requests import servicex_retry, REQUEST_TIMEOUT
 from servicex_app.resources.servicex_resource import ServiceXResource
 from servicex_app.web.slack_msg_builder import (
     signup_ia,
-    missing_slack_app,
+    action_not_supported,
     request_expired,
-    verification_failed,
     user_not_found,
 )
 
@@ -43,14 +42,11 @@ class SlackInteraction(ServiceXResource):
             current_app.logger.error(
                 "Slack interaction received but no Slack app configured"
             )
-            respond(response_url, missing_slack_app())
             return Response(status=403)
 
-        timestamp = request.headers["X-Slack-Request-Timestamp"]
-        if abs(time.time() - float(timestamp) > 60 * 5):
-            respond(response_url, request_expired())
-            return Response(status=403)
-
+        # The signature must be verified before we contact the caller-supplied
+        # response_url, otherwise anyone can make us issue outbound requests.
+        timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
         sig_basestring = f"v0:{timestamp}:{body}".encode("utf-8")
         signature = (
             "v0="
@@ -58,10 +54,18 @@ class SlackInteraction(ServiceXResource):
                 secret.encode("utf-8"), sig_basestring, digestmod=hashlib.sha256
             ).hexdigest()
         )
-        slack_signature = request.headers["X-Slack-Signature"]
+        slack_signature = request.headers.get("X-Slack-Signature", "")
         if not hmac.compare_digest(signature, slack_signature):
-            respond(response_url, verification_failed())
+            current_app.logger.error("Slack signature verification failed")
             return Response(status=401)
+
+        try:
+            expired = abs(time.time() - float(timestamp)) > 60 * 5
+        except ValueError:
+            expired = True
+        if expired:
+            respond(response_url, request_expired())
+            return Response(status=403)
 
         action = data["actions"][0]
         initiating_user = data["user"]
@@ -80,5 +84,7 @@ class SlackInteraction(ServiceXResource):
             slack_response.raise_for_status()
         elif action_id == "reject_user":
             # todo blocked by PR for delete-user endpoint
-            raise NotImplementedError
+            current_app.logger.warning(f"Unsupported Slack action: {action_id}")
+            respond(response_url, action_not_supported(action_id))
+            return Response(status=200)
         return Response(status=200)

--- a/servicex_app/servicex_app/web/slack_msg_builder.py
+++ b/servicex_app/servicex_app/web/slack_msg_builder.py
@@ -69,6 +69,16 @@ def verification_failed() -> str:
     )
 
 
+def action_not_supported(action_id) -> str:
+    return json.dumps(
+        {
+            "response_type": "ephemeral",
+            "replace_original": False,
+            "text": f"Sorry, the '{action_id}' action is not supported yet.",
+        }
+    )
+
+
 def user_not_found(error) -> str:
     return json.dumps(
         {"response_type": "ephemeral", "replace_original": False, "text": error}

--- a/servicex_app/servicex_app/web/transformation_request.py
+++ b/servicex_app/servicex_app/web/transformation_request.py
@@ -2,6 +2,7 @@ from flask import render_template, abort, current_app
 
 from servicex_app.decorators import oauth_required
 from servicex_app.models import TransformRequest
+from servicex_app.web.utils import user_owns_request
 
 
 @oauth_required
@@ -10,4 +11,6 @@ def transformation_request(id_: str):
     req = TransformRequest.lookup(id_)
     if not req:
         abort(404)
+    if not user_owns_request(req):
+        abort(403)
     return render_template("transformation_request.html", req=req)

--- a/servicex_app/servicex_app/web/transformation_results.py
+++ b/servicex_app/servicex_app/web/transformation_results.py
@@ -2,6 +2,7 @@ from flask import abort, render_template, request
 from flask_sqlalchemy.pagination import Pagination
 from servicex_app.decorators import oauth_required
 from servicex_app.models import TransformationResult, TransformRequest
+from servicex_app.web.utils import user_owns_request
 
 
 @oauth_required
@@ -9,6 +10,8 @@ def transformation_results(id_: str):
     treq = TransformRequest.lookup(id_)
     if not treq:
         abort(404)
+    if not user_owns_request(treq):
+        abort(403)
     page = request.args.get("page", 1, type=int)
     filter_by_values = {}
     status = request.args.get("status")

--- a/servicex_app/servicex_app/web/utils.py
+++ b/servicex_app/servicex_app/web/utils.py
@@ -1,7 +1,19 @@
-from flask import current_app
+from flask import current_app, session
 from authlib.integrations.flask_client import OAuth
 
 oauth = None
+
+
+def user_owns_request(req) -> bool:
+    """
+    Return True if the signed-in web user is allowed to view this transform
+    request, i.e. auth is disabled, they are an admin, or they submitted it.
+    """
+    if not current_app.config.get("ENABLE_AUTH"):
+        return True
+    if session.get("admin"):
+        return True
+    return session.get("user_id") == req.submitted_by
 
 
 def load_oauth_client():

--- a/servicex_app/servicex_app_test/resources/transformation/test_cancel.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_cancel.py
@@ -26,7 +26,7 @@ class TestTransformCancel(ResourceTestBase):
     def fake_transform(self, mocker) -> TransformRequest:
         fake = self._generate_transform_request()
         fake.save_to_db = mocker.Mock()
-        mocker.patch(f"{self.module}.TransformRequest.lookup", return_value=fake)
+        mocker.patch("servicex_app.models.TransformRequest.lookup", return_value=fake)
         return fake
 
     def test_submitted(
@@ -107,3 +107,45 @@ class TestTransformCancel(ResourceTestBase):
         resp = getattr(client, http_method)(URL)
         assert resp.status_code == 404
         assert "Transformation request not found" in resp.json["message"]
+
+    def test_auth_disabled(self, http_method, fake_transform, mock_transform_manager):
+        fake_transform.status = TransformStatus.running
+        fake_transform.submitted_by = 43
+        client = self._test_client(transformation_manager=mock_transform_manager)
+
+        resp = getattr(client, http_method)(URL)
+        assert resp.status_code == 200
+
+    @pytest.mark.parametrize(
+        "user_id, submitter_id, is_admin, expected_status",
+        [
+            (42, 42, False, 200),  # Owner cancels their own request
+            (42, 43, True, 200),  # Admin cancels someone else's request
+            (42, 43, False, 403),  # User tries to cancel someone else's request
+        ],
+    )
+    def test_ownership(
+        self,
+        http_method,
+        user_id,
+        submitter_id,
+        is_admin,
+        expected_status,
+        fake_transform,
+        mock_transform_manager,
+        mock_jwt_extended,
+        mock_requesting_user,
+    ):
+        fake_transform.status = TransformStatus.running
+        client = self._test_client(
+            extra_config={"ENABLE_AUTH": True},
+            transformation_manager=mock_transform_manager,
+        )
+        with client.application.app_context():
+            mock_requesting_user.id = user_id
+            mock_requesting_user.admin = is_admin
+            fake_transform.submitted_by = submitter_id
+
+            resp = getattr(client, http_method)(URL, headers=self.fake_header())
+
+            assert resp.status_code == expected_status

--- a/servicex_app/servicex_app_test/resources/transformation/test_delete.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_delete.py
@@ -15,9 +15,10 @@ class TestTransformDelete(ResourceTestBase):
 
     @pytest.fixture
     def fake_transform(self, mocker) -> TransformRequest:
-        mock_transform_request_cls = mocker.patch(f"{self.module}.TransformRequest")
         transform = self._generate_transform_request()
-        mock_transform_request_cls.lookup.return_value = transform
+        mocker.patch(
+            "servicex_app.models.TransformRequest.lookup", return_value=transform
+        )
         return transform
 
     @pytest.fixture

--- a/servicex_app/servicex_app_test/resources/transformation/test_get_all.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_get_all.py
@@ -52,8 +52,16 @@ class TestAllTransformationRequest(ResourceTestBase):
         assert response.json == self.example_json()
         mock_return_json.assert_called()
 
+    @fixture()
+    def mock_query(self, mocker):
+        mock_tr_cls = mocker.patch(
+            "servicex_app.resources.transformation.get_all.TransformRequest"
+        )
+        mock_tr_cls.return_json.return_value = self.example_json()
+        return mock_tr_cls.query
+
     def test_get_all_auth_enabled(
-        self, mock_jwt_extended, mock_return_json, mock_requesting_user
+        self, mock_jwt_extended, mock_requesting_user, mock_query
     ):
         client = self._test_client(extra_config={"ENABLE_AUTH": True})
         with client.application.app_context():
@@ -62,11 +70,26 @@ class TestAllTransformationRequest(ResourceTestBase):
             )
         assert response.status_code == 200
         assert response.json == self.example_json()
-        mock_return_json.assert_called()
+        # A non-admin user only sees their own requests
+        mock_query.filter_by.assert_called_once_with(
+            submitted_by=mock_requesting_user.id
+        )
+        mock_query.all.assert_not_called()
 
-    def test_get_by_user(
-        self, mock_jwt_extended, mock_requesting_user, mock_return_json
+    def test_get_all_as_admin(
+        self, mock_jwt_extended, mock_requesting_user, mock_query
     ):
+        mock_requesting_user.admin = True
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+        with client.application.app_context():
+            response = client.get(
+                "/servicex/transformation", headers=self.fake_header()
+            )
+        assert response.status_code == 200
+        assert response.json == self.example_json()
+        mock_query.all.assert_called_once_with()
+
+    def test_get_by_user(self, mock_jwt_extended, mock_requesting_user, mock_query):
         user_id = mock_requesting_user.id
         client = self._test_client(extra_config={"ENABLE_AUTH": True})
         with client.application.app_context():
@@ -76,4 +99,47 @@ class TestAllTransformationRequest(ResourceTestBase):
             )
         assert response.status_code == 200
         assert response.json == self.example_json()
-        mock_return_json.assert_called()
+        mock_query.filter_by.assert_called_once_with(submitted_by=user_id)
+
+    def test_get_by_other_user_forbidden(
+        self, mock_jwt_extended, mock_requesting_user, mock_query
+    ):
+        other_id = mock_requesting_user.id + 1
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+        with client.application.app_context():
+            response = client.get(
+                f"/servicex/transformation?submitted_by={other_id}",
+                headers=self.fake_header(),
+            )
+        assert response.status_code == 403
+        mock_query.filter_by.assert_not_called()
+        mock_query.all.assert_not_called()
+
+    def test_get_by_other_user_as_admin(
+        self, mock_jwt_extended, mock_requesting_user, mock_query
+    ):
+        mock_requesting_user.admin = True
+        other_id = mock_requesting_user.id + 1
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+        with client.application.app_context():
+            response = client.get(
+                f"/servicex/transformation?submitted_by={other_id}",
+                headers=self.fake_header(),
+            )
+        assert response.status_code == 200
+        mock_query.filter_by.assert_called_once_with(submitted_by=other_id)
+
+    def test_get_by_user_zero(
+        self, mock_jwt_extended, mock_requesting_user, mock_query
+    ):
+        """submitted_by=0 must not be treated as an absent filter."""
+        mock_requesting_user.admin = True
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+        with client.application.app_context():
+            response = client.get(
+                "/servicex/transformation?submitted_by=0",
+                headers=self.fake_header(),
+            )
+        assert response.status_code == 200
+        mock_query.filter_by.assert_called_once_with(submitted_by=0)
+        mock_query.all.assert_not_called()

--- a/servicex_app/servicex_app_test/resources/transformation/test_get_one.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_get_one.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from servicex_app_test.resource_test_base import ResourceTestBase
 
 
@@ -52,3 +54,36 @@ class TestTransformationRequest(ResourceTestBase):
             response = client.get("/servicex/transformation/1234")
         assert response.status_code == 404
         mock_lookup.assert_called_with("1234")
+
+    @pytest.mark.parametrize(
+        "user_id, submitter_id, is_admin, expected_status",
+        [
+            (42, 42, False, 200),  # Owner reads their own request
+            (42, 43, True, 200),  # Admin reads someone else's request
+            (42, 43, False, 403),  # User tries to read someone else's request
+        ],
+    )
+    def test_get_single_request_ownership(
+        self,
+        user_id,
+        submitter_id,
+        is_admin,
+        expected_status,
+        mock_jwt_extended,
+        mock_requesting_user,
+    ):
+        with patch("servicex_app.models.TransformRequest.lookup") as mock_lookup:
+            fake_transform_request = self._generate_transform_request()
+            fake_transform_request.submitted_by = submitter_id
+            mock_lookup.return_value = fake_transform_request
+
+            client = self._test_client(extra_config={"ENABLE_AUTH": True})
+            with client.application.app_context():
+                mock_requesting_user.id = user_id
+                mock_requesting_user.admin = is_admin
+
+                response = client.get(
+                    "/servicex/transformation/1234", headers=self.fake_header()
+                )
+
+                assert response.status_code == expected_status

--- a/servicex_app/servicex_app_test/resources/transformation/test_results.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_results.py
@@ -37,6 +37,14 @@ class TestTransformationResults(ResourceTestBase):
             "servicex_app.resources.transformation.results.TransformationResult"
         )
 
+    @fixture
+    def fake_transform(self, mocker):
+        transform = self._generate_transform_request()
+        mocker.patch(
+            "servicex_app.models.TransformRequest.lookup", return_value=transform
+        )
+        return transform
+
     @staticmethod
     def sample_results():
         """Return a list of sample transformation results"""
@@ -73,12 +81,8 @@ class TestTransformationResults(ResourceTestBase):
 
         response = client.get("/servicex/transformation/non-existent-id/results")
 
-        assert response.status_code == 200
-        data = response.json
-
-        assert "results" in data
-        assert isinstance(data["results"], list)
-        assert len(data["results"]) == 0
+        assert response.status_code == 404
+        assert "Transformation request not found" in response.json["message"]
 
     def test_get_results_missing_request_id(
         self, mock_rabbit_adaptor, mock_codegen, mock_celery_app
@@ -100,6 +104,7 @@ class TestTransformationResults(ResourceTestBase):
         mock_codegen,
         mock_celery_app,
         mock_transformation_result,
+        fake_transform,
     ):
         """Test getting results with mock sample results."""
         client = self._test_client(
@@ -136,7 +141,7 @@ class TestTransformationResults(ResourceTestBase):
         mock_query.filter_by.assert_called_with(request_id="test-request-id")
 
     def test_get_results_with_invalid_later_than_format(
-        self, mock_rabbit_adaptor, mock_codegen, mock_celery_app
+        self, mock_rabbit_adaptor, mock_codegen, mock_celery_app, fake_transform
     ):
         """Test later_than parameter with invalid datetime format."""
         client = self._test_client(

--- a/servicex_app/servicex_app_test/resources/transformation/test_status.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_status.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from unittest.mock import patch, PropertyMock
 
+import pytest
+
 from servicex_app_test.resource_test_base import ResourceTestBase
 
 
@@ -58,3 +60,38 @@ class TestTransformStatus(ResourceTestBase):
         response = client.get("/servicex/transformation/1234/status")
         assert response.status_code == 404
         mock_transform_request_read.assert_called_with("1234")
+
+    @pytest.mark.parametrize(
+        "user_id, submitter_id, is_admin, expected_status",
+        [
+            (42, 42, False, 200),  # Owner reads their own request
+            (42, 43, True, 200),  # Admin reads someone else's request
+            (42, 43, False, 403),  # User tries to read someone else's request
+        ],
+    )
+    def test_get_status_ownership(
+        self,
+        user_id,
+        submitter_id,
+        is_admin,
+        expected_status,
+        mock_jwt_extended,
+        mock_requesting_user,
+    ):
+        fake_transform_request = self._generate_transform_request()
+        fake_transform_request.submitted_by = submitter_id
+        with patch(
+            "servicex_app.models.TransformRequest.lookup",
+            return_value=fake_transform_request,
+        ):
+            client = self._test_client(extra_config={"ENABLE_AUTH": True})
+            with client.application.app_context():
+                mock_requesting_user.id = user_id
+                mock_requesting_user.admin = is_admin
+
+                response = client.get(
+                    "/servicex/transformation/1234/status",
+                    headers=self.fake_header(),
+                )
+
+                assert response.status_code == expected_status

--- a/servicex_app/servicex_app_test/resources/users/test_slack_interaction.py
+++ b/servicex_app/servicex_app_test/resources/users/test_slack_interaction.py
@@ -85,25 +85,31 @@ payload = {
 
 
 class TestSlackInteraction(ResourceTestBase):
+    @staticmethod
+    def _signed_headers(secret, timestamp):
+        body = f"payload={quote_plus(json.dumps(payload), safe=',:@/')}"
+        sig_basestring = f"v0:{timestamp}:{body}".encode("utf-8")
+        signature = hmac.new(
+            secret.encode("utf-8"), sig_basestring, digestmod=hashlib.sha256
+        ).hexdigest()
+        return {
+            "X-Slack_Request-Timestamp": timestamp,
+            "X-Slack-Signature": "v0=" + signature,
+        }
+
     def test_slack_interaction_not_configured(self, mocker, client):
         mock_post = mocker.patch("requests.post")
         response: Response = client.post(
             "/slack", data={"payload": json.dumps(payload)}
         )
         assert response.status_code == 403
-        with client.application.app_context():
-            from servicex_app.web.slack_msg_builder import missing_slack_app
-
-            mock_post.assert_called_once_with(
-                payload["response_url"], missing_slack_app(), timeout=(0.5, None)
-            )
+        mock_post.assert_not_called()
 
     def test_slack_interaction_expired(self, mocker):
+        secret = "my-slack-secret"
         mock_post = mocker.patch("requests.post")
-        client = self._test_client(
-            extra_config={"SLACK_SIGNING_SECRET": "my-slack-secret"}
-        )
-        headers = {"X-Slack_Request-Timestamp": 0}
+        client = self._test_client(extra_config={"SLACK_SIGNING_SECRET": secret})
+        headers = self._signed_headers(secret, 0)
         response: Response = client.post(
             "/slack", data={"payload": json.dumps(payload)}, headers=headers
         )
@@ -113,6 +119,53 @@ class TestSlackInteraction(ResourceTestBase):
 
             mock_post.assert_called_once_with(
                 payload["response_url"], request_expired(), timeout=(0.5, None)
+            )
+
+    def test_slack_interaction_future_timestamp(self, mocker):
+        secret = "my-slack-secret"
+        mock_post = mocker.patch("requests.post")
+        client = self._test_client(extra_config={"SLACK_SIGNING_SECRET": secret})
+        headers = self._signed_headers(secret, time.time() + 3600)
+        response: Response = client.post(
+            "/slack", data={"payload": json.dumps(payload)}, headers=headers
+        )
+        assert response.status_code == 403
+        with client.application.app_context():
+            from servicex_app.web.slack_msg_builder import request_expired
+
+            mock_post.assert_called_once_with(
+                payload["response_url"], request_expired(), timeout=(0.5, None)
+            )
+
+    def test_slack_interaction_reject_user(self, mocker):
+        secret = "my-slack-secret"
+        mock_post = mocker.patch("requests.post")
+        client = self._test_client(extra_config={"SLACK_SIGNING_SECRET": secret})
+        reject_payload = dict(payload)
+        reject_payload["actions"] = [
+            dict(payload["actions"][0], action_id="reject_user")
+        ]
+        body = f"payload={quote_plus(json.dumps(reject_payload), safe=',:@/')}"
+        timestamp = time.time()
+        sig_basestring = f"v0:{timestamp}:{body}".encode("utf-8")
+        signature = hmac.new(
+            secret.encode("utf-8"), sig_basestring, digestmod=hashlib.sha256
+        ).hexdigest()
+        headers = {
+            "X-Slack_Request-Timestamp": timestamp,
+            "X-Slack-Signature": "v0=" + signature,
+        }
+        response: Response = client.post(
+            "/slack", data={"payload": json.dumps(reject_payload)}, headers=headers
+        )
+        assert response.status_code == 200
+        with client.application.app_context():
+            from servicex_app.web.slack_msg_builder import action_not_supported
+
+            mock_post.assert_called_once_with(
+                payload["response_url"],
+                action_not_supported("reject_user"),
+                timeout=(0.5, None),
             )
 
     def test_slack_interaction_invalid(self, mocker):
@@ -125,12 +178,7 @@ class TestSlackInteraction(ResourceTestBase):
             "/slack", data={"payload": json.dumps(payload)}, headers=headers
         )
         assert response.status_code == 401
-        with client.application.app_context():
-            from servicex_app.web.slack_msg_builder import verification_failed
-
-            mock_post.assert_called_once_with(
-                payload["response_url"], verification_failed(), timeout=(0.5, None)
-            )
+        mock_post.assert_not_called()
 
     def test_slack_interaction_accept_user(self, mocker):
         mock_post = mocker.patch("requests.post")

--- a/servicex_app/servicex_app_test/test_decorators.py
+++ b/servicex_app/servicex_app_test/test_decorators.py
@@ -118,6 +118,7 @@ class TestDecorators(WebTestBase):
         mock.to_json.return_value = data
         with client.session_transaction() as sess:
             sess["is_authenticated"] = True
+            sess["user_id"] = user.id
         with client.application.app_context():
             response: Response = client.get(
                 f"servicex/transformation/{fake_transform_id}"
@@ -125,6 +126,43 @@ class TestDecorators(WebTestBase):
             print(response.data)
             assert response.status_code == 200
             assert response.json == data
+
+    def test_auth_decorator_integration_oauth_user_deleted(self, mocker):
+        mocker.patch("servicex_app.models.UserModel.find_by_id", return_value=None)
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+        with client.session_transaction() as sess:
+            sess["is_authenticated"] = True
+            sess["user_id"] = 7
+        with client.application.app_context():
+            response: Response = client.get("servicex/transformation/123")
+            assert response.status_code == 401
+            assert "deleted" in response.json["message"]
+
+    def test_auth_decorator_integration_oauth_user_pending(self, user):
+        user.pending = True
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+        with client.session_transaction() as sess:
+            sess["is_authenticated"] = True
+            sess["user_id"] = user.id
+        with client.application.app_context():
+            response: Response = client.get("servicex/transformation/123")
+            assert response.status_code == 401
+            assert "pending" in response.json["message"]
+
+    def test_auth_decorator_integration_oauth_not_owner(self, mocker, user):
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+        mock = mocker.patch(
+            "servicex_app.resources.transformation.get_one" ".TransformRequest.lookup"
+        ).return_value
+        mock.submitted_by = 4321
+        user.id = 7
+        user.admin = False
+        with client.session_transaction() as sess:
+            sess["is_authenticated"] = True
+            sess["user_id"] = user.id
+        with client.application.app_context():
+            response: Response = client.get("servicex/transformation/123")
+            assert response.status_code == 403
 
     def test_admin_decorator_integration_auth_disabled(self, mocker, client):
         data = {"users": [{"id": 1234}]}

--- a/servicex_app/servicex_app_test/web/test_transformation_request.py
+++ b/servicex_app/servicex_app_test/web/test_transformation_request.py
@@ -41,3 +41,32 @@ class TestTransformationRequest(WebTestBase):
         mock_tr_cls.lookup.return_value = None
         resp: Response = client.get(url_for(self.endpoint, id_=1))
         assert resp.status_code == 404
+
+    @fixture
+    def auth_client(self):
+        return self._test_client(extra_config={"ENABLE_AUTH": True})
+
+    def test_403_for_non_owner(self, auth_client, mock_tr: TransformRequest):
+        mock_tr.submitted_by = 43
+        with auth_client.session_transaction() as sess:
+            sess["is_authenticated"] = True
+            sess["user_id"] = 42
+        resp: Response = auth_client.get(url_for(self.endpoint, id_=mock_tr.id))
+        assert resp.status_code == 403
+
+    def test_owner_allowed(self, auth_client, mock_tr: TransformRequest):
+        mock_tr.submitted_by = 42
+        with auth_client.session_transaction() as sess:
+            sess["is_authenticated"] = True
+            sess["user_id"] = 42
+        resp: Response = auth_client.get(url_for(self.endpoint, id_=mock_tr.id))
+        assert resp.status_code == 200
+
+    def test_admin_allowed(self, auth_client, mock_tr: TransformRequest):
+        mock_tr.submitted_by = 43
+        with auth_client.session_transaction() as sess:
+            sess["is_authenticated"] = True
+            sess["user_id"] = 42
+            sess["admin"] = True
+        resp: Response = auth_client.get(url_for(self.endpoint, id_=mock_tr.id))
+        assert resp.status_code == 200

--- a/servicex_app/servicex_app_test/web/test_transformation_results.py
+++ b/servicex_app/servicex_app_test/web/test_transformation_results.py
@@ -85,3 +85,12 @@ class TestUserDashboard(WebTestBase):
             url_for(self.endpoint, id_=1), headers=self.fake_header()
         )
         assert resp.status_code == 404
+
+    def test_403_for_non_owner(self, mock_tr):
+        client = self._test_client(extra_config={"ENABLE_AUTH": True})
+        mock_tr.submitted_by = 43
+        with client.session_transaction() as sess:
+            sess["is_authenticated"] = True
+            sess["user_id"] = 42
+        resp: Response = client.get(url_for(self.endpoint, id_=mock_tr.id))
+        assert resp.status_code == 403


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Tightens authorization in the Flask app: transform requests can now only be read, cancelled or deleted by their submitter or an administrator, session-cookie callers are subject to the same account checks as API token callers, the transform listing endpoint no longer exposes every user's requests, and the Slack interaction handler verifies the request signature before it contacts the caller-supplied `response_url`.

**How to review.** Each finding is one commit; the Commits tab shows them in severity order. Each entry below links to its commit; tick approve or reject under it. To ask for a change instead, leave a review comment on the commit. Rejected commits will be dropped from the branch and this list will be updated to match.

- **B1, B2** · high · [`c031b5b`](https://github.com/ssl-hep/ServiceX/pull/1546/commits/c031b5b3ba9b97da825e1b714243074f4e6364a2) · Restrict transform request endpoints and web pages to the submitter or an administrator, and make the session branch of `auth_required` load the user and apply the same missing and pending checks as the JWT branch; the two findings share one commit because they touch the same functions and each one's tests depend on the other
  - [ ] approve
  - [ ] reject
- **B3** · high · [`7569d3d`](https://github.com/ssl-hep/ServiceX/pull/1546/commits/7569d3d2fe11ada85ad699459e9215ec182b2954) · Scope the transform listing endpoint to the requesting user unless they are an administrator, and stop treating `submitted_by=0` as an absent filter
  - [ ] approve
  - [ ] reject
- **B28** · high · [`3281284`](https://github.com/ssl-hep/ServiceX/pull/1546/commits/3281284d53a7ff0c9e80456f09f1d81ae09686a4) · Verify the Slack HMAC signature before any outbound request to the caller-supplied `response_url`, fix the misparenthesized timestamp expiry check, and answer the unimplemented `reject_user` action with a Slack message instead of an uncaught `NotImplementedError`
  - [ ] approve
  - [ ] reject

**Follow-ups noticed, out of scope**

- B3 returns 403 when a non-admin asks for another user's `submitted_by` rather than silently rescoping the query to their own requests. Silently rescoping would avoid leaking whether that user has requests, so this is a deliberate choice worth confirming.
- `web/slack_msg_builder.py:missing_slack_app` and `verification_failed` are no longer called anywhere after B28, since those paths must not contact `response_url` before the signature is verified. They were left in place rather than deleted.

Part of #1539.
