### PR TITLE
perf(app): index files.dataset_id and remove per-row work in lifecycle tasks

### DIFF
--- a/servicex_app/migrations/versions/f1c2a9d47b3e_index_files_dataset_id.py
+++ b/servicex_app/migrations/versions/f1c2a9d47b3e_index_files_dataset_id.py
@@ -1,0 +1,22 @@
+"""
+add index to DatasetFile.dataset_id
+
+Revision ID: f1c2a9d47b3e
+Revises: v1_8_4
+Create Date: 2026-09-09 10:12:41.183422
+"""
+
+from alembic import op
+
+revision = "f1c2a9d47b3e"
+down_revision = "v1_8_4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f("ix_files_dataset_id"), "files", ["dataset_id"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_files_dataset_id"), table_name="files")

--- a/servicex_app/servicex_app/decorators.py
+++ b/servicex_app/servicex_app/decorators.py
@@ -50,7 +50,6 @@ def jwt_required_if_auth_enabled(*dargs, **dkwargs):
     return decorate
 
 
-@jwt_required_if_auth_enabled
 def get_jwt_user():
     user = UserModel.find_by_email(get_jwt_identity())
 

--- a/servicex_app/servicex_app/docker_repo_adapter.py
+++ b/servicex_app/servicex_app/docker_repo_adapter.py
@@ -25,27 +25,32 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import functools
 import subprocess
 
 from flask import current_app
 
+# Images which have been confirmed to exist in the registry. Only successful
+# lookups are cached, so failures are retried on the next request.
+_known_images = set()
+
 
 class DockerRepoAdapter:
     @staticmethod
-    @functools.cache
     def check_image_exists(tagged_image: str) -> bool:
         """
         Checks that the given Docker image exists using crane.
         :param tagged_image: Full Docker image name, e.g. "sslhep/servicex_app:latest".
         :return: Whether or not the image exists in the registry.
         """
+        if tagged_image in _known_images:
+            return True
         try:
             result = subprocess.run(
                 ["crane", "digest", tagged_image], capture_output=True, timeout=30
             )
             if result.returncode == 0:
                 current_app.logger.info(f"Requested Image: {tagged_image} exists")
