### PR TITLE
fix(app): guard request status transitions and return client errors as 4xx

### DIFF
--- a/servicex_app/migrations/versions/1.8.6.py
+++ b/servicex_app/migrations/versions/1.8.6.py
@@ -1,0 +1,35 @@
+"""
+widen TransformRequest.did to match Dataset.name
+
+Revision ID: v1_8_6
+Revises: v1_8_4
+Create Date: 2026-09-09 10:12:03.114217
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "v1_8_6"
+down_revision = "v1_8_4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "requests",
+        "did",
+        existing_type=sa.String(length=512),
+        type_=sa.String(length=1024),
+        existing_nullable=False,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "requests",
+        "did",
+        existing_type=sa.String(length=1024),
+        type_=sa.String(length=512),
+        existing_nullable=False,
+    )

--- a/servicex_app/servicex_app/dataset_manager.py
+++ b/servicex_app/servicex_app/dataset_manager.py
@@ -207,8 +207,17 @@ class DatasetManager:
         self.dataset.save_to_db()
 
         for request in requests:
-            request.files += len(files)
-            lookup_result_processor.add_files_to_processing_queue(
-                request, files=[file for file in files]
+            # Lock the row for update so that concurrent batches of files from the
+            # DID finder do not lose increments to the file count
+            locked_request = (
+                self.db.session.query(TransformRequest)
+                .filter_by(request_id=request.request_id)
+                .populate_existing()
+                .with_for_update()
+                .one()
             )
-            request.save_to_db()
+            locked_request.files += len(files)
+            lookup_result_processor.add_files_to_processing_queue(
+                locked_request, files=[file for file in files]
+            )
+            locked_request.save_to_db()

--- a/servicex_app/servicex_app/models.py
+++ b/servicex_app/servicex_app/models.py
@@ -184,7 +184,7 @@ class TransformRequest(db.Model):
     title = db.Column(db.String(10240), nullable=True)
     submit_time = db.Column(db.DateTime, nullable=False)
     finish_time = db.Column(db.DateTime, nullable=True)
-    did = db.Column(db.String(512), unique=False, nullable=False)
+    did = db.Column(db.String(1024), unique=False, nullable=False)
     did_id = db.Column(
         db.Integer, ForeignKey("datasets.id"), unique=False, nullable=False
     )

--- a/servicex_app/servicex_app/resources/internal/fileset_complete.py
+++ b/servicex_app/servicex_app/resources/internal/fileset_complete.py
@@ -47,6 +47,23 @@ class FilesetComplete(ServiceXResource):
         cls.transformer_manager = transformer_manager
         return cls
 
+    def _complete_if_finished(self, transform_request, namespace):
+        """
+        Complete a request whose files have all been transformed already. No further
+        file-complete callbacks are coming for it, so nothing else would finish it.
+        """
+        files_remaining = transform_request.files_remaining
+        if files_remaining is not None and files_remaining == 0:
+            current_app.logger.info(
+                "All files already transformed. Shutting down transformers",
+                extra={"request_id": transform_request.request_id},
+            )
+            transform_request.status = TransformStatus.complete
+            transform_request.finish_time = datetime.now(tz=timezone.utc)
+            self.transformer_manager.shutdown_transformer_job(
+                transform_request.request_id, namespace
+            )
+
     def put(self, dataset_id):
         summary = request.get_json()
         dataset = Dataset.find_by_id(int(dataset_id))
@@ -62,6 +79,8 @@ class FilesetComplete(ServiceXResource):
         db.session.commit()
 
         if summary["files"] > 0:
+            namespace = current_app.config["TRANSFORMER_NAMESPACE"]
+
             # Now time to pick up any transform requests for this dataset that came in
             # while we were still looking up files and send the dataset to them
             dataset_manager = DatasetManager(dataset, current_app.logger, db)
@@ -72,12 +91,14 @@ class FilesetComplete(ServiceXResource):
                     transform_request, self.lookup_result_processor
                 )
                 transform_request.status = TransformStatus.running
+                self._complete_if_finished(transform_request, namespace)
 
             # also resolve the status of whatever transform prompted this lookup
             for transform_request in TransformRequest.lookup_running_by_dataset_id(
                 int(dataset_id)
             ):
                 transform_request.status = TransformStatus.running
+                self._complete_if_finished(transform_request, namespace)
 
         else:
             current_app.logger.info(
@@ -104,5 +125,8 @@ class FilesetComplete(ServiceXResource):
             ):
                 pending_transform.status = TransformStatus.complete
                 pending_transform.finish_time = datetime.now(tz=timezone.utc)
+                self.transformer_manager.shutdown_transformer_job(
+                    pending_transform.request_id, namespace
+                )
 
         db.session.commit()

--- a/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
+++ b/servicex_app/servicex_app/resources/internal/transformer_file_complete.py
@@ -120,7 +120,7 @@ class TransformerFileComplete(ServiceXResource):
 
             # Lookup the transformation request and increment either the successful
             # or failed file count
-            transform_req = self.record_file_complete(
+            transform_req, is_last_file = self.record_file_complete(
                 session, current_app.logger, request_id, info, log_extra, orig_counts
             )
 
@@ -129,11 +129,9 @@ class TransformerFileComplete(ServiceXResource):
                 return "Request not found", 404
 
             # Now we can see if we are done with the transformation and
-            # can shut down the transformers. Files remaining is None if
-            # we are still waiting for final results from the DID finder
-            with session.begin():
-                files_remaining = transform_req.files_remaining
-                if files_remaining is not None and files_remaining == 0:
+            # can shut down the transformers.
+            if is_last_file:
+                with session.begin():
                     self.transform_complete(
                         session,
                         current_app.logger,
@@ -167,7 +165,7 @@ class TransformerFileComplete(ServiceXResource):
         info: dict[str, str],
         log_extra: dict[str, str],
         orig_counts: Optional[dict[str, str]],
-    ) -> TransformRequest | None:
+    ) -> tuple[TransformRequest | None, bool]:
 
         with session.begin():
             # Lock the row for update
@@ -181,7 +179,7 @@ class TransformerFileComplete(ServiceXResource):
             if transform_req is None:
                 msg = f"Request not found with id: '{request_id}'"
                 logger.error(msg, extra=log_extra)
-                return None
+                return None, False
 
             if orig_counts:
                 # undo previous statistics accumulation
@@ -209,7 +207,18 @@ class TransformerFileComplete(ServiceXResource):
             else:
                 transform_req.files_failed += 1
 
-        return transform_req
+            # Decide, while the row is still locked, whether this is the callback
+            # that finishes the request. Files remaining is None if we are still
+            # waiting for final results from the DID finder, and a request which
+            # is not running yet may still be given more files.
+            files_remaining = transform_req.files_remaining
+            is_last_file = (
+                files_remaining is not None
+                and files_remaining == 0
+                and transform_req.status == TransformStatus.running
+            )
+
+        return transform_req, is_last_file
 
     @staticmethod
     @file_complete_ops_retry

--- a/servicex_app/servicex_app/resources/transformation/submit.py
+++ b/servicex_app/servicex_app/resources/transformation/submit.py
@@ -84,9 +84,7 @@ class SubmitTransformationRequest(ServiceXResource):
         cls.celery_app = celery_app
 
         cls.parser = reqparse.RequestParser()
-        cls.parser.add_argument(
-            "title", help="Optional title for this request (max 128 chars)"
-        )
+        cls.parser.add_argument("title", help="Optional title for this request")
         cls.parser.add_argument(
             "did", help="Dataset Identifier. Provide this or file-list"
         )
@@ -201,7 +199,7 @@ class SubmitTransformationRequest(ServiceXResource):
             if not code_gen_image_name:
                 msg = f"Invalid Codegen Image Passed in Request: {user_codegen_name}"
                 current_app.logger.error(msg, extra={"request_id": request_id})
-                return {"message": msg}, 500
+                return {"message": msg}, 400
 
             # The first thing to do is make sure the requested selection is correct
             # and can generate the requested code.
@@ -217,7 +215,13 @@ class SubmitTransformationRequest(ServiceXResource):
                 user_codegen_name=user_codegen_name,
             )
 
-            _validate_custom_docker_image(codegen_transformer_image)
+            try:
+                _validate_custom_docker_image(codegen_transformer_image)
+            except ValueError as invalid_image:
+                current_app.logger.error(
+                    str(invalid_image), extra={"request_id": request_id}
+                )
+                return {"message": str(invalid_image)}, 400
 
             # Check to make sure the transformer docker image actually exists (if enabled)
             if config["TRANSFORMER_VALIDATE_DOCKER_IMAGE"]:
@@ -226,7 +230,7 @@ class SubmitTransformationRequest(ServiceXResource):
                 ):
                     msg = f"Requested transformer docker image doesn't exist: {codegen_transformer_image}"  # noqa: E501
                     current_app.logger.error(msg, extra={"request_id": request_id})
-                    return {"message": msg}, 500
+                    return {"message": msg}, 400
 
             # If the user has requested an object store destination, now is the time
             # to create a bucket named after the request id
@@ -313,7 +317,6 @@ class SubmitTransformationRequest(ServiceXResource):
 
             # start transformers independently of the state of dataset.
             if current_app.config["TRANSFORMER_MANAGER_ENABLED"]:
-                print(f"-----------> files: {request_rec.files}")
                 self.transformer_manager.start_transformers(
                     current_app.config, request_rec
                 )

--- a/servicex_app/servicex_app/transformer_manager.py
+++ b/servicex_app/servicex_app/transformer_manager.py
@@ -750,7 +750,7 @@ class TransformerManager:
 
     def cancel_transform(self, request: TransformRequest):
         namespace = current_app.config["TRANSFORMER_NAMESPACE"]
-        if request.status in (TransformStatus.running, TransformStatus.lookup):
+        if not request.status.is_complete:
             try:
                 self.shutdown_transformer_job(request.request_id, namespace)
             except kubernetes.client.exceptions.ApiException as exc:

--- a/servicex_app/servicex_app/web/auth_callback.py
+++ b/servicex_app/servicex_app/web/auth_callback.py
@@ -7,9 +7,9 @@ from .utils import load_oauth_client
 def auth_callback():
     """Handles the interaction with OIDC Auth."""
     if "error" in request.args:
+        description = request.args.get("error_description") or request.args["error"]
         flash(
-            "You could not be logged into the portal: "
-            + request.args.get("error_description"),
+            "You could not be logged into the portal: " + description,
             request.args["error"],
         )
         return redirect("/")

--- a/servicex_app/servicex_app/web/create_profile.py
+++ b/servicex_app/servicex_app/web/create_profile.py
@@ -60,11 +60,11 @@ def create_profile():
                         "Your account is pending approval.",
                         "We'll email you when it's ready.",
                     ]
-                current_app.logger.info(f"Created profile for {new_user.id}")
-                flash(" ".join(msg_segments), "success")
-                return redirect(url_for("profile"))
             except requests.exceptions.HTTPError as err:
                 current_app.logger.error(f"Error in response from Slack webhook: {err}")
+            current_app.logger.info(f"Created profile for {new_user.id}")
+            flash(" ".join(msg_segments), "success")
+            return redirect(url_for("profile"))
         else:
             current_app.logger.error(f"Create Profile Form error: {form.errors}")
             flash(

--- a/servicex_app/servicex_app/web/dashboard.py
+++ b/servicex_app/servicex_app/web/dashboard.py
@@ -32,10 +32,11 @@ parser.add_argument(
 def dashboard(template_name: str, user_specific=False):
     args = parser.parse_args()
     sort, order = args["sort"], args["order"]
-    query = TransformRequest.query.filter_by()
+    query = TransformRequest.query
 
-    if user_specific:
-        query = query.filter_by(submitted_by=session["user_id"])
+    user_id = session.get("user_id")
+    if user_specific and user_id is not None:
+        query = query.filter_by(submitted_by=user_id)
 
     sort_column = model_attributes[sort]
     sort_order = sort_column.asc() if order == "asc" else sort_column.desc()

--- a/servicex_app/servicex_app/web/edit_profile.py
+++ b/servicex_app/servicex_app/web/edit_profile.py
@@ -30,6 +30,9 @@ def edit_profile():
             user.experiment = form.experiment.data
             user.updated_at = datetime.utcnow()
             db.session.commit()
+            session["name"] = user.name
+            session["email"] = user.email
+            session["institution"] = user.institution
             flash("Your profile has been saved!", "success")
             current_app.logger.info(f"Updated profile for {user.name}")
             return redirect(url_for("profile"))

--- a/servicex_app/servicex_app_test/resources/internal/test_fileset_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_fileset_complete.py
@@ -104,8 +104,53 @@ class TestFilesetComplete(ResourceTestBase):
         assert pending_request.status == TransformStatus.running
         assert lookup_request.status == TransformStatus.running
 
+    def test_put_fileset_complete_all_files_already_done(
+        self, mocker, mock_find_dataset_by_id
+    ):
+        mocker.patch.object(
+            TransformRequest, "lookup_pending_on_dataset", return_value=[]
+        )
+
+        lookup_request = TransformRequest()
+        lookup_request.request_id = "111-111"
+        lookup_request.status = TransformStatus.lookup
+        lookup_request.files = 17
+        lookup_request.files_completed = 15
+        lookup_request.files_failed = 2
+        mocker.patch.object(
+            TransformRequest,
+            "lookup_running_by_dataset_id",
+            return_value=[lookup_request],
+        )
+
+        mock_transformer_manager = mocker.MagicMock(TransformerManager)
+        mock_transformer_manager.shutdown_transformer_job = mocker.Mock()
+
+        client = self._test_client(
+            lookup_result_processor=mocker.MagicMock(LookupResultProcessor),
+            transformation_manager=mock_transformer_manager,
+        )
+
+        response = client.put(
+            "/servicex/internal/transformation/1234/complete",
+            json={
+                "files": 17,
+                "total-events": 1024,
+                "total-bytes": 2046,
+                "elapsed-time": 42,
+            },
+        )
+
+        assert response.status_code == 200
+        assert lookup_request.status == TransformStatus.complete
+        assert lookup_request.finish_time is not None
+        mock_transformer_manager.shutdown_transformer_job.assert_called_once_with(
+            "111-111", "my-ws"
+        )
+
     def test_put_fileset_complete_empty_dataset(self, mocker, mock_find_dataset_by_id):
         pending_request = TransformRequest()
+        pending_request.request_id = "222-222"
         pending_request.status = TransformStatus.pending_lookup
 
         running_request = TransformRequest()
@@ -141,8 +186,11 @@ class TestFilesetComplete(ResourceTestBase):
         mock_find_dataset_by_id.assert_called_once_with(12345)
         mock_lookup_pending.assert_called_once_with(12345)
         mock_lookup_running.assert_called_once_with(12345)
-        mock_transformer_manager.shutdown_transformer_job.assert_called_with(
+        mock_transformer_manager.shutdown_transformer_job.assert_any_call(
             "111-111", "my-ws"
+        )
+        mock_transformer_manager.shutdown_transformer_job.assert_any_call(
+            "222-222", "my-ws"
         )
         assert running_request.status == TransformStatus.complete
         assert running_request.finish_time is not None

--- a/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
+++ b/servicex_app/servicex_app_test/resources/internal/test_transform_file_complete.py
@@ -262,6 +262,55 @@ class TestTransformFileComplete(ResourceTestBase):
             "1234", "my-ws"
         )
 
+    def test_put_transform_file_complete_no_files_remaining_still_in_lookup(
+        self,
+        mock_transformer_manager,
+        db_session,
+        trqmock,
+        mock_transform_request_lookup,
+        fake_transform_request,
+        file_complete_response,
+        test_client,
+    ):
+        # The DID finder is still publishing files in batches, so more are coming
+        fake_transform_request.status = TransformStatus.lookup
+        fake_transform_request.files_completed = 7
+        fake_transform_request.files_failed = 2
+
+        response = test_client.put(
+            "/servicex/internal/transformation/1234/file-complete",
+            json=file_complete_response,
+        )
+
+        assert response.status_code == 200
+        assert fake_transform_request.status == TransformStatus.lookup
+        assert fake_transform_request.finish_time is None
+        mock_transformer_manager.shutdown_transformer_job.assert_not_called()
+
+    def test_put_transform_file_complete_no_files_remaining_canceled(
+        self,
+        mock_transformer_manager,
+        db_session,
+        trqmock,
+        mock_transform_request_lookup,
+        fake_transform_request,
+        file_complete_response,
+        test_client,
+    ):
+        fake_transform_request.status = TransformStatus.canceled
+        fake_transform_request.files_completed = 7
+        fake_transform_request.files_failed = 2
+
+        response = test_client.put(
+            "/servicex/internal/transformation/1234/file-complete",
+            json=file_complete_response,
+        )
+
+        assert response.status_code == 200
+        assert fake_transform_request.status == TransformStatus.canceled
+        assert fake_transform_request.finish_time is None
+        mock_transformer_manager.shutdown_transformer_job.assert_not_called()
+
     def test_put_transform_file_complete_duplicate_report(
         self,
         mocker,

--- a/servicex_app/servicex_app_test/resources/transformation/test_submit.py
+++ b/servicex_app/servicex_app_test/resources/transformation/test_submit.py
@@ -156,7 +156,7 @@ class TestSubmitTransformationRequest(ResourceTestBase):
     def test_submit_transformation_bad_code_gen_image(self, client):
         request = self._generate_transformation_request(codegen="foo")
         response = client.post("/servicex/transformation", json=request)
-        assert response.status_code == 500
+        assert response.status_code == 400
         assert (
             "Invalid Codegen Image Passed in Request: foo" in response.json["message"]
         )
@@ -423,6 +423,44 @@ class TestSubmitTransformationRequest(ResourceTestBase):
 
             mock_transform_manager.start_transformers.assert_called_with(
                 ANY, submitted_request
+            )
+
+    def test_submit_transformation_disallowed_image(
+        self, mock_dataset_manager_from_did, mock_codegen
+    ):
+        client = self._test_client(
+            code_gen_service=mock_codegen,
+            allowed_image_prefixes='["someoneelse/"]',
+        )
+        with client.application.app_context():
+            request = self._generate_transformation_request()
+            response = client.post(
+                "/servicex/transformation", json=request, headers=self.fake_header()
+            )
+            assert response.status_code == 400
+            assert "does not match any allowed prefix" in response.json["message"]
+
+    def test_submit_transformation_missing_image(
+        self,
+        mocker,
+        mock_docker_repo_adapter,
+        mock_dataset_manager_from_did,
+        mock_codegen,
+    ):
+        mock_docker_repo_adapter.check_image_exists = mocker.Mock(return_value=False)
+        client = self._test_client(
+            docker_repo_adapter=mock_docker_repo_adapter,
+            code_gen_service=mock_codegen,
+        )
+        with client.application.app_context():
+            request = self._generate_transformation_request()
+            response = client.post(
+                "/servicex/transformation", json=request, headers=self.fake_header()
+            )
+            assert response.status_code == 400
+            assert (
+                "Requested transformer docker image doesn't exist"
+                in response.json["message"]
             )
 
     def test_submit_transformation_request_no_docker_check(

--- a/servicex_app/servicex_app_test/test_dataset_manager.py
+++ b/servicex_app/servicex_app_test/test_dataset_manager.py
@@ -380,6 +380,9 @@ class TestDatasetManager(ResourceTestBase):
                 )
             first_request.did_id = d.id
             second_request.did_id = d.id
+            db.session.add(first_request)
+            db.session.add(second_request)
+            db.session.flush()
 
             newfiles = [
                 DatasetFile(

--- a/servicex_app/servicex_app_test/test_transformer_manager.py
+++ b/servicex_app/servicex_app_test/test_transformer_manager.py
@@ -1398,7 +1398,7 @@ class TestShutdownPod:
         req.status = status
         return req
 
-    def test_skips_shutdown_for_non_active_status(self, app_context, mocker):
+    def test_skips_shutdown_for_terminal_status(self, app_context, mocker):
         app_context.config["TRANSFORMER_NAMESPACE"] = "test-ns"
 
         mocker.patch(
@@ -1406,9 +1406,21 @@ class TestShutdownPod:
         )
         manager = TransformerManager("internal-kubernetes")
         manager.shutdown_transformer_job = Mock()
-        req = self._make_req(TransformStatus.submitted)
+        req = self._make_req(TransformStatus.complete)
         manager.cancel_transform(req)
         manager.shutdown_transformer_job.assert_not_called()
+
+    def test_calls_shutdown_for_pending_lookup(self, app_context, mocker):
+        app_context.config["TRANSFORMER_NAMESPACE"] = "test-ns"
+
+        mocker.patch(
+            "servicex_app.transformer_manager.kubernetes.config.load_incluster_config"
+        )
+        manager = TransformerManager("internal-kubernetes")
+        manager.shutdown_transformer_job = Mock()
+        req = self._make_req(TransformStatus.pending_lookup)
+        manager.cancel_transform(req)
+        manager.shutdown_transformer_job.assert_called_once_with("test-123", "test-ns")
 
     def test_calls_shutdown_for_running(self, app_context, mocker):
         app_context.config["TRANSFORMER_NAMESPACE"] = "test-ns"

--- a/servicex_app/servicex_app_test/web/test_global_dashboard.py
+++ b/servicex_app/servicex_app_test/web/test_global_dashboard.py
@@ -9,7 +9,7 @@ class TestGlobalDashboard(WebTestBase):
     @fixture
     def mock_query(self, mocker):
         mock_tr = mocker.patch("servicex_app.web.dashboard.TransformRequest")
-        return mock_tr.query.filter_by().order_by.return_value
+        return mock_tr.query.order_by.return_value
 
     def test_get_empty_state(self, client, user, mock_query, captured_templates):
         pagination = mock_query.paginate(page=1, per_page=15, total=0, items=[])

--- a/servicex_app/servicex_app_test/web/test_user_dashboard.py
+++ b/servicex_app/servicex_app_test/web/test_user_dashboard.py
@@ -11,21 +11,12 @@ class TestUserDashboard(WebTestBase):
         mock_tr = mocker.patch("servicex_app.web.dashboard.TransformRequest")
         return mock_tr.query.filter_by.return_value.order_by.return_value
 
-    @fixture
-    def mock_query_two_filters(self, mocker):
-        mock_tr = mocker.patch("servicex_app.web.dashboard.TransformRequest")
-        return mock_tr.query.filter_by().filter_by.return_value.order_by.return_value
-
-    def test_get_empty_state(
-        self, client, user, mock_query_two_filters, captured_templates
-    ):
+    def test_get_empty_state(self, client, user, mock_query, captured_templates):
+        user.id = 42
         with client.session_transaction() as sess:
             sess["user_id"] = user.id
-        print(sess)
-        pagination = mock_query_two_filters.paginate(
-            page=1, per_page=15, total=0, items=[]
-        )
-        mock_query_two_filters.paginate.return_value = pagination
+        pagination = mock_query.paginate(page=1, per_page=15, total=0, items=[])
+        mock_query.paginate.return_value = pagination
         response: Response = client.get(
             url_for("user-dashboard"), headers=self.fake_header()
         )
@@ -34,17 +25,30 @@ class TestUserDashboard(WebTestBase):
         assert template.name == "user_dashboard.html"
         assert context["pagination"] == pagination
 
-    def test_get_with_results(
-        self, client, user, mock_query_two_filters, captured_templates
+    def test_get_without_user_id_in_session(
+        self, client, user, mocker, captured_templates
     ):
+        # auth is disabled, so nothing ever put a user_id in the session
+        mock_tr = mocker.patch("servicex_app.web.dashboard.TransformRequest")
+        mock_query = mock_tr.query.order_by.return_value
+        pagination = mock_query.paginate(page=1, per_page=15, total=0, items=[])
+        mock_query.paginate.return_value = pagination
+        response: Response = client.get(
+            url_for("user-dashboard"), headers=self.fake_header()
+        )
+        assert response.status_code == 200
+        mock_tr.query.filter_by.assert_not_called()
+        template, context = captured_templates[0]
+        assert template.name == "user_dashboard.html"
+        assert context["pagination"] == pagination
+
+    def test_get_with_results(self, client, user, mock_query, captured_templates):
+        user.id = 42
         with client.session_transaction() as sess:
             sess["user_id"] = user.id
-        print(sess)
         items = [self._test_transformation_req(id=i + 1) for i in range(3)]
-        pagination = mock_query_two_filters.paginate(
-            page=1, per_page=15, total=100, items=items
-        )
-        mock_query_two_filters.paginate.return_value = pagination
+        pagination = mock_query.paginate(page=1, per_page=15, total=100, items=items)
+        mock_query.paginate.return_value = pagination
         response: Response = client.get(
             url_for("user-dashboard"), headers=self.fake_header()
         )


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This PR tightens the transform request lifecycle in the Flask app so a request only reaches a terminal state when it really is finished and concurrent callbacks from the DID finder and the transformers cannot corrupt the file counters. It also stops the submit endpoint from reporting client errors as server errors, widens the DID column to match the datasets table, and fixes a handful of web portal bugs around session state and redirects.

**How to review.** Each finding is one commit; the Commits tab shows them in severity order. Each entry below links to its commit; tick approve or reject under it. To ask for a change instead, leave a review comment on the commit. Rejected commits will be dropped from the branch and this list will be updated to match.

- **B19** · medium · [`f9e1513`](https://github.com/ssl-hep/ServiceX/pull/1549/commits/f9e151335887e8e612574afd64f4c10fe804fad6) · Decide completion inside the locked `record_file_complete` transaction and only for `running` requests, complete and shut down requests whose files finished before lookup did, and shut down any non terminal job on cancel
  - [ ] approve
  - [ ] reject
- **B27** · medium · [`f8e3e6a`](https://github.com/ssl-hep/ServiceX/pull/1549/commits/f8e3e6a52bf0687deddf80aa9b848d70707c5266) · Refresh the session from the saved user after editing a profile so a changed email no longer breaks `/profile` and `/api-token`
  - [ ] approve
  - [ ] reject
- **B54** · medium · [`e05e9c7`](https://github.com/ssl-hep/ServiceX/pull/1549/commits/e05e9c7fbfc0e26b856fd7795e2deede963637c4) · Return 400 instead of 500 for an unknown codegen, a disallowed custom docker image or a missing transformer image, and drop a debug `print` and a stale help string
  - [ ] approve
  - [ ] reject
- **B58** · medium · [`82d3461`](https://github.com/ssl-hep/ServiceX/pull/1549/commits/82d34618b6b648dd9ab6d55c6e0e31d8dda24ce1) · Lock the request rows with `with_for_update()` in `add_files` so concurrent PUTs cannot lose file count increments
  - [ ] approve
  - [ ] reject
- **B59** · medium · [`c5c7ce3`](https://github.com/ssl-hep/ServiceX/pull/1549/commits/c5c7ce3c18aaa124a5aa47007df137fd7e8004c7) · Widen `TransformRequest.did` from 512 to 1024 characters to match `Dataset.name`, with an Alembic migration
  - [ ] approve
  - [ ] reject
- **B60** · medium · [`5d6c39f`](https://github.com/ssl-hep/ServiceX/pull/1549/commits/5d6c39fe50055838af90127c9e8cbee4522d3abd) · Read the dashboard user id defensively, redirect to the profile after saving even when the Slack webhook fails, and tolerate a missing `error_description` in the auth callback
  - [ ] approve
  - [ ] reject

**Follow-ups noticed, out of scope**

- PR #1547 adds a migration with the same parent revision (`v1_8_4`); whichever of the two merges second needs its `down_revision` re-pointed at the other.
- The celery worker tests were not run locally, so the interaction between the lifecycle changes and the worker is only covered by CI.
- `_validate_custom_docker_image` can also fail because of a server side misconfiguration, which now surfaces to the client as a 400 rather than a 500.
- The MinIO bucket is still created before the database transaction in `submit.py`, so a failed submit orphans a bucket.

Part of #1539.