+                _known_images.add(tagged_image)
                 return True
             else:
                 current_app.logger.warning(

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -182,7 +182,7 @@ class TransformRequest(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     request_id = db.Column(db.String(48), unique=True, nullable=False, index=True)
     title = db.Column(db.String(10240), nullable=True)
-    submit_time = db.Column(db.DateTime, nullable=False)
+    submit_time = db.Column(db.DateTime, nullable=False, index=True)
     finish_time = db.Column(db.DateTime, nullable=True)
     did = db.Column(db.String(512), unique=False, nullable=False)
     did_id = db.Column(
@@ -579,7 +579,7 @@ class DatasetFile(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     dataset_id = db.Column(
-        db.Integer, ForeignKey("datasets.id"), unique=False, nullable=False
+        db.Integer, ForeignKey("datasets.id"), unique=False, nullable=False, index=True
     )
     adler32 = db.Column(db.String(48), nullable=True)
     file_size = db.Column(db.BigInteger, nullable=True)

--- a/servicex_app/servicex_app/object_store_manager.py
+++ b/servicex_app/servicex_app/object_store_manager.py
@@ -25,6 +25,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from flask import current_app
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
 
@@ -47,17 +48,26 @@ class ObjectStoreManager:
         return self.minio_client.list_buckets()
 
     def delete_bucket_and_contents(self, bucket_name):
+        from minio.deleteobjects import DeleteObject
+
         if not self.minio_client.bucket_exists(bucket_name):
-            print(f"Bucket '{bucket_name}' does not exist. Nothing to delete.")
+            current_app.logger.warning(
+                f"Bucket '{bucket_name}' does not exist. Nothing to delete."
+            )
             return
 
         # List all objects in the bucket
         objects = self.minio_client.list_objects(bucket_name, recursive=True)
 
-        # Remove each object
-        for obj in objects:
-            self.minio_client.remove_object(bucket_name, obj.object_name)
+        # Remove the objects in batches
+        errors = self.minio_client.remove_objects(
+            bucket_name, [DeleteObject(obj.object_name) for obj in objects]
+        )
+        for error in errors:
+            current_app.logger.error(
+                f"Error deleting object from bucket '{bucket_name}': {error}"
+            )
 
         # Remove the bucket itself
         self.minio_client.remove_bucket(bucket_name)
-        print(f"Bucket '{bucket_name}' deleted successfully.")
+        current_app.logger.info(f"Bucket '{bucket_name}' deleted successfully.")

--- a/servicex_app/servicex_app/reliable_requests.py
+++ b/servicex_app/servicex_app/reliable_requests.py
@@ -31,7 +31,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential_jitter
 
 # This is the default timeout settings for requests. It represents the time to make a
 # connection and then the time to wait for a response.
-REQUEST_TIMEOUT = (0.5, None)
+REQUEST_TIMEOUT = (3, 30)
 
 
 # Use this decorator on all functions that wrap requests to

--- a/servicex_app/servicex_app/resources/internal/data_lifecycle_ops.py
+++ b/servicex_app/servicex_app/resources/internal/data_lifecycle_ops.py
@@ -30,7 +30,7 @@ from typing import List
 
 from flask import request, current_app
 from sqlalchemy import select, exists
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from servicex_app import ObjectStoreManager
 from servicex_app.models import (
@@ -57,12 +57,12 @@ class DataLifecycleOps(ServiceXResource):
         with session.begin():
             expired_transforms = (
                 session.query(TransformRequest)
+                .options(joinedload(TransformRequest.user))
                 .filter(TransformRequest.submit_time <= cutoff_timestamp)
                 .all()
             )
 
-        for transform in expired_transforms:
-            with session.begin():
+            for transform in expired_transforms:
                 # Delete all the results for this transform
                 session.query(TransformationResult).filter_by(
                     request_id=transform.request_id
@@ -72,12 +72,13 @@ class DataLifecycleOps(ServiceXResource):
                 if object_store:
                     object_store.delete_bucket_and_contents(transform.request_id)
 
-                # Delete the transform request
-                session.delete(transform)
-
                 deleted_log.append(
                     f"{transform.submitter_name} - {transform.request_id}: {transform.title}"
                 )
+
+                # Delete the transform request
+                session.delete(transform)
+
         return deleted_log
 
     def delete_orphaned_datasets(self, session: Session):
@@ -91,13 +92,12 @@ class DataLifecycleOps(ServiceXResource):
             query = select(Dataset).where(~exists(subquery))
             orphaned_datasets = session.execute(query).scalars().all()
 
-        for dataset in orphaned_datasets:
-            with session.begin():
+            for dataset in orphaned_datasets:
                 session.query(DatasetFile).filter_by(dataset_id=dataset.id).delete()
 
-                session.delete(dataset)
-
                 deleted_datasets.append(f"{dataset.name} - {dataset.id}")
+
+                session.delete(dataset)
 
         return deleted_datasets
 
@@ -129,9 +129,12 @@ class DataLifecycleOps(ServiceXResource):
             cutoff_timestamp: ISO formatted datetime string.
         """
 
-        with db.session.begin():
+        try:
             cutoff_timestamp = datetime.fromisoformat(request.args["cutoff_timestamp"])
+        except (KeyError, TypeError, ValueError):
+            return {"message": "Invalid or missing cutoff_timestamp parameter"}, 400
 
+        with db.session.begin():
             # See how many bytes are currently in the cache
             total_bytes = TransformRequest.total_cache_size()
 

--- a/servicex_app/servicex_app/resources/internal/dataset_lifecycle_ops.py
+++ b/servicex_app/servicex_app/resources/internal/dataset_lifecycle_ops.py
@@ -30,7 +30,7 @@ from datetime import datetime, timedelta, timezone
 from flask import request, current_app
 
 from servicex_app.resources.servicex_resource import ServiceXResource
-from servicex_app.models import Dataset
+from servicex_app.models import Dataset, db
 
 
 class DatasetLifecycleOps(ServiceXResource):
@@ -44,17 +44,20 @@ class DatasetLifecycleOps(ServiceXResource):
         except Exception:
             return {"message": "Invalid age parameter"}, 422
         delta = timedelta(hours=age)
-        datasets = (
-            Dataset.get_all()
-        )  # by default this will only give non-stale datasets
-        todelete = [
-            _.id for _ in datasets if _.last_updated and (now - _.last_updated) > delta
-        ]
+        cutoff = now - delta
+        obsoleted = (
+            db.session.query(Dataset)
+            .filter(
+                Dataset.stale.is_(False),
+                Dataset.last_updated.isnot(None),
+                Dataset.last_updated < cutoff,
+            )
+            .update({Dataset.stale: True}, synchronize_session=False)
+        )
+        db.session.commit()
         current_app.logger.info(
             f"Obsoletion called for datasets older than {delta}. "
-            f"Obsoleting {len(todelete)} datasets."
+            f"Obsoleting {obsoleted} datasets."
         )
-        for dataset_id in todelete:
-            Dataset.delete_dataset(dataset_id)
 
         return {"message": "Success"}, 200

--- a/servicex_app/servicex_app/resources/transformation/file_urls.py
+++ b/servicex_app/servicex_app/resources/transformation/file_urls.py
@@ -25,7 +25,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import datetime
+from datetime import datetime, timezone
 
 from flask import current_app
 from flask_restful import reqparse
@@ -38,22 +38,27 @@ import boto3
 
 
 class FileURLGenerator(ServiceXResource):
-    def __init__(self):
-        super().__init__()
-        # Add branches for different backends when relevant
-        # set up S3 client
-        endpoint_url = (
-            "https://"
-            if current_app.config.get("MINIO_ENCRYPT_PUBLIC", True)
-            else "http://"
-        ) + current_app.config["MINIO_PUBLIC_URL"]
-        self.s3client = boto3.client(
-            "s3",
-            endpoint_url=endpoint_url,
-            aws_access_key_id=current_app.config["MINIO_ACCESS_KEY"],
-            aws_secret_access_key=current_app.config["MINIO_SECRET_KEY"],
-            use_ssl=current_app.config.get("MINIO_ENCRYPT_PUBLIC", True),
-        )
+    # Add branches for different backends when relevant
+    _s3clients = {}
+
+    @property
+    def s3client(self):
+        """S3 client, built once per set of object store settings."""
+        use_ssl = current_app.config.get("MINIO_ENCRYPT_PUBLIC", True)
+        public_url = current_app.config["MINIO_PUBLIC_URL"]
+        access_key = current_app.config["MINIO_ACCESS_KEY"]
+        secret_key = current_app.config["MINIO_SECRET_KEY"]
+
+        key = (use_ssl, public_url, access_key, secret_key)
+        if key not in self._s3clients:
+            FileURLGenerator._s3clients[key] = boto3.client(
+                "s3",
+                endpoint_url=("https://" if use_ssl else "http://") + public_url,
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                use_ssl=use_ssl,
+            )
+        return self._s3clients[key]
 
     @auth_required
     def post(self):
@@ -78,7 +83,7 @@ class FileURLGenerator(ServiceXResource):
             return {"message": msg}, 404
 
         expirydelta = 365 * 24 * 60 * 60
-        expiry = int(datetime.datetime.now().timestamp() + expirydelta)
+        expiry = int(datetime.now(timezone.utc).timestamp() + expirydelta)
 
         # Add branches for other backends when relevant
         rv = {

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -500,7 +500,9 @@ class TransformerManager:
             current_app.config["TRANSFORMER_CACHE_VPS_LASTCHECK"] = now
             vps_server = current_app.config["TRANSFORMER_CACHE_VPS_LIVENESS_URL"]
             try:
-                sitedata = urllib3.request("GET", vps_server).json()
+                sitedata = urllib3.request(
+                    "GET", vps_server, timeout=urllib3.Timeout(connect=2, read=5)
+                ).json()
                 if thissite not in sitedata:
                     current_app.logger.error(f"{thissite} is not in VPS liveness data")
                     return

--- a/servicex_app/servicex_app_test/conftest.py
+++ b/servicex_app/servicex_app_test/conftest.py
@@ -7,6 +7,7 @@ def mock_jwt_extended(mocker):
     During unit tests, functions from Flask-JWT-extended are mocked to do nothing.
     """
     mocker.patch("servicex_app.decorators.verify_jwt_in_request")
+    mocker.patch("servicex_app.decorators.get_jwt_identity", return_value="testuser")
 
 
 @fixture(scope="session")

--- a/servicex_app/servicex_app_test/resources/internal/test_data_lifecycle_ops.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_data_lifecycle_ops.py
@@ -472,3 +472,12 @@ class TestDataLifecycleOps(ResourceTestBase):
         )
 
         mock_orphaned.assert_called_with(ANY)
+
+    @mark.parametrize("query_string", [{}, {"cutoff_timestamp": "not-a-timestamp"}])
+    def test_post_bad_cutoff_timestamp(self, query_string):
+        client = self._test_client()
+        with client.application.app_context():
+            response = client.post(
+                "/servicex/internal/data-lifecycle", query_string=query_string
+            )
+        assert response.status_code == 400

--- a/servicex_app/servicex_app_test/resources/internal/test_dataset_lifecycle_ops.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_dataset_lifecycle_ops.py
@@ -25,45 +25,40 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from datetime import datetime
-from unittest.mock import patch
+from datetime import datetime, timedelta, timezone
 
 from pytest import fixture
 
-from servicex_app.models import Dataset
+from servicex_app.models import Dataset, db
 
 from servicex_app_test.resource_test_base import ResourceTestBase
 
 
 class TestDatasetLifecycle(ResourceTestBase):
     @fixture
-    def fake_dataset_list(self):
-        with patch("servicex_app.models.Dataset.get_all") as dsfunc:
-            dsfunc.return_value = [
-                Dataset(
-                    last_used=datetime(2022, 1, 1),
-                    last_updated=datetime(2022, 1, 1),
-                    id=1,
-                    name="not-orphaned",
-                    events=100,
-                    size=1000,
-                    n_files=1,
-                    lookup_status="complete",
-                    did_finder="rucio",
-                ),
-                Dataset(
-                    last_used=datetime.now(),
-                    last_updated=datetime.now(),
-                    id=2,
-                    name="orphaned",
-                    events=100,
-                    size=1000,
-                    n_files=1,
-                    lookup_status="complete",
-                    did_finder="rucio",
-                ),
-            ]
-            yield dsfunc
+    def datasets(self, client):
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        with client.application.app_context():
+            for dataset_id, name, last_updated in [
+                (1, "obsolete", now - timedelta(days=30)),
+                (2, "recent", now),
+                (3, "never-updated", None),
+            ]:
+                db.session.add(
+                    Dataset(
+                        last_used=now,
+                        last_updated=last_updated,
+                        id=dataset_id,
+                        name=name,
+                        events=100,
+                        size=1000,
+                        n_files=1,
+                        lookup_status="complete",
+                        did_finder="rucio",
+                    )
+                )
+            db.session.commit()
+        yield
 
     def test_fail_on_bad_param(self, client):
         with client.application.app_context():
@@ -72,12 +67,20 @@ class TestDatasetLifecycle(ResourceTestBase):
             )
             assert response.status_code == 422
 
-    def test_deletion(self, fake_dataset_list, client):
+    def test_deletion(self, datasets, client):
         with client.application.app_context():
-            with patch("servicex_app.models.Dataset.delete_dataset") as deletion_obj:
-                response = client.post(
-                    "/servicex/internal/dataset-lifecycle", json={"age": 24}
-                )
-                fake_dataset_list.assert_called_once()
-                deletion_obj.assert_called_once()
-                assert response.status_code == 200
+            response = client.post(
+                "/servicex/internal/dataset-lifecycle", json={"age": 24}
+            )
+            assert response.status_code == 200
+            assert response.json == {"message": "Success"}
+
+            stale_by_name = {
+                dataset.name: dataset.stale
+                for dataset in db.session.query(Dataset).all()
+            }
+            assert stale_by_name == {
+                "obsolete": True,
+                "recent": False,
+                "never-updated": False,
+            }

--- a/servicex_app/servicex_app_test/resources/users/test_slack_interaction.py
+++ b/servicex_app/servicex_app_test/resources/users/test_slack_interaction.py
@@ -6,6 +6,8 @@ from urllib.parse import quote_plus
 
 from flask import Response
 
+from servicex_app.reliable_requests import REQUEST_TIMEOUT
+
 from ...resource_test_base import ResourceTestBase
 
 payload = {
@@ -95,7 +97,7 @@ class TestSlackInteraction(ResourceTestBase):
             from servicex_app.web.slack_msg_builder import missing_slack_app
 
             mock_post.assert_called_once_with(
-                payload["response_url"], missing_slack_app(), timeout=(0.5, None)
+                payload["response_url"], missing_slack_app(), timeout=REQUEST_TIMEOUT
             )
 
     def test_slack_interaction_expired(self, mocker):
@@ -112,7 +114,7 @@ class TestSlackInteraction(ResourceTestBase):
             from servicex_app.web.slack_msg_builder import request_expired
 
             mock_post.assert_called_once_with(
-                payload["response_url"], request_expired(), timeout=(0.5, None)
+                payload["response_url"], request_expired(), timeout=REQUEST_TIMEOUT
             )
 
     def test_slack_interaction_invalid(self, mocker):
@@ -129,7 +131,7 @@ class TestSlackInteraction(ResourceTestBase):
             from servicex_app.web.slack_msg_builder import verification_failed
 
             mock_post.assert_called_once_with(
-                payload["response_url"], verification_failed(), timeout=(0.5, None)
+                payload["response_url"], verification_failed(), timeout=REQUEST_TIMEOUT
             )
 
     def test_slack_interaction_accept_user(self, mocker):
@@ -162,5 +164,5 @@ class TestSlackInteraction(ResourceTestBase):
 
             resp = signup_ia(payload["message"], payload["user"], "accept_user")
             mock_post.assert_called_once_with(
-                payload["response_url"], resp, timeout=(0.5, None)
+                payload["response_url"], resp, timeout=REQUEST_TIMEOUT
             )

--- a/servicex_app/servicex_app_test/test_docker_repo_adapter.py
+++ b/servicex_app/servicex_app_test/test_docker_repo_adapter.py
@@ -30,6 +30,7 @@ import subprocess
 import pytest
 from unittest.mock import MagicMock
 
+from servicex_app import docker_repo_adapter
 from servicex_app.docker_repo_adapter import DockerRepoAdapter
 
 
@@ -65,7 +66,7 @@ class TestDockerRepoAdapter:
     @pytest.fixture(autouse=True)
     def clear_cache(self):
         """Clear the cache before each test to ensure test isolation."""
-        DockerRepoAdapter.check_image_exists.cache_clear()
+        docker_repo_adapter._known_images.clear()
 
     def test_check_image_exists(self, mock_subprocess_success):
         docker = DockerRepoAdapter()
@@ -76,6 +77,25 @@ class TestDockerRepoAdapter:
         docker = DockerRepoAdapter()
         result = docker.check_image_exists("foo/bar:baz")
         assert not result
+
+    def test_check_image_exists_caches_only_successes(
+        self, mocker, mock_subprocess_failure
+    ):
+        docker = DockerRepoAdapter()
+        assert not docker.check_image_exists("foo/bar:baz")
+
+        # A failed lookup is not cached, so a later success is picked up
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        success = mocker.patch(
+            "servicex_app.docker_repo_adapter.subprocess.run",
+            return_value=mock_result,
+        )
+        assert docker.check_image_exists("foo/bar:baz")
+
+        # A successful lookup is cached, so the registry is not queried again
+        assert docker.check_image_exists("foo/bar:baz")
+        assert success.call_count == 1
 
     def test_check_image_exists_invalid_name(self, mock_subprocess_failure):
         docker = DockerRepoAdapter()

--- a/servicex_app/servicex_app_test/test_object_store_manager.py
+++ b/servicex_app/servicex_app_test/test_object_store_manager.py
@@ -25,10 +25,17 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from flask import Flask
+from pytest import fixture
+
 from servicex_app.object_store_manager import ObjectStoreManager
 
 
 class TestObjectStoreManager:
+    @fixture
+    def app(self):
+        return Flask(__name__)
+
     def test_init(self, mocker):
         mock_minio = mocker.patch("minio.Minio")
         ObjectStoreManager("localhost:9999", "foo", "bar")
@@ -58,7 +65,7 @@ class TestObjectStoreManager:
         mock_minio.list_buckets.assert_called()
         assert bucket_list == ["a", "b"]
 
-    def test_delete_bucket_and_contents(self, mocker):
+    def test_delete_bucket_and_contents(self, mocker, app):
         import minio
 
         mock_minio = mocker.MagicMock(minio.api.Minio)
@@ -67,17 +74,21 @@ class TestObjectStoreManager:
         mock_object = mocker.MagicMock()
         mock_object.object_name = "a"
         mock_minio.list_objects = mocker.Mock(return_value=[mock_object])
+        mock_minio.remove_objects = mocker.Mock(return_value=[])
         mocker.patch("minio.Minio", return_value=mock_minio)
 
         object_store = ObjectStoreManager("localhost:9999", "foo", "bar")
-        object_store.delete_bucket_and_contents("123-455")
+        with app.app_context():
+            object_store.delete_bucket_and_contents("123-455")
 
         mock_minio.bucket_exists.assert_called_with("123-455")
         mock_minio.list_objects.assert_called_with("123-455", recursive=True)
-        mock_minio.remove_object.assert_called_with("123-455", "a")
+        bucket, delete_objects = mock_minio.remove_objects.call_args[0]
+        assert bucket == "123-455"
+        assert [obj.name for obj in delete_objects] == ["a"]
         mock_minio.remove_bucket.assert_called_with("123-455")
 
-    def test_delete_bucket_and_contents_no_bucket(self, mocker):
+    def test_delete_bucket_and_contents_no_bucket(self, mocker, app):
         import minio
 
         mock_minio = mocker.MagicMock(minio.api.Minio)
@@ -86,7 +97,8 @@ class TestObjectStoreManager:
         mocker.patch("minio.Minio", return_value=mock_minio)
 
         object_store = ObjectStoreManager("localhost:9999", "foo", "bar")
-        object_store.delete_bucket_and_contents("123-455")
+        with app.app_context():
+            object_store.delete_bucket_and_contents("123-455")
 
         mock_minio.bucket_exists.assert_called_with("123-455")
         mock_minio.list_objects.assert_not_called()

--- a/servicex_app/servicex_app_test/test_transformer_manager.py
+++ b/servicex_app/servicex_app_test/test_transformer_manager.py
@@ -992,7 +992,10 @@ class TestTransformerManager(ResourceTestBase):
             container = called_job.spec.template.spec.containers[0]
 
             env = container.env
-            request_func_mock.assert_called_with("GET", "https://dummy")
+            request_args, request_kwargs = request_func_mock.call_args
+            assert request_args == ("GET", "https://dummy")
+            assert request_kwargs["timeout"].connect_timeout == 2
+            assert request_kwargs["timeout"].read_timeout == 5
             assert (
                 _env_value(env, "CACHE_PREFIX")
                 == "1.1.1.1:1094,1.1.1.2:1094,1.1.1.3:1094"
@@ -1073,7 +1076,10 @@ class TestTransformerManager(ResourceTestBase):
             container = called_job.spec.template.spec.containers[0]
 
             env = container.env
-            request_func_mock.assert_called_with("GET", "https://dummy")
+            request_args, request_kwargs = request_func_mock.call_args
+            assert request_args == ("GET", "https://dummy")
+            assert request_kwargs["timeout"].connect_timeout == 2
+            assert request_kwargs["timeout"].read_timeout == 5
             assert _env_value(env, "CACHE_PREFIX") == "root://dummy"
 
     def test_get_all_deployments(self, mocker, mock_kubernetes):


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Cuts the per-row and per-request work out of the app's hot paths and bounds its outbound HTTP calls: the two lifecycle endpoints now do their deletions in bulk inside a single transaction, the `files` table gets back the index it needs, authenticated requests decode their JWT once instead of twice, the presigning S3 client is reused, and no outbound request can hang forever.

**How to review.** Each finding is one commit; the Commits tab shows them in severity order. Each entry below links to its commit; tick approve or reject under it. To ask for a change instead, leave a review comment on the commit. Rejected commits will be dropped from the branch and this list will be updated to match.

- **B32** · medium · [`ec37cf6`](https://github.com/ssl-hep/ServiceX/pull/1547/commits/ec37cf6ea90695dbe3a7bc8f5b0b8940bb351ae5) · Give `REQUEST_TIMEOUT` a real read timeout and add one to the VPS liveness request
  - [ ] approve
  - [ ] reject
- **B33** · medium · [`2ea3d89`](https://github.com/ssl-hep/ServiceX/pull/1547/commits/2ea3d892a4e1b9e67acf1722487b27cb6d3ba037) · Remember only images confirmed to exist, so failed registry lookups are retried
  - [ ] approve
  - [ ] reject
- **B55** · medium · [`80ffe44`](https://github.com/ssl-hep/ServiceX/pull/1547/commits/80ffe44ebd6cd80b3d07a6505e78378f6c892409) · Restore the index on `files.dataset_id` and declare the existing `submit_time` index on the model
  - [ ] approve
  - [ ] reject
- **P1** · perf · [`d872baa`](https://github.com/ssl-hep/ServiceX/pull/1547/commits/d872baae0fe7e2b1fc0189ebac1412794aefc935) · Bulk update in dataset obsoletion, one transaction and eager loading in the data lifecycle task
  - [ ] approve
  - [ ] reject
- **P2** · perf · [`15f6c33`](https://github.com/ssl-hep/ServiceX/pull/1547/commits/15f6c33df7f11c4a3a248210120048d935ad9d1d) · Empty buckets with minio's batched `remove_objects` and log through the app logger
  - [ ] approve
  - [ ] reject
- **P6** · perf · [`0e271c1`](https://github.com/ssl-hep/ServiceX/pull/1547/commits/0e271c1282d600944f11ead4ec45c82bec91422d) · Build the presigning S3 client once per set of object store settings and compute the expiry in UTC
  - [ ] approve
  - [ ] reject
- **P7** · perf · [`eae77b5`](https://github.com/ssl-hep/ServiceX/pull/1547/commits/eae77b5a2ebabefe1bc14d8dc420479c4249f782) · Stop verifying the JWT a second time inside `get_jwt_user`
  - [ ] approve
  - [ ] reject

**Follow-ups noticed, out of scope**

- PR #1549 adds a migration with the same parent revision (`v1_8_4`); whichever of the two merges second needs its `down_revision` re-pointed at the other.
- `servicex_app_test/test_transformer_manager.py` passes only as part of the full suite: `test_init_invalid_config` and `test_persistent_claim_exists` rely on an application context that an earlier test file leaves pushed. This is pre-existing and untouched here, but it makes the file impossible to run on its own.
- `urllib3.Timeout` does not implement `__eq__`, so the VPS liveness test compares `connect_timeout` and `read_timeout` by hand instead of using `assert_called_with`. A small comparison helper would read better if more call sites start passing timeouts.
- The sidecar has the other half of P6: `transformer_sidecar/src/transformer_sidecar/transformer.py` constructs a fresh `ObjectStoreManager`, and therefore a fresh minio client, in two places rather than reusing one.
- `Dataset.find_by_id` in `models.py` still uses the legacy `cls.query.get(id)`, which SQLAlchemy 2.0 deprecates in favour of `db.session.get`; the other two call sites in the same file were already converted.

Part of #1539.
